### PR TITLE
install Windows version to C:\svt-hevc by default

### DIFF
--- a/Build/windows/generate_vs17.bat
+++ b/Build/windows/generate_vs17.bat
@@ -1,5 +1,5 @@
 :: Copyright(c) 2018 Intel Corporation 
 :: SPDX-License-Identifier: BSD-2-Clause-Patent
 
-cmake ../.. "-GVisual Studio 15 2017 Win64" -DCMAKE_ASM_NASM_COMPILER="yasm.exe" -DCMAKE_CONFIGURATION_TYPES="Debug;Release"
+cmake ../.. "-GVisual Studio 15 2017 Win64" -DCMAKE_ASM_NASM_COMPILER="yasm.exe" -DCMAKE_INSTALL_PREFIX=%SYSTEMDRIVE%\svt-encoders -DCMAKE_CONFIGURATION_TYPES="Debug;Release"
 pause


### PR DESCRIPTION
CMake's default "C:\Program Files" location breaks pkg-config and tools using it because there is a space in it.