### PR TITLE
Optimize function pointers and duplicate definition of DECODED_PICTURE_HASH

### DIFF
--- a/Source/Lib/Codec/EbAvcStyleMcp.c
+++ b/Source/Lib/Codec/EbAvcStyleMcp.c
@@ -386,7 +386,7 @@ void BiPredIFreeRef8Bit(
 #ifndef NON_AVX512_SUPPORT
 			BiPredAverageKernel_funcPtrArray[(ASM_TYPES & AVX512_MASK) && 1 ](
 #else
-            BiPredAverageKernel_funcPtrArray[(ASM_TYPES & AVX2_MASK) && 1](
+            BiPredAverageKernel_funcPtrArray[!!(ASM_TYPES & AVX2_MASK)](
 #endif
 				refPicList0->bufferY + integPosL0x + integPosL0y * refLumaStride,
 				refLumaStride,
@@ -498,7 +498,7 @@ void BiPredIFreeRef8Bit(
 #ifndef NON_AVX512_SUPPORT
             BiPredAverageKernel_funcPtrArray[(ASM_TYPES & AVX512_MASK) && 1](
 #else
-            BiPredAverageKernel_funcPtrArray[(ASM_TYPES & AVX2_MASK) && 1](
+            BiPredAverageKernel_funcPtrArray[!!(ASM_TYPES & AVX2_MASK)](
 #endif
 				refPicList0->bufferCb + integPosL0x + integPosL0y * refPicList0->strideCb,
 				refPicList0->strideCb,
@@ -512,7 +512,7 @@ void BiPredIFreeRef8Bit(
 #ifndef NON_AVX512_SUPPORT
             BiPredAverageKernel_funcPtrArray[(ASM_TYPES & AVX512_MASK) && 1](
 #else
-            BiPredAverageKernel_funcPtrArray[(ASM_TYPES & AVX2_MASK) && 1](
+            BiPredAverageKernel_funcPtrArray[!!(ASM_TYPES & AVX2_MASK)](
 #endif
 				refPicList0->bufferCr + integPosL0x + integPosL0y * refPicList0->strideCr,
 				refPicList0->strideCr,

--- a/Source/Lib/Codec/EbAvcStyleMcp.c
+++ b/Source/Lib/Codec/EbAvcStyleMcp.c
@@ -384,7 +384,7 @@ void BiPredIFreeRef8Bit(
 		if ( (fracPosL0 == 0) && (fracPosL1 == 0) )	 
 		{
 #ifndef NON_AVX512_SUPPORT
-			BiPredAverageKernel_funcPtrArray[(ASM_TYPES & AVX512_MASK) && 1 ](
+			BiPredAverageKernel_funcPtrArray[!!(ASM_TYPES & AVX512_MASK) ](
 #else
             BiPredAverageKernel_funcPtrArray[!!(ASM_TYPES & AVX2_MASK)](
 #endif
@@ -496,7 +496,7 @@ void BiPredIFreeRef8Bit(
 		if ((fracPosL0 == 0) && (fracPosL1 == 0))
 		{
 #ifndef NON_AVX512_SUPPORT
-            BiPredAverageKernel_funcPtrArray[(ASM_TYPES & AVX512_MASK) && 1](
+            BiPredAverageKernel_funcPtrArray[!!(ASM_TYPES & AVX512_MASK)](
 #else
             BiPredAverageKernel_funcPtrArray[!!(ASM_TYPES & AVX2_MASK)](
 #endif
@@ -510,7 +510,7 @@ void BiPredIFreeRef8Bit(
 				chromaPuHeight);
 
 #ifndef NON_AVX512_SUPPORT
-            BiPredAverageKernel_funcPtrArray[(ASM_TYPES & AVX512_MASK) && 1](
+            BiPredAverageKernel_funcPtrArray[!!(ASM_TYPES & AVX512_MASK)](
 #else
             BiPredAverageKernel_funcPtrArray[!!(ASM_TYPES & AVX2_MASK)](
 #endif

--- a/Source/Lib/Codec/EbAvcStyleMcp.c
+++ b/Source/Lib/Codec/EbAvcStyleMcp.c
@@ -213,7 +213,7 @@ void UniPredIFreeRef8Bit(
    if (componentMask & PICTURE_BUFFER_DESC_LUMA_MASK) 
    {
 	   //doing the luma interpolation
-       AvcStyleUniPredLumaIFFunctionPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1][0](
+       AvcStyleUniPredLumaIFFunctionPtrArray[!!(ASM_TYPES & PREAVX2_MASK)][0](
 		   refPic->bufferY + integPosx + integPosy*refPic->strideY, refPic->strideY,
 		   dst->bufferY + dstLumaIndex, lumaStride,
 		   puWidth, puHeight,
@@ -242,7 +242,7 @@ void UniPredIFreeRef8Bit(
         // Note: chromaPuWidth equals 4 is only supported in Intrinsic 
 	   //       for integer positions ( mappedFracPosx + (mappedFracPosy << 3) equals 0 )
 	   //doing the chroma Cb interpolation
-       AvcStyleUniPredLumaIFFunctionPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1][0](
+       AvcStyleUniPredLumaIFFunctionPtrArray[!!(ASM_TYPES & PREAVX2_MASK)][0](
 		   refPic->bufferCb + integPosx + integPosy*refPic->strideCb,
 		   refPic->strideCb,
 		   dst->bufferCb + dstChromaIndex,
@@ -253,7 +253,7 @@ void UniPredIFreeRef8Bit(
 		   mappedFracPosx ? mappedFracPosx : mappedFracPosy);
 
 	   //doing the chroma Cr interpolation
-       AvcStyleUniPredLumaIFFunctionPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1][0](
+       AvcStyleUniPredLumaIFFunctionPtrArray[!!(ASM_TYPES & PREAVX2_MASK)][0](
 		   refPic->bufferCr + integPosx + integPosy*refPic->strideCr,
 		   refPic->strideCr,
 		   dst->bufferCr + dstChromaIndex,
@@ -416,7 +416,7 @@ void BiPredIFreeRef8Bit(
 			integPosx += IntegerPosoffsetTabX[fracPos];
 			integPosy += IntegerPosoffsetTabY[fracPos];
 
-            AvcStyleUniPredLumaIFFunctionPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1][0](
+            AvcStyleUniPredLumaIFFunctionPtrArray[!!(ASM_TYPES & PREAVX2_MASK)][0](
 				refPicList0->bufferY + integPosx + integPosy*refLumaStride, refLumaStride,
 				refList0TempDst, puWidth,
 				puWidth, puHeight,
@@ -441,7 +441,7 @@ void BiPredIFreeRef8Bit(
 			integPosy += IntegerPosoffsetTabY[fracPos];
 
 			//doing the luma interpolation
-            AvcStyleUniPredLumaIFFunctionPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1][0](
+            AvcStyleUniPredLumaIFFunctionPtrArray[!!(ASM_TYPES & PREAVX2_MASK)][0](
 				refPicList1->bufferY + integPosx + integPosy*refLumaStride, refLumaStride,
 				refList1TempDst, puWidth,
 				puWidth, puHeight,
@@ -450,7 +450,7 @@ void BiPredIFreeRef8Bit(
 
 
 			// bi-pred luma
-			PictureAverageArray[(ASM_TYPES & PREAVX2_MASK) && 1](refList0TempDst, puWidth , refList1TempDst, puWidth , biDst->bufferY + dstLumaIndex, lumaStride , puWidth, puHeight );
+			PictureAverageArray[!!(ASM_TYPES & PREAVX2_MASK)](refList0TempDst, puWidth , refList1TempDst, puWidth , biDst->bufferY + dstLumaIndex, lumaStride , puWidth, puHeight );
 		}
 
 	}
@@ -544,7 +544,7 @@ void BiPredIFreeRef8Bit(
 			if (fracPosy > 4)
 				integPosy++;
 
-            AvcStyleUniPredLumaIFFunctionPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1][0](
+            AvcStyleUniPredLumaIFFunctionPtrArray[!!(ASM_TYPES & PREAVX2_MASK)][0](
 				refPicList0->bufferCb + integPosx + integPosy*refPicList0->strideCb,
 				refPicList0->strideCb,
 				refList0TempDst,
@@ -569,7 +569,7 @@ void BiPredIFreeRef8Bit(
 			if (fracPosy > 4)
 				integPosy++;
 
-            AvcStyleUniPredLumaIFFunctionPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1][0](
+            AvcStyleUniPredLumaIFFunctionPtrArray[!!(ASM_TYPES & PREAVX2_MASK)][0](
 				refPicList1->bufferCb + integPosx + integPosy*refPicList1->strideCb,
 				refPicList1->strideCb,
 				refList1TempDst,
@@ -580,7 +580,7 @@ void BiPredIFreeRef8Bit(
 				mappedFracPosx ? mappedFracPosx : mappedFracPosy);
 
 			// bi-pred Chroma Cb
-			PictureAverageArray[(ASM_TYPES & PREAVX2_MASK) && 1](
+			PictureAverageArray[!!(ASM_TYPES & PREAVX2_MASK)](
 				refList0TempDst,
 				chromaPuWidth << shift,
 				refList1TempDst,
@@ -609,7 +609,7 @@ void BiPredIFreeRef8Bit(
 			if (fracPosy > 4)
 				integPosy++;
 
-            AvcStyleUniPredLumaIFFunctionPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1][0](
+            AvcStyleUniPredLumaIFFunctionPtrArray[!!(ASM_TYPES & PREAVX2_MASK)][0](
 				refPicList0->bufferCr + integPosx + integPosy*refPicList0->strideCr,
 				refPicList0->strideCr,
 				refList0TempDst,
@@ -634,7 +634,7 @@ void BiPredIFreeRef8Bit(
 			if (fracPosy > 4)
 				integPosy++;
 
-            AvcStyleUniPredLumaIFFunctionPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1][0](
+            AvcStyleUniPredLumaIFFunctionPtrArray[!!(ASM_TYPES & PREAVX2_MASK)][0](
 				refPicList1->bufferCr + integPosx + integPosy*refPicList1->strideCr,
 				refPicList1->strideCr,
 				refList1TempDst,
@@ -645,7 +645,7 @@ void BiPredIFreeRef8Bit(
 				mappedFracPosx ? mappedFracPosx : mappedFracPosy);
 
 			// bi-pred Chroma Cr
-			PictureAverageArray[(ASM_TYPES & PREAVX2_MASK) && 1](
+			PictureAverageArray[!!(ASM_TYPES & PREAVX2_MASK)](
 				refList0TempDst,
 				chromaPuWidth << shift,
 				refList1TempDst,

--- a/Source/Lib/Codec/EbCodingLoop.c
+++ b/Source/Lib/Codec/EbCodingLoop.c
@@ -683,7 +683,7 @@ static void EncodeLoop(
 
 		// For the case that DC path chosen for chroma, we check the DC values and determine to use DC or N2Shape for chroma. Since there is only one flag for ChromaShaping, we do the prediction of Cr and Cb and decide on the chroma shaping
 		if (tuSize > MIN_PU_SIZE && contextPtr->transCoeffShapeChroma == ONLY_DC_SHAPE) {
-			EB_S64 sumResidual = SumResidual_funcPtrArray[(ASM_TYPES & AVX2_MASK) && 1](
+			EB_S64 sumResidual = SumResidual_funcPtrArray[!!(ASM_TYPES & AVX2_MASK)](
 					((EB_S16*)residual16bit->bufferCb) + scratchCbOffset,
 					tuSize >> subWidthCMinus1,
 					residual16bit->strideCb);
@@ -793,7 +793,7 @@ static void EncodeLoop(
 				tuSize > MIN_PU_SIZE? (tuSize >> subWidthCMinus1): tuSize);
 
 		if (tuSize > MIN_PU_SIZE && contextPtr->transCoeffShapeChroma == ONLY_DC_SHAPE) {
-			EB_S64 sumResidual = SumResidual_funcPtrArray[(ASM_TYPES & AVX2_MASK) && 1](
+			EB_S64 sumResidual = SumResidual_funcPtrArray[!!(ASM_TYPES & AVX2_MASK)](
 					((EB_S16*)residual16bit->bufferCr) + scratchCrOffset,
 					tuSize >> subWidthCMinus1,
 					residual16bit->strideCr);
@@ -1255,7 +1255,7 @@ static void EncodeLoop16bit(
 
 		// For the case that DC path chosen for chroma, we check the DC values and determine to use DC or N2Shape for chroma. Since there is only one flag for ChromaShaping, we do the prediction of Cr and Cb and decide on the chroma shaping
 		if (tuSize > MIN_PU_SIZE && contextPtr->transCoeffShapeChroma == ONLY_DC_SHAPE) {
-			EB_S64 sumResidual = SumResidual_funcPtrArray[(ASM_TYPES & AVX2_MASK) && 1](
+			EB_S64 sumResidual = SumResidual_funcPtrArray[!!(ASM_TYPES & AVX2_MASK)](
 					((EB_S16*)residual16bit->bufferCb) + scratchCbOffset,
 					tuSize >> subWidthCMinus1,
 					residual16bit->strideCb);
@@ -1364,7 +1364,7 @@ static void EncodeLoop16bit(
 				tuSize > MIN_PU_SIZE? (tuSize >> subWidthCMinus1): tuSize);
 
 		if (tuSize > MIN_PU_SIZE && contextPtr->transCoeffShapeChroma == ONLY_DC_SHAPE) {
-			EB_S64 sumResidual = SumResidual_funcPtrArray[(ASM_TYPES & AVX2_MASK) && 1](
+			EB_S64 sumResidual = SumResidual_funcPtrArray[!!(ASM_TYPES & AVX2_MASK)](
 					((EB_S16*)residual16bit->bufferCr) + scratchCrOffset,
 					tuSize >> subWidthCMinus1,
 					residual16bit->strideCr);

--- a/Source/Lib/Codec/EbCodingLoop.c
+++ b/Source/Lib/Codec/EbCodingLoop.c
@@ -977,7 +977,7 @@ static void EncodeGenerateRecon(
 				BIT_INCREMENT_8BIT,
 				(EB_BOOL)(tuSize == MIN_PU_SIZE));
 
-			AdditionKernel_funcPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1][tuSize >> 3](
+			AdditionKernel_funcPtrArray[!!(ASM_TYPES & PREAVX2_MASK)][tuSize >> 3](
 				predSamples->bufferY + predLumaOffset,
 				predSamples->strideY,
 				((EB_S16*)residual16bit->bufferY) + scratchLumaOffset,
@@ -1016,7 +1016,7 @@ static void EncodeGenerateRecon(
 				BIT_INCREMENT_8BIT,
 				EB_FALSE);
 
-			AdditionKernel_funcPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1][tuSize >> (3 + shift_bit)](
+			AdditionKernel_funcPtrArray[!!(ASM_TYPES & PREAVX2_MASK)][tuSize >> (3 + shift_bit)](
 				predSamples->bufferCb + predChromaOffset,
 				predSamples->strideCb,
 				((EB_S16*)residual16bit->bufferCb) + scratchChromaOffset,
@@ -1049,7 +1049,7 @@ static void EncodeGenerateRecon(
 				BIT_INCREMENT_8BIT,
 				EB_FALSE);
 
-			AdditionKernel_funcPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1][tuSize >> (3 + shift_bit)](
+			AdditionKernel_funcPtrArray[!!(ASM_TYPES & PREAVX2_MASK)][tuSize >> (3 + shift_bit)](
 				predSamples->bufferCr + predChromaOffset,
 				predSamples->strideCr,
 				((EB_S16*)residual16bit->bufferCr) + scratchChromaOffset,
@@ -1552,7 +1552,7 @@ static void EncodeGenerateRecon16bit(
 				BIT_INCREMENT_10BIT,
 				(EB_BOOL)(tuSize == MIN_PU_SIZE));
 
-            AdditionKernel_funcPtrArray16bit[(ASM_TYPES & PREAVX2_MASK) && 1](
+            AdditionKernel_funcPtrArray16bit[!!(ASM_TYPES & PREAVX2_MASK)](
                 (EB_U16*)predSamples->bufferY + predLumaOffset,
                 predSamples->strideY,
                 ((EB_S16*)residual16bit->bufferY) + scratchLumaOffset,
@@ -1591,7 +1591,7 @@ static void EncodeGenerateRecon16bit(
 				BIT_INCREMENT_10BIT,
 				EB_FALSE);
 
-            AdditionKernel_funcPtrArray16bit[(ASM_TYPES & PREAVX2_MASK) && 1](
+            AdditionKernel_funcPtrArray16bit[!!(ASM_TYPES & PREAVX2_MASK)](
                 (EB_U16*)predSamples->bufferCb + predChromaOffset,
 				predSamples->strideCb,
 				((EB_S16*)residual16bit->bufferCb) + scratchChromaOffset,
@@ -1624,7 +1624,7 @@ static void EncodeGenerateRecon16bit(
 				BIT_INCREMENT_10BIT,
 				EB_FALSE);
 
-            AdditionKernel_funcPtrArray16bit[(ASM_TYPES & PREAVX2_MASK) && 1](
+            AdditionKernel_funcPtrArray16bit[!!(ASM_TYPES & PREAVX2_MASK)](
                 (EB_U16*)predSamples->bufferCr + predChromaOffset,
 				predSamples->strideCr,
 				((EB_S16*)residual16bit->bufferCr) + scratchChromaOffset,

--- a/Source/Lib/Codec/EbDeblockingFilter.c
+++ b/Source/Lib/Codec/EbDeblockingFilter.c
@@ -1071,7 +1071,7 @@ static void Luma8x8blkDLFCore(
 		edgeStartFilteredSamplePtr = reconPic->bufferY + reconPic->originX + reconPic->originY * reconPic->strideY + (centerSamplePos_y - 4) * reconLumaPicStride + centerSamplePos_x;
 
 		// luma 4 sample edge DLF core
-		Luma4SampleEdgeDLFCore_Table[(ASM_TYPES & PREAVX2_MASK) && 1](
+		Luma4SampleEdgeDLFCore_Table[!!(ASM_TYPES & PREAVX2_MASK)](
 			edgeStartFilteredSamplePtr,
 			reconLumaPicStride,
 			EB_TRUE,
@@ -1110,7 +1110,7 @@ static void Luma8x8blkDLFCore(
 
 
 		// luma 4 sample edge DLF core
-		Luma4SampleEdgeDLFCore_Table[(ASM_TYPES & PREAVX2_MASK) && 1](
+		Luma4SampleEdgeDLFCore_Table[!!(ASM_TYPES & PREAVX2_MASK)](
 			edgeStartFilteredSamplePtr,
 			reconLumaPicStride,
 			EB_TRUE,
@@ -1148,7 +1148,7 @@ static void Luma8x8blkDLFCore(
 		edgeStartFilteredSamplePtr = reconPic->bufferY + reconPic->originX + reconPic->originY * reconPic->strideY + centerSamplePos_y * reconLumaPicStride + (centerSamplePos_x - 4);
 
 		// luma 4 sample edge DLF core
-		Luma4SampleEdgeDLFCore_Table[(ASM_TYPES & PREAVX2_MASK) && 1](
+		Luma4SampleEdgeDLFCore_Table[!!(ASM_TYPES & PREAVX2_MASK)](
 			edgeStartFilteredSamplePtr,
 			reconLumaPicStride,
 			EB_FALSE,
@@ -1186,7 +1186,7 @@ static void Luma8x8blkDLFCore(
 		edgeStartFilteredSamplePtr = reconPic->bufferY + reconPic->originX + reconPic->originY * reconPic->strideY + centerSamplePos_y * reconLumaPicStride + centerSamplePos_x;
 
 		// luma 4 sample edge DLF core
-		Luma4SampleEdgeDLFCore_Table[(ASM_TYPES & PREAVX2_MASK) && 1](
+		Luma4SampleEdgeDLFCore_Table[!!(ASM_TYPES & PREAVX2_MASK)](
 			edgeStartFilteredSamplePtr,
 			reconLumaPicStride,
 			EB_FALSE,
@@ -1253,7 +1253,7 @@ void Luma8x8blkDLFCore16bit(
 		edgeStartFilteredSamplePtr = (EB_U16*)reconPic->bufferY + reconPic->originX + reconPic->originY * reconPic->strideY + (centerSamplePos_y - 4) * reconLumaPicStride + centerSamplePos_x;
 
 		// luma 4 sample edge DLF core
-		lumaDlf_funcPtrArray16bit[(ASM_TYPES & PREAVX2_MASK) && 1](
+		lumaDlf_funcPtrArray16bit[!!(ASM_TYPES & PREAVX2_MASK)](
 			edgeStartFilteredSamplePtr,
 			reconLumaPicStride,
 			EB_TRUE,
@@ -1296,7 +1296,7 @@ void Luma8x8blkDLFCore16bit(
 		edgeStartFilteredSamplePtr = (EB_U16*)reconPic->bufferY + reconPic->originX + reconPic->originY * reconPic->strideY + centerSamplePos_y  * reconLumaPicStride + centerSamplePos_x;
 
 		// luma 4 sample edge DLF core
-		lumaDlf_funcPtrArray16bit[(ASM_TYPES & PREAVX2_MASK) && 1](
+		lumaDlf_funcPtrArray16bit[!!(ASM_TYPES & PREAVX2_MASK)](
 			edgeStartFilteredSamplePtr,
 			reconLumaPicStride,
 			EB_TRUE,
@@ -1338,7 +1338,7 @@ void Luma8x8blkDLFCore16bit(
 		edgeStartFilteredSamplePtr = (EB_U16*)reconPic->bufferY + reconPic->originX + reconPic->originY * reconPic->strideY + centerSamplePos_y * reconLumaPicStride + (centerSamplePos_x - 4);
 
 		// luma 4 sample edge DLF core
-		lumaDlf_funcPtrArray16bit[(ASM_TYPES & PREAVX2_MASK) && 1](
+		lumaDlf_funcPtrArray16bit[!!(ASM_TYPES & PREAVX2_MASK)](
 			edgeStartFilteredSamplePtr,
 			reconLumaPicStride,
 			EB_FALSE,
@@ -1379,7 +1379,7 @@ void Luma8x8blkDLFCore16bit(
 		edgeStartFilteredSamplePtr = (EB_U16*)reconPic->bufferY + reconPic->originX + reconPic->originY * reconPic->strideY + centerSamplePos_y * reconLumaPicStride + centerSamplePos_x;
 
 		// luma 4 sample edge DLF core
-		lumaDlf_funcPtrArray16bit[(ASM_TYPES & PREAVX2_MASK) && 1](
+		lumaDlf_funcPtrArray16bit[!!(ASM_TYPES & PREAVX2_MASK)](
 			edgeStartFilteredSamplePtr,
 			reconLumaPicStride,
 			EB_FALSE,
@@ -1479,7 +1479,7 @@ static void chroma8x8blkDLFCore(
 		edgeStartSampleCb = reconPic->bufferCb + (reconPic->originX >> subWidthCMinus1) + (reconPic->originY >> subHeightCMinus1) * reconPic->strideCb + (centerSamplePos_y - 4) * reconChromaPicStride + centerSamplePos_x;
 		edgeStartSampleCr = reconPic->bufferCr + (reconPic->originX >> subWidthCMinus1) + (reconPic->originY >> subHeightCMinus1) * reconPic->strideCr + (centerSamplePos_y - 4) * reconChromaPicStride + centerSamplePos_x;
 
-		Chroma2SampleEdgeDLFCore_Table[(ASM_TYPES & PREAVX2_MASK) && 1](
+		Chroma2SampleEdgeDLFCore_Table[!!(ASM_TYPES & PREAVX2_MASK)](
 			edgeStartSampleCb,
 			edgeStartSampleCr,
 			reconChromaPicStride,
@@ -1522,7 +1522,7 @@ static void chroma8x8blkDLFCore(
 		edgeStartSampleCr = reconPic->bufferCr + (reconPic->originX >> subWidthCMinus1) + (reconPic->originY >> subHeightCMinus1) * reconPic->strideCr + (centerSamplePos_y - 2) * reconChromaPicStride + centerSamplePos_x;
 
 
-		Chroma2SampleEdgeDLFCore_Table[(ASM_TYPES & PREAVX2_MASK) && 1](
+		Chroma2SampleEdgeDLFCore_Table[!!(ASM_TYPES & PREAVX2_MASK)](
 			edgeStartSampleCb,
 			edgeStartSampleCr,
 			reconChromaPicStride,
@@ -1568,7 +1568,7 @@ static void chroma8x8blkDLFCore(
 		edgeStartSampleCr = reconPic->bufferCr + (reconPic->originX >> subWidthCMinus1) + (reconPic->originY >> subHeightCMinus1) * reconPic->strideCr + centerSamplePos_y * reconChromaPicStride + centerSamplePos_x;
 
 
-		Chroma2SampleEdgeDLFCore_Table[(ASM_TYPES & PREAVX2_MASK) && 1](
+		Chroma2SampleEdgeDLFCore_Table[!!(ASM_TYPES & PREAVX2_MASK)](
 			edgeStartSampleCb,
 			edgeStartSampleCr,
 			reconChromaPicStride,
@@ -1611,7 +1611,7 @@ static void chroma8x8blkDLFCore(
 		edgeStartSampleCb = reconPic->bufferCb + (reconPic->originX >> subWidthCMinus1) + (reconPic->originY >> subHeightCMinus1) * reconPic->strideCb + (centerSamplePos_y + 2) * reconChromaPicStride + centerSamplePos_x;
 		edgeStartSampleCr = reconPic->bufferCr + (reconPic->originX >> subWidthCMinus1) + (reconPic->originY >> subHeightCMinus1) * reconPic->strideCr + (centerSamplePos_y + 2) * reconChromaPicStride + centerSamplePos_x;
 
-		Chroma2SampleEdgeDLFCore_Table[(ASM_TYPES & PREAVX2_MASK) && 1](
+		Chroma2SampleEdgeDLFCore_Table[!!(ASM_TYPES & PREAVX2_MASK)](
 			edgeStartSampleCb,
 			edgeStartSampleCr,
 			reconChromaPicStride,
@@ -1654,7 +1654,7 @@ static void chroma8x8blkDLFCore(
 		edgeStartSampleCb = reconPic->bufferCb + (reconPic->originX >> subWidthCMinus1) + (reconPic->originY >> subHeightCMinus1) * reconPic->strideCb + centerSamplePos_y * reconChromaPicStride + (centerSamplePos_x - 4);
 		edgeStartSampleCr = reconPic->bufferCr + (reconPic->originX >> subWidthCMinus1) + (reconPic->originY >> subHeightCMinus1) * reconPic->strideCr + centerSamplePos_y * reconChromaPicStride + (centerSamplePos_x - 4);
 
-		Chroma2SampleEdgeDLFCore_Table[(ASM_TYPES & PREAVX2_MASK) && 1](
+		Chroma2SampleEdgeDLFCore_Table[!!(ASM_TYPES & PREAVX2_MASK)](
 			edgeStartSampleCb,
 			edgeStartSampleCr,
 			reconChromaPicStride,
@@ -1697,7 +1697,7 @@ static void chroma8x8blkDLFCore(
 		edgeStartSampleCb = reconPic->bufferCb + (reconPic->originX >> subWidthCMinus1) + (reconPic->originY >> subHeightCMinus1) * reconPic->strideCb + centerSamplePos_y * reconChromaPicStride + (centerSamplePos_x - 2);
 		edgeStartSampleCr = reconPic->bufferCr + (reconPic->originX >> subWidthCMinus1) + (reconPic->originY >> subHeightCMinus1) * reconPic->strideCr + centerSamplePos_y * reconChromaPicStride + (centerSamplePos_x - 2);
 
-		Chroma2SampleEdgeDLFCore_Table[(ASM_TYPES & PREAVX2_MASK) && 1](
+		Chroma2SampleEdgeDLFCore_Table[!!(ASM_TYPES & PREAVX2_MASK)](
 			edgeStartSampleCb,
 			edgeStartSampleCr,
 			reconChromaPicStride,
@@ -1741,7 +1741,7 @@ static void chroma8x8blkDLFCore(
 		edgeStartSampleCb = reconPic->bufferCb + (reconPic->originX >> subWidthCMinus1) + (reconPic->originY >> subHeightCMinus1) * reconPic->strideCb + centerSamplePos_y * reconChromaPicStride + centerSamplePos_x;
 		edgeStartSampleCr = reconPic->bufferCr + (reconPic->originX >> subWidthCMinus1) + (reconPic->originY >> subHeightCMinus1) * reconPic->strideCr + centerSamplePos_y * reconChromaPicStride + centerSamplePos_x;
 
-		Chroma2SampleEdgeDLFCore_Table[(ASM_TYPES & PREAVX2_MASK) && 1](
+		Chroma2SampleEdgeDLFCore_Table[!!(ASM_TYPES & PREAVX2_MASK)](
 			edgeStartSampleCb,
 			edgeStartSampleCr,
 			reconChromaPicStride,
@@ -1784,7 +1784,7 @@ static void chroma8x8blkDLFCore(
 		edgeStartSampleCb = reconPic->bufferCb + (reconPic->originX >> subWidthCMinus1) + (reconPic->originY >> subHeightCMinus1) * reconPic->strideCb + centerSamplePos_y * reconChromaPicStride + (centerSamplePos_x + 2);
 		edgeStartSampleCr = reconPic->bufferCr + (reconPic->originX >> subWidthCMinus1) + (reconPic->originY >> subHeightCMinus1) * reconPic->strideCr + centerSamplePos_y * reconChromaPicStride + (centerSamplePos_x + 2);
 
-		Chroma2SampleEdgeDLFCore_Table[(ASM_TYPES & PREAVX2_MASK) && 1](
+		Chroma2SampleEdgeDLFCore_Table[!!(ASM_TYPES & PREAVX2_MASK)](
 			edgeStartSampleCb,
 			edgeStartSampleCr,
 			reconChromaPicStride,
@@ -1862,7 +1862,7 @@ static void chroma8x8blkDLFCore16bit(
         edgeStartSampleCb = (EB_U16*)reconPic->bufferCb + (reconPic->originX >> subWidthCMinus1) + (reconPic->originY >> subHeightCMinus1) * reconPic->strideCb + (centerSamplePos_y - 4) * reconChromaPicStride + centerSamplePos_x;
         edgeStartSampleCr = (EB_U16*)reconPic->bufferCr + (reconPic->originX >> subWidthCMinus1) + (reconPic->originY >> subHeightCMinus1) * reconPic->strideCr + (centerSamplePos_y - 4) * reconChromaPicStride + centerSamplePos_x;
 
-		chromaDlf_funcPtrArray16bit[(ASM_TYPES & PREAVX2_MASK) && 1](
+		chromaDlf_funcPtrArray16bit[!!(ASM_TYPES & PREAVX2_MASK)](
 			edgeStartSampleCb,
 			edgeStartSampleCr,
 			reconChromaPicStride,
@@ -1909,7 +1909,7 @@ static void chroma8x8blkDLFCore16bit(
 		edgeStartSampleCb = (EB_U16*)reconPic->bufferCb + (reconPic->originX >> subWidthCMinus1) + (reconPic->originY >> subHeightCMinus1) * reconPic->strideCb + (centerSamplePos_y - 2) * reconChromaPicStride + centerSamplePos_x;
 		edgeStartSampleCr = (EB_U16*)reconPic->bufferCr + (reconPic->originX >> subWidthCMinus1) + (reconPic->originY >> subHeightCMinus1) * reconPic->strideCr + (centerSamplePos_y - 2) * reconChromaPicStride + centerSamplePos_x;
 
-		chromaDlf_funcPtrArray16bit[(ASM_TYPES & PREAVX2_MASK) && 1](
+		chromaDlf_funcPtrArray16bit[!!(ASM_TYPES & PREAVX2_MASK)](
 			edgeStartSampleCb,
 			edgeStartSampleCr,
 			reconChromaPicStride,
@@ -1959,7 +1959,7 @@ static void chroma8x8blkDLFCore16bit(
 		edgeStartSampleCb = (EB_U16*)reconPic->bufferCb + (reconPic->originX >> subWidthCMinus1) + (reconPic->originY >> subHeightCMinus1) * reconPic->strideCb + centerSamplePos_y * reconChromaPicStride + centerSamplePos_x;
 		edgeStartSampleCr = (EB_U16*)reconPic->bufferCr + (reconPic->originX >> subWidthCMinus1) + (reconPic->originY >> subHeightCMinus1) * reconPic->strideCr + centerSamplePos_y * reconChromaPicStride + centerSamplePos_x;
 
-		chromaDlf_funcPtrArray16bit[(ASM_TYPES & PREAVX2_MASK) && 1](
+		chromaDlf_funcPtrArray16bit[!!(ASM_TYPES & PREAVX2_MASK)](
 			edgeStartSampleCb,
 			edgeStartSampleCr,
 			reconChromaPicStride,
@@ -2006,7 +2006,7 @@ static void chroma8x8blkDLFCore16bit(
 		edgeStartSampleCr = (EB_U16*)reconPic->bufferCr + (reconPic->originX >> subWidthCMinus1) + (reconPic->originY >> subHeightCMinus1) * reconPic->strideCr + (centerSamplePos_y + 2) * reconChromaPicStride + centerSamplePos_x;
 
 
-		chromaDlf_funcPtrArray16bit[(ASM_TYPES & PREAVX2_MASK) && 1](
+		chromaDlf_funcPtrArray16bit[!!(ASM_TYPES & PREAVX2_MASK)](
 			edgeStartSampleCb,
 			edgeStartSampleCr,
 			reconChromaPicStride,
@@ -2055,7 +2055,7 @@ static void chroma8x8blkDLFCore16bit(
 		edgeStartSampleCb = (EB_U16*)reconPic->bufferCb + (reconPic->originX >> subWidthCMinus1) + (reconPic->originY >> subHeightCMinus1) * reconPic->strideCb + centerSamplePos_y * reconChromaPicStride + (centerSamplePos_x - 4);
 		edgeStartSampleCr = (EB_U16*)reconPic->bufferCr + (reconPic->originX >> subWidthCMinus1) + (reconPic->originY >> subHeightCMinus1) * reconPic->strideCr + centerSamplePos_y * reconChromaPicStride + (centerSamplePos_x - 4);
 
-		chromaDlf_funcPtrArray16bit[(ASM_TYPES & PREAVX2_MASK) && 1](
+		chromaDlf_funcPtrArray16bit[!!(ASM_TYPES & PREAVX2_MASK)](
 			edgeStartSampleCb,
 			edgeStartSampleCr,
 			reconChromaPicStride,
@@ -2103,7 +2103,7 @@ static void chroma8x8blkDLFCore16bit(
 		edgeStartSampleCr = (EB_U16*)reconPic->bufferCr + (reconPic->originX >> subWidthCMinus1) + (reconPic->originY >> subHeightCMinus1) * reconPic->strideCr + centerSamplePos_y * reconChromaPicStride + (centerSamplePos_x - 2);
 
 
-		chromaDlf_funcPtrArray16bit[(ASM_TYPES & PREAVX2_MASK) && 1](
+		chromaDlf_funcPtrArray16bit[!!(ASM_TYPES & PREAVX2_MASK)](
 			edgeStartSampleCb,
 			edgeStartSampleCr,
 			reconChromaPicStride,
@@ -2152,7 +2152,7 @@ static void chroma8x8blkDLFCore16bit(
 		edgeStartSampleCr = (EB_U16*)reconPic->bufferCr + (reconPic->originX >> subWidthCMinus1) + (reconPic->originY >> subHeightCMinus1) * reconPic->strideCr + centerSamplePos_y * reconChromaPicStride + centerSamplePos_x;
 
 
-		chromaDlf_funcPtrArray16bit[(ASM_TYPES & PREAVX2_MASK) && 1](
+		chromaDlf_funcPtrArray16bit[!!(ASM_TYPES & PREAVX2_MASK)](
 			edgeStartSampleCb,
 			edgeStartSampleCr,
 			reconChromaPicStride,
@@ -2199,7 +2199,7 @@ static void chroma8x8blkDLFCore16bit(
 		edgeStartSampleCb = (EB_U16*)reconPic->bufferCb + (reconPic->originX >> subWidthCMinus1) + (reconPic->originY >> subHeightCMinus1) * reconPic->strideCb + centerSamplePos_y * reconChromaPicStride + (centerSamplePos_x + 2);
 		edgeStartSampleCr = (EB_U16*)reconPic->bufferCr + (reconPic->originX >> subWidthCMinus1) + (reconPic->originY >> subHeightCMinus1) * reconPic->strideCr + centerSamplePos_y * reconChromaPicStride + (centerSamplePos_x + 2);
 
-		chromaDlf_funcPtrArray16bit[(ASM_TYPES & PREAVX2_MASK) && 1](
+		chromaDlf_funcPtrArray16bit[!!(ASM_TYPES & PREAVX2_MASK)](
 			edgeStartSampleCb,
 			edgeStartSampleCr,
 			reconChromaPicStride,
@@ -2326,7 +2326,7 @@ EB_ERRORTYPE LCUInternalAreaDLFCore(
 				edgeStartFilteredSamplePtr = reconpicture->bufferY + reconpicture->originX + reconpicture->originY * reconpicture->strideY + (fourSampleEdgeStartSamplePos_y + lcuPos_y) * reconpicture->strideY + fourSampleEdgeStartSamplePos_x + lcuPos_x;
 
 				// 4 sample edge DLF core
-				Luma4SampleEdgeDLFCore_Table[(ASM_TYPES & PREAVX2_MASK) && 1](
+				Luma4SampleEdgeDLFCore_Table[!!(ASM_TYPES & PREAVX2_MASK)](
 					edgeStartFilteredSamplePtr,
 					reconpicture->strideY,
 					EB_TRUE,
@@ -2377,7 +2377,7 @@ EB_ERRORTYPE LCUInternalAreaDLFCore(
 				edgeStartFilteredSamplePtr = reconpicture->bufferY + reconpicture->originX + reconpicture->originY * reconpicture->strideY + (fourSampleEdgeStartSamplePos_y + lcuPos_y) * reconpicture->strideY + fourSampleEdgeStartSamplePos_x + lcuPos_x;
 
 				// 4 sample edge DLF core
-				Luma4SampleEdgeDLFCore_Table[(ASM_TYPES & PREAVX2_MASK) && 1](
+				Luma4SampleEdgeDLFCore_Table[!!(ASM_TYPES & PREAVX2_MASK)](
 					edgeStartFilteredSamplePtr,
 					reconpicture->strideY,
 					EB_FALSE,
@@ -2432,7 +2432,7 @@ EB_ERRORTYPE LCUInternalAreaDLFCore(
 				edgeStartSampleCb = reconpicture->bufferCb + (reconpicture->originX >> subWidthCMinus1) + (reconpicture->originY >> subHeightCMinus1) * reconpicture->strideCb + (twoSampleEdgeStartSamplePos_y + chromaLcuPos_y) * reconpicture->strideCb + (twoSampleEdgeStartSamplePos_x + chromaLcuPos_x);
 				edgeStartSampleCr = reconpicture->bufferCr + (reconpicture->originX >> subWidthCMinus1) + (reconpicture->originY >> subHeightCMinus1) * reconpicture->strideCr + (twoSampleEdgeStartSamplePos_y + chromaLcuPos_y) * reconpicture->strideCr + (twoSampleEdgeStartSamplePos_x + chromaLcuPos_x);
 
-				Chroma2SampleEdgeDLFCore_Table[(ASM_TYPES & PREAVX2_MASK) && 1](
+				Chroma2SampleEdgeDLFCore_Table[!!(ASM_TYPES & PREAVX2_MASK)](
 					edgeStartSampleCb,
 					edgeStartSampleCr,
 					reconpicture->strideCb,
@@ -2488,7 +2488,7 @@ EB_ERRORTYPE LCUInternalAreaDLFCore(
 				edgeStartSampleCb = reconpicture->bufferCb + (reconpicture->originX >> subWidthCMinus1) + (reconpicture->originY >> subHeightCMinus1) * reconpicture->strideCb + (twoSampleEdgeStartSamplePos_y + chromaLcuPos_y) * reconpicture->strideCb + (twoSampleEdgeStartSamplePos_x + chromaLcuPos_x);
 				edgeStartSampleCr = reconpicture->bufferCr + (reconpicture->originX >> subWidthCMinus1) + (reconpicture->originY >> subHeightCMinus1) * reconpicture->strideCr + (twoSampleEdgeStartSamplePos_y + chromaLcuPos_y) * reconpicture->strideCr + (twoSampleEdgeStartSamplePos_x + chromaLcuPos_x);
 
-				Chroma2SampleEdgeDLFCore_Table[(ASM_TYPES & PREAVX2_MASK) && 1](
+				Chroma2SampleEdgeDLFCore_Table[!!(ASM_TYPES & PREAVX2_MASK)](
 					edgeStartSampleCb,
 					edgeStartSampleCr,
 					reconpicture->strideCb,
@@ -2629,7 +2629,7 @@ EB_ERRORTYPE LCUInternalAreaDLFCore16bit(
 				edgeStartFilteredSamplePtr = (EB_U16*)reconpicture->bufferY + reconpicture->originX + reconpicture->originY * reconpicture->strideY + (fourSampleEdgeStartSamplePos_y + lcuPos_y) * reconpicture->strideY + fourSampleEdgeStartSamplePos_x + lcuPos_x;
 
 				// 4 sample edge DLF core
-				lumaDlf_funcPtrArray16bit[(ASM_TYPES & PREAVX2_MASK) && 1](
+				lumaDlf_funcPtrArray16bit[!!(ASM_TYPES & PREAVX2_MASK)](
 					edgeStartFilteredSamplePtr,
 					reconpicture->strideY,
 					EB_TRUE,
@@ -2684,7 +2684,7 @@ EB_ERRORTYPE LCUInternalAreaDLFCore16bit(
 				edgeStartFilteredSamplePtr = (EB_U16*)reconpicture->bufferY + reconpicture->originX + reconpicture->originY * reconpicture->strideY + (fourSampleEdgeStartSamplePos_y + lcuPos_y) * reconpicture->strideY + fourSampleEdgeStartSamplePos_x + lcuPos_x;
 
 				// 4 sample edge DLF core
-				lumaDlf_funcPtrArray16bit[(ASM_TYPES & PREAVX2_MASK) && 1](
+				lumaDlf_funcPtrArray16bit[!!(ASM_TYPES & PREAVX2_MASK)](
 					edgeStartFilteredSamplePtr,
 					reconpicture->strideY,
 					EB_FALSE,
@@ -2743,7 +2743,7 @@ EB_ERRORTYPE LCUInternalAreaDLFCore16bit(
 				edgeStartSampleCr = (EB_U16*)reconpicture->bufferCr + (reconpicture->originX >> subWidthCMinus1) + (reconpicture->originY >> subHeightCMinus1) * reconpicture->strideCr + (twoSampleEdgeStartSamplePos_y + chromaLcuPos_y) * reconpicture->strideCr + (twoSampleEdgeStartSamplePos_x + chromaLcuPos_x);
 
 
-				chromaDlf_funcPtrArray16bit[(ASM_TYPES & PREAVX2_MASK) && 1](
+				chromaDlf_funcPtrArray16bit[!!(ASM_TYPES & PREAVX2_MASK)](
 					edgeStartSampleCb,
 					edgeStartSampleCr,
 					reconpicture->strideCb,
@@ -2802,7 +2802,7 @@ EB_ERRORTYPE LCUInternalAreaDLFCore16bit(
 				edgeStartSampleCb = (EB_U16*)reconpicture->bufferCb + (reconpicture->originX >> subWidthCMinus1) + (reconpicture->originY >> subHeightCMinus1) * reconpicture->strideCb + (twoSampleEdgeStartSamplePos_y + chromaLcuPos_y) * reconpicture->strideCb + (twoSampleEdgeStartSamplePos_x + chromaLcuPos_x);
 				edgeStartSampleCr = (EB_U16*)reconpicture->bufferCr + (reconpicture->originX >> subWidthCMinus1) + (reconpicture->originY >> subHeightCMinus1) * reconpicture->strideCr + (twoSampleEdgeStartSamplePos_y + chromaLcuPos_y) * reconpicture->strideCr + (twoSampleEdgeStartSamplePos_x + chromaLcuPos_x);
 
-				chromaDlf_funcPtrArray16bit[(ASM_TYPES & PREAVX2_MASK) && 1](
+				chromaDlf_funcPtrArray16bit[!!(ASM_TYPES & PREAVX2_MASK)](
 					edgeStartSampleCb,
 					edgeStartSampleCr,
 					reconpicture->strideCb,
@@ -3624,7 +3624,7 @@ void LCUPictureEdgeDLFCore(
 				edgeStartFilteredSamplePtr = reconPic->bufferY + reconPic->originX + reconPic->originY * reconPic->strideY + fourSampleEdgeStartSamplePos_y * reconPic->strideY + fourSampleEdgeStartSamplePos_x;
 
 				// 4 sample luma edge filter core
-				Luma4SampleEdgeDLFCore_Table[(ASM_TYPES & PREAVX2_MASK) && 1](
+				Luma4SampleEdgeDLFCore_Table[!!(ASM_TYPES & PREAVX2_MASK)](
 					edgeStartFilteredSamplePtr,
 					reconPic->strideY,
 					EB_FALSE,
@@ -3684,7 +3684,7 @@ void LCUPictureEdgeDLFCore(
 					edgeStartSampleCb = reconPic->bufferCb + (reconPic->originX >> subWidthCMinus1) + (reconPic->originY >> subHeightCMinus1) * reconPic->strideCb + fourSampleEdgeStartSamplePos_y * reconPic->strideCb + fourSampleEdgeStartSamplePos_x;
 					edgeStartSampleCr = reconPic->bufferCr + (reconPic->originX >> subWidthCMinus1) + (reconPic->originY >> subHeightCMinus1) * reconPic->strideCr + fourSampleEdgeStartSamplePos_y * reconPic->strideCr + fourSampleEdgeStartSamplePos_x;
 
-					Chroma2SampleEdgeDLFCore_Table[(ASM_TYPES & PREAVX2_MASK) && 1](
+					Chroma2SampleEdgeDLFCore_Table[!!(ASM_TYPES & PREAVX2_MASK)](
 						edgeStartSampleCb,
 						edgeStartSampleCr,
 						reconPic->strideCb,
@@ -3733,7 +3733,7 @@ void LCUPictureEdgeDLFCore(
 					edgeStartSampleCb = reconPic->bufferCb + (reconPic->originX >> subWidthCMinus1) + (reconPic->originY >> subHeightCMinus1) * reconPic->strideCb + fourSampleEdgeStartSamplePos_y * reconPic->strideCb + (fourSampleEdgeStartSamplePos_x + 2);
 					edgeStartSampleCr = reconPic->bufferCr + (reconPic->originX >> subWidthCMinus1) + (reconPic->originY >> subHeightCMinus1) * reconPic->strideCr + fourSampleEdgeStartSamplePos_y * reconPic->strideCr + (fourSampleEdgeStartSamplePos_x + 2);
 
-					Chroma2SampleEdgeDLFCore_Table[(ASM_TYPES & PREAVX2_MASK) && 1](
+					Chroma2SampleEdgeDLFCore_Table[!!(ASM_TYPES & PREAVX2_MASK)](
 						edgeStartSampleCb,
 						edgeStartSampleCr,
 						reconPic->strideCb,
@@ -3793,7 +3793,7 @@ void LCUPictureEdgeDLFCore(
 				edgeStartFilteredSamplePtr = reconPic->bufferY + reconPic->originX + reconPic->originY * reconPic->strideY + fourSampleEdgeStartSamplePos_y * reconPic->strideY + fourSampleEdgeStartSamplePos_x;
 
 				// 4 sample edge luma filter core
-				Luma4SampleEdgeDLFCore_Table[(ASM_TYPES & PREAVX2_MASK) && 1](
+				Luma4SampleEdgeDLFCore_Table[!!(ASM_TYPES & PREAVX2_MASK)](
 					edgeStartFilteredSamplePtr,
 					reconPic->strideY,
 					EB_TRUE,
@@ -3855,7 +3855,7 @@ void LCUPictureEdgeDLFCore(
 					edgeStartSampleCr = reconPic->bufferCr + (reconPic->originX >> subWidthCMinus1) + (reconPic->originY >> subHeightCMinus1) * reconPic->strideCr + fourSampleEdgeStartSamplePos_y * reconPic->strideCr + fourSampleEdgeStartSamplePos_x;
 
 
-					Chroma2SampleEdgeDLFCore_Table[(ASM_TYPES & PREAVX2_MASK) && 1](
+					Chroma2SampleEdgeDLFCore_Table[!!(ASM_TYPES & PREAVX2_MASK)](
 						edgeStartSampleCb,
 						edgeStartSampleCr,
 						reconPic->strideCb,
@@ -3903,7 +3903,7 @@ void LCUPictureEdgeDLFCore(
 					edgeStartSampleCr = reconPic->bufferCr + (reconPic->originX >> subWidthCMinus1) + (reconPic->originY >> subHeightCMinus1) * reconPic->strideCr + (fourSampleEdgeStartSamplePos_y + 2) * reconPic->strideCr + fourSampleEdgeStartSamplePos_x;
 
 
-					Chroma2SampleEdgeDLFCore_Table[(ASM_TYPES & PREAVX2_MASK) && 1](
+					Chroma2SampleEdgeDLFCore_Table[!!(ASM_TYPES & PREAVX2_MASK)](
 						edgeStartSampleCb,
 						edgeStartSampleCr,
 						reconPic->strideCb,
@@ -4033,7 +4033,7 @@ void LCUPictureEdgeDLFCore16bit(
 				edgeStartFilteredSamplePtr = (EB_U16*)reconPic->bufferY + reconPic->originX + reconPic->originY * reconPic->strideY + fourSampleEdgeStartSamplePos_y * reconPic->strideY + fourSampleEdgeStartSamplePos_x;
 
 				// 4 sample luma edge filter core
-				lumaDlf_funcPtrArray16bit[(ASM_TYPES & PREAVX2_MASK) && 1](
+				lumaDlf_funcPtrArray16bit[!!(ASM_TYPES & PREAVX2_MASK)](
 					edgeStartFilteredSamplePtr,
 					reconPic->strideY,
 					EB_FALSE,
@@ -4096,7 +4096,7 @@ void LCUPictureEdgeDLFCore16bit(
 					edgeStartSampleCb = ((EB_U16*)reconPic->bufferCb) + (reconPic->originX >> subWidthCMinus1) + (reconPic->originY >> subHeightCMinus1) * reconPic->strideCb + fourSampleEdgeStartSamplePos_y * reconPic->strideCb + fourSampleEdgeStartSamplePos_x;
 					edgeStartSampleCr = ((EB_U16*)reconPic->bufferCr) + (reconPic->originX >> subWidthCMinus1) + (reconPic->originY >> subHeightCMinus1) * reconPic->strideCr + fourSampleEdgeStartSamplePos_y * reconPic->strideCr + fourSampleEdgeStartSamplePos_x;
 
-					chromaDlf_funcPtrArray16bit[(ASM_TYPES & PREAVX2_MASK) && 1](
+					chromaDlf_funcPtrArray16bit[!!(ASM_TYPES & PREAVX2_MASK)](
 						edgeStartSampleCb,
 						edgeStartSampleCr,
 						reconPic->strideCb,
@@ -4149,7 +4149,7 @@ void LCUPictureEdgeDLFCore16bit(
 					edgeStartSampleCb = ((EB_U16*)reconPic->bufferCb) + (reconPic->originX >> subWidthCMinus1) + (reconPic->originY >> subHeightCMinus1) * reconPic->strideCb + fourSampleEdgeStartSamplePos_y * reconPic->strideCb + (fourSampleEdgeStartSamplePos_x + 2);
 					edgeStartSampleCr = ((EB_U16*)reconPic->bufferCr) + (reconPic->originX >> subWidthCMinus1) + (reconPic->originY >> subHeightCMinus1) * reconPic->strideCr + fourSampleEdgeStartSamplePos_y * reconPic->strideCr + (fourSampleEdgeStartSamplePos_x + 2);
 
-					chromaDlf_funcPtrArray16bit[(ASM_TYPES & PREAVX2_MASK) && 1](
+					chromaDlf_funcPtrArray16bit[!!(ASM_TYPES & PREAVX2_MASK)](
 						edgeStartSampleCb,
 						edgeStartSampleCr,
 						reconPic->strideCb,
@@ -4211,7 +4211,7 @@ void LCUPictureEdgeDLFCore16bit(
 				edgeStartFilteredSamplePtr = (EB_U16*)reconPic->bufferY + reconPic->originX + reconPic->originY * reconPic->strideY + fourSampleEdgeStartSamplePos_y * reconPic->strideY + fourSampleEdgeStartSamplePos_x;
 
 				// 4 sample edge luma filter core
-				lumaDlf_funcPtrArray16bit[(ASM_TYPES & PREAVX2_MASK) && 1](
+				lumaDlf_funcPtrArray16bit[!!(ASM_TYPES & PREAVX2_MASK)](
 					edgeStartFilteredSamplePtr,
 					reconPic->strideY,
 					EB_TRUE,
@@ -4274,7 +4274,7 @@ void LCUPictureEdgeDLFCore16bit(
 					edgeStartSampleCr = (EB_U16*)reconPic->bufferCr + (reconPic->originX >> subWidthCMinus1) + (reconPic->originY >> subHeightCMinus1) * reconPic->strideCr + fourSampleEdgeStartSamplePos_y * reconPic->strideCr + fourSampleEdgeStartSamplePos_x;
 
 
-					chromaDlf_funcPtrArray16bit[(ASM_TYPES & PREAVX2_MASK) && 1](
+					chromaDlf_funcPtrArray16bit[!!(ASM_TYPES & PREAVX2_MASK)](
 						edgeStartSampleCb,
 						edgeStartSampleCr,
 						reconPic->strideCb,
@@ -4325,7 +4325,7 @@ void LCUPictureEdgeDLFCore16bit(
 					edgeStartSampleCb = (EB_U16*)reconPic->bufferCb + (reconPic->originX >> subWidthCMinus1) + (reconPic->originY >> subHeightCMinus1) * reconPic->strideCb + (fourSampleEdgeStartSamplePos_y + 2) * reconPic->strideCb + fourSampleEdgeStartSamplePos_x;
 					edgeStartSampleCr = (EB_U16*)reconPic->bufferCr + (reconPic->originX >> subWidthCMinus1) + (reconPic->originY >> subHeightCMinus1) * reconPic->strideCr + (fourSampleEdgeStartSamplePos_y + 2) * reconPic->strideCr + fourSampleEdgeStartSamplePos_x;
 
-					chromaDlf_funcPtrArray16bit[(ASM_TYPES & PREAVX2_MASK) && 1](
+					chromaDlf_funcPtrArray16bit[!!(ASM_TYPES & PREAVX2_MASK)](
 						edgeStartSampleCb,
 						edgeStartSampleCr,
 						reconPic->strideCb,

--- a/Source/Lib/Codec/EbEncDecProcess.c
+++ b/Source/Lib/Codec/EbEncDecProcess.c
@@ -286,7 +286,7 @@ static EB_ERRORTYPE ApplySaoOffsetsLcu(
         }
 
 
-        SaoFunctionTableEO_0_90[(ASM_TYPES & PREAVX2_MASK) && 1][(saoPtr->saoTypeIndex[isChroma]) - 1][((lcuHeight & 15) == 0) && ((lcuWidth & 15) == 0) && (lcuWidth >= 32)](
+        SaoFunctionTableEO_0_90[!!(ASM_TYPES & PREAVX2_MASK)][(saoPtr->saoTypeIndex[isChroma]) - 1][((lcuHeight & 15) == 0) && ((lcuWidth & 15) == 0) && (lcuWidth >= 32)](
             reconSamplePtr,
             reconStride,
             temporalBufferLeft,
@@ -326,7 +326,7 @@ static EB_ERRORTYPE ApplySaoOffsetsLcu(
                 tmp[i] = reconSamplePtr[i + reconStride*(lcuHeight - 1)];
             }
         }
-        SaoFunctionTableEO_0_90[(ASM_TYPES & PREAVX2_MASK) && 1][(saoPtr->saoTypeIndex[isChroma]) - 1][((lcuHeight & 15) == 0) && ((lcuWidth & 15) == 0) && (lcuWidth >= 32)](
+        SaoFunctionTableEO_0_90[!!(ASM_TYPES & PREAVX2_MASK)][(saoPtr->saoTypeIndex[isChroma]) - 1][((lcuHeight & 15) == 0) && ((lcuWidth & 15) == 0) && (lcuWidth >= 32)](
             reconSamplePtr,
             reconStride,
             temporalBufferUpper,
@@ -382,7 +382,7 @@ static EB_ERRORTYPE ApplySaoOffsetsLcu(
             }
         }
 
-        SaoFunctionTableEO_135_45[(ASM_TYPES & PREAVX2_MASK) && 1][(saoPtr->saoTypeIndex[isChroma]) - 3][(lcuHeight == MAX_LCU_SIZE_REMAINING) && ((lcuWidth & 15) == 0) && (lcuWidth >= 32)][((lcuHeight & 15) == 0) && ((lcuWidth & 15) == 0) && (lcuWidth >= 32)](
+        SaoFunctionTableEO_135_45[!!(ASM_TYPES & PREAVX2_MASK)][(saoPtr->saoTypeIndex[isChroma]) - 3][(lcuHeight == MAX_LCU_SIZE_REMAINING) && ((lcuWidth & 15) == 0) && (lcuWidth >= 32)][((lcuHeight & 15) == 0) && ((lcuWidth & 15) == 0) && (lcuWidth >= 32)](
             reconSamplePtr,
             reconStride,
             temporalBufferLeft,
@@ -448,7 +448,7 @@ static EB_ERRORTYPE ApplySaoOffsetsLcu(
             }
         }
 
-        SaoFunctionTableEO_135_45[(ASM_TYPES & PREAVX2_MASK) && 1][(saoPtr->saoTypeIndex[isChroma]) - 3][(lcuHeight == MAX_LCU_SIZE_REMAINING) && ((lcuWidth & 15) == 0) && (lcuWidth >= 32)][((lcuHeight & 15) == 0) && ((lcuWidth & 15) == 0) && (lcuWidth >= 32)](
+        SaoFunctionTableEO_135_45[!!(ASM_TYPES & PREAVX2_MASK)][(saoPtr->saoTypeIndex[isChroma]) - 3][(lcuHeight == MAX_LCU_SIZE_REMAINING) && ((lcuWidth & 15) == 0) && (lcuWidth >= 32)][((lcuHeight & 15) == 0) && ((lcuWidth & 15) == 0) && (lcuWidth >= 32)](
             reconSamplePtr,
             reconStride,
             temporalBufferLeft,
@@ -483,7 +483,7 @@ static EB_ERRORTYPE ApplySaoOffsetsLcu(
 
     case 5: // BO
 
-        SaoFunctionTableBo[(ASM_TYPES & PREAVX2_MASK) && 1][((lcuWidth & 15) == 0 && (lcuHeight != MAX_LCU_SIZE_REMAINING))](
+        SaoFunctionTableBo[!!(ASM_TYPES & PREAVX2_MASK)][((lcuWidth & 15) == 0 && (lcuHeight != MAX_LCU_SIZE_REMAINING))](
             reconSamplePtr,
             reconStride,
             saoPtr->saoBandPosition[videoComponent],
@@ -813,7 +813,7 @@ static EB_ERRORTYPE ApplySaoOffsetsLcu16bit(
         }
 
 
-        SaoFunctionTableEO_0_90_16bit[(ASM_TYPES & PREAVX2_MASK) && 1][(saoPtr->saoTypeIndex[isChroma]) - 1][((lcuHeight & 15) == 0) && ((lcuWidth & 15) == 0) && (lcuWidth >= 32)](
+        SaoFunctionTableEO_0_90_16bit[!!(ASM_TYPES & PREAVX2_MASK)][(saoPtr->saoTypeIndex[isChroma]) - 1][((lcuHeight & 15) == 0) && ((lcuWidth & 15) == 0) && (lcuWidth >= 32)](
             reconSamplePtr,
             reconStride,
             temporalBufferLeft,
@@ -854,7 +854,7 @@ static EB_ERRORTYPE ApplySaoOffsetsLcu16bit(
             }
         }
 
-        SaoFunctionTableEO_0_90_16bit[(ASM_TYPES & PREAVX2_MASK) && 1][(saoPtr->saoTypeIndex[isChroma]) - 1][((lcuHeight & 15) == 0) && ((lcuWidth & 15) == 0) && (lcuWidth >= 32)](
+        SaoFunctionTableEO_0_90_16bit[!!(ASM_TYPES & PREAVX2_MASK)][(saoPtr->saoTypeIndex[isChroma]) - 1][((lcuHeight & 15) == 0) && ((lcuWidth & 15) == 0) && (lcuWidth >= 32)](
             reconSamplePtr,
             reconStride,
             temporalBufferUpper,
@@ -910,7 +910,7 @@ static EB_ERRORTYPE ApplySaoOffsetsLcu16bit(
             }
         }
 
-        SaoFunctionTableEO_135_45_16bit[(ASM_TYPES & PREAVX2_MASK) && 1][(saoPtr->saoTypeIndex[isChroma]) - 3][((lcuWidth & 15) == 0) && (lcuWidth >= 32) && ((lcuHeight & 7) == 0) && (lcuHeight >= 8)](
+        SaoFunctionTableEO_135_45_16bit[!!(ASM_TYPES & PREAVX2_MASK)][(saoPtr->saoTypeIndex[isChroma]) - 3][((lcuWidth & 15) == 0) && (lcuWidth >= 32) && ((lcuHeight & 7) == 0) && (lcuHeight >= 8)](
             reconSamplePtr,
             reconStride,
             temporalBufferLeft,
@@ -976,7 +976,7 @@ static EB_ERRORTYPE ApplySaoOffsetsLcu16bit(
             }
         }
 
-        SaoFunctionTableEO_135_45_16bit[(ASM_TYPES & PREAVX2_MASK) && 1][(saoPtr->saoTypeIndex[isChroma]) - 3][((lcuWidth & 15) == 0) && (lcuWidth >= 32) && ((lcuHeight & 7) == 0) && (lcuHeight >= 8)](
+        SaoFunctionTableEO_135_45_16bit[!!(ASM_TYPES & PREAVX2_MASK)][(saoPtr->saoTypeIndex[isChroma]) - 3][((lcuWidth & 15) == 0) && (lcuWidth >= 32) && ((lcuHeight & 7) == 0) && (lcuHeight >= 8)](
             reconSamplePtr,
             reconStride,
             temporalBufferLeft,
@@ -1011,7 +1011,7 @@ static EB_ERRORTYPE ApplySaoOffsetsLcu16bit(
 
     case 5: // BO
 
-        SaoFunctionTableBo_16bit[(ASM_TYPES & PREAVX2_MASK) && 1][((lcuWidth & 15) == 0)](
+        SaoFunctionTableBo_16bit[!!(ASM_TYPES & PREAVX2_MASK)][((lcuWidth & 15) == 0)](
             reconSamplePtr,
             reconStride,
             saoPtr->saoBandPosition[videoComponent],

--- a/Source/Lib/Codec/EbEntropyCoding.c
+++ b/Source/Lib/Codec/EbEntropyCoding.c
@@ -4094,7 +4094,7 @@ static EB_ERRORTYPE EncodeCoeff(
 	coeffBuffer = (EB_S16*)&coeffPtr->bufferY[coeffLocation * sizeof(EB_S16)];
 
 	if (tuPtr->lumaCbf) {
-		EncodeQuantizedCoefficientsFuncArray[(ASM_TYPES & PREAVX2_MASK) && 1](
+		EncodeQuantizedCoefficientsFuncArray[!!(ASM_TYPES & PREAVX2_MASK)](
 			cabacEncodeCtxPtr,
 			tuSize,
 			(EB_MODETYPE)cuPtr->predictionModeFlag,
@@ -4116,7 +4116,7 @@ static EB_ERRORTYPE EncodeCoeff(
 
 	if (tuSize > 4){
 		if (tuPtr->cbCbf) {
-			EncodeQuantizedCoefficientsFuncArray[(ASM_TYPES & PREAVX2_MASK) && 1](
+			EncodeQuantizedCoefficientsFuncArray[!!(ASM_TYPES & PREAVX2_MASK)](
 				cabacEncodeCtxPtr,
 				tuChromaSize,
 				(EB_MODETYPE)cuPtr->predictionModeFlag,
@@ -4131,7 +4131,7 @@ static EB_ERRORTYPE EncodeCoeff(
         if (cabacEncodeCtxPtr->colorFormat == EB_YUV422 && tuPtr->cbCbf2) {
             coeffLocation = (tuOriginX >> 1) + ((tuOriginY+tuChromaSize) * coeffPtr->strideCb);
 	        coeffBuffer = (EB_S16*)&coeffPtr->bufferCb[coeffLocation * sizeof(EB_S16)];
-			EncodeQuantizedCoefficientsFuncArray[(ASM_TYPES & PREAVX2_MASK) && 1](
+			EncodeQuantizedCoefficientsFuncArray[!!(ASM_TYPES & PREAVX2_MASK)](
 				cabacEncodeCtxPtr,
 				tuChromaSize,
 				(EB_MODETYPE)cuPtr->predictionModeFlag,
@@ -4145,7 +4145,7 @@ static EB_ERRORTYPE EncodeCoeff(
 	} else if (tuPtr->tuIndex - ((tuPtr->tuIndex >> 2) << 2) == 0) {
         // Never be here
 		if (tuPtr->cbCbf) {
-			EncodeQuantizedCoefficientsFuncArray[(ASM_TYPES & PREAVX2_MASK) && 1](
+			EncodeQuantizedCoefficientsFuncArray[!!(ASM_TYPES & PREAVX2_MASK)](
 				cabacEncodeCtxPtr,
 				tuChromaSize,
 				(EB_MODETYPE)cuPtr->predictionModeFlag,
@@ -4165,7 +4165,7 @@ static EB_ERRORTYPE EncodeCoeff(
 
 	if (tuSize > 4){
 		if (tuPtr->crCbf) {
-			EncodeQuantizedCoefficientsFuncArray[(ASM_TYPES & PREAVX2_MASK) && 1](
+			EncodeQuantizedCoefficientsFuncArray[!!(ASM_TYPES & PREAVX2_MASK)](
 				cabacEncodeCtxPtr,
 				tuChromaSize,
 				(EB_MODETYPE)cuPtr->predictionModeFlag,
@@ -4180,7 +4180,7 @@ static EB_ERRORTYPE EncodeCoeff(
         if (cabacEncodeCtxPtr->colorFormat == EB_YUV422 && tuPtr->crCbf2) {
             coeffLocation = (tuOriginX >> 1) + ((tuOriginY+tuChromaSize) * coeffPtr->strideCr);
 	        coeffBuffer = (EB_S16*)&coeffPtr->bufferCr[coeffLocation * sizeof(EB_S16)];
-			EncodeQuantizedCoefficientsFuncArray[(ASM_TYPES & PREAVX2_MASK) && 1](
+			EncodeQuantizedCoefficientsFuncArray[!!(ASM_TYPES & PREAVX2_MASK)](
 				cabacEncodeCtxPtr,
 				tuChromaSize,
 				(EB_MODETYPE)cuPtr->predictionModeFlag,
@@ -4195,7 +4195,7 @@ static EB_ERRORTYPE EncodeCoeff(
 	else if (tuPtr->tuIndex - ((tuPtr->tuIndex >> 2) << 2) == 0) {
 
 		if (tuPtr->crCbf) {
-			EncodeQuantizedCoefficientsFuncArray[(ASM_TYPES & PREAVX2_MASK) && 1](
+			EncodeQuantizedCoefficientsFuncArray[!!(ASM_TYPES & PREAVX2_MASK)](
 				cabacEncodeCtxPtr,
 				tuChromaSize,
 				(EB_MODETYPE)cuPtr->predictionModeFlag,
@@ -6918,7 +6918,7 @@ static EB_ERRORTYPE Intra4x4EncodeLumaCoeff(
 			MIN_PU_SIZE,
 			&countNonZeroCoeffs);
 
-		EncodeQuantizedCoefficientsFuncArray[(ASM_TYPES & PREAVX2_MASK) && 1](
+		EncodeQuantizedCoefficientsFuncArray[!!(ASM_TYPES & PREAVX2_MASK)](
 			cabacEncodeCtxPtr,
 			MIN_PU_SIZE,
 			(EB_MODETYPE)cuPtr->predictionModeFlag,
@@ -6966,7 +6966,7 @@ static EB_ERRORTYPE Intra4x4EncodeChromaCoeff(
                     MIN_PU_SIZE,
                     &countNonZeroCoeffs);
 
-            EncodeQuantizedCoefficientsFuncArray[(ASM_TYPES & PREAVX2_MASK) && 1](
+            EncodeQuantizedCoefficientsFuncArray[!!(ASM_TYPES & PREAVX2_MASK)](
                     cabacEncodeCtxPtr,
                     MIN_PU_SIZE,
                     (EB_MODETYPE)cuPtr->predictionModeFlag,
@@ -6994,7 +6994,7 @@ static EB_ERRORTYPE Intra4x4EncodeChromaCoeff(
                     MIN_PU_SIZE,
                     &countNonZeroCoeffs);
 
-            EncodeQuantizedCoefficientsFuncArray[(ASM_TYPES & PREAVX2_MASK) && 1](
+            EncodeQuantizedCoefficientsFuncArray[!!(ASM_TYPES & PREAVX2_MASK)](
                     cabacEncodeCtxPtr,
                     MIN_PU_SIZE,
                     (EB_MODETYPE)cuPtr->predictionModeFlag,
@@ -7675,7 +7675,7 @@ EB_ERRORTYPE TuEstimateCoeffBitsEncDec(
 
 		if (countNonZeroCoeffs[0]) {
 
-			EstimateQuantizedCoefficients[1][(ASM_TYPES & PREAVX2_MASK) && 1](
+			EstimateQuantizedCoefficients[1][!!(ASM_TYPES & PREAVX2_MASK)](
 				CabacCost,
 				cabacEncodeCtxPtr,
 				transformSize,
@@ -7699,7 +7699,7 @@ EB_ERRORTYPE TuEstimateCoeffBitsEncDec(
 
 		if (countNonZeroCoeffs[1]) {
 
-			EstimateQuantizedCoefficients[1][(ASM_TYPES & PREAVX2_MASK) && 1](
+			EstimateQuantizedCoefficients[1][!!(ASM_TYPES & PREAVX2_MASK)](
 				CabacCost,
 				cabacEncodeCtxPtr,
 				transformChromaSize,
@@ -7722,7 +7722,7 @@ EB_ERRORTYPE TuEstimateCoeffBitsEncDec(
 
 		if (countNonZeroCoeffs[2]) {
 
-			EstimateQuantizedCoefficients[1][(ASM_TYPES & PREAVX2_MASK) && 1](
+			EstimateQuantizedCoefficients[1][!!(ASM_TYPES & PREAVX2_MASK)](
 				CabacCost,
 				cabacEncodeCtxPtr,
 				transformChromaSize,
@@ -7770,7 +7770,7 @@ EB_ERRORTYPE TuEstimateCoeffBitsLuma(
 	if (yCountNonZeroCoeffs) {
 
         if(coeffCabacUpdate)
-            EstimateQuantizedCoefficientsUpdate[(ASM_TYPES & PREAVX2_MASK) && 1](
+            EstimateQuantizedCoefficientsUpdate[!!(ASM_TYPES & PREAVX2_MASK)](
                 updatedCoeffCtxModel,
                 CabacCost,
                 cabacEncodeCtxPtr,
@@ -7784,7 +7784,7 @@ EB_ERRORTYPE TuEstimateCoeffBitsLuma(
                 yCountNonZeroCoeffs,
                 yTuCoeffBits);
         else
-		    EstimateQuantizedCoefficients[1][(ASM_TYPES & PREAVX2_MASK) && 1](
+		    EstimateQuantizedCoefficients[1][!!(ASM_TYPES & PREAVX2_MASK)](
 			    CabacCost,
 			    cabacEncodeCtxPtr,
 			    (transformSize >> partialFrequencyN2Flag),
@@ -7846,7 +7846,7 @@ EB_ERRORTYPE TuEstimateCoeffBits_R(
 		if (yCountNonZeroCoeffs) {
 
 			if (coeffCabacUpdate)
-				EstimateQuantizedCoefficientsUpdate[(ASM_TYPES & PREAVX2_MASK) && 1](
+				EstimateQuantizedCoefficientsUpdate[!!(ASM_TYPES & PREAVX2_MASK)](
 					updatedCoeffCtxModel,
 					CabacCost,
 					cabacEncodeCtxPtr,
@@ -7862,7 +7862,7 @@ EB_ERRORTYPE TuEstimateCoeffBits_R(
 
             else
 
-			    EstimateQuantizedCoefficients[encoderModeIndex][(ASM_TYPES & PREAVX2_MASK) && 1](
+			    EstimateQuantizedCoefficients[encoderModeIndex][!!(ASM_TYPES & PREAVX2_MASK)](
 				    CabacCost,
 				    cabacEncodeCtxPtr,
 				    (transformSize >> partialFrequencyN2Flag),
@@ -7887,7 +7887,7 @@ EB_ERRORTYPE TuEstimateCoeffBits_R(
 		if (cbCountNonZeroCoeffs) {
 
 			if (coeffCabacUpdate)
-				EstimateQuantizedCoefficientsUpdate[(ASM_TYPES & PREAVX2_MASK) && 1](
+				EstimateQuantizedCoefficientsUpdate[!!(ASM_TYPES & PREAVX2_MASK)](
 					updatedCoeffCtxModel,
 					CabacCost,
 					cabacEncodeCtxPtr,
@@ -7902,7 +7902,7 @@ EB_ERRORTYPE TuEstimateCoeffBits_R(
 					cbTuCoeffBits);
             else
 
-			    EstimateQuantizedCoefficients[encoderModeIndex][(ASM_TYPES & PREAVX2_MASK) && 1](
+			    EstimateQuantizedCoefficients[encoderModeIndex][!!(ASM_TYPES & PREAVX2_MASK)](
 				    CabacCost,
 				    cabacEncodeCtxPtr,
 				    (transformChromaSize >> partialFrequencyN2Flag),
@@ -7927,7 +7927,7 @@ EB_ERRORTYPE TuEstimateCoeffBits_R(
 		if (crCountNonZeroCoeffs) {
 
             if (coeffCabacUpdate) 
-                EstimateQuantizedCoefficientsUpdate[(ASM_TYPES & PREAVX2_MASK) && 1](
+                EstimateQuantizedCoefficientsUpdate[!!(ASM_TYPES & PREAVX2_MASK)](
                     updatedCoeffCtxModel,
                     CabacCost,
                     cabacEncodeCtxPtr,
@@ -7943,7 +7943,7 @@ EB_ERRORTYPE TuEstimateCoeffBits_R(
 
             else
 
-			    EstimateQuantizedCoefficients[encoderModeIndex][(ASM_TYPES & PREAVX2_MASK) && 1](
+			    EstimateQuantizedCoefficients[encoderModeIndex][!!(ASM_TYPES & PREAVX2_MASK)](
 				    CabacCost,
 				    cabacEncodeCtxPtr,
                     (transformChromaSize >> partialFrequencyN2Flag),

--- a/Source/Lib/Codec/EbEntropyCoding.c
+++ b/Source/Lib/Codec/EbEntropyCoding.c
@@ -6358,8 +6358,6 @@ static void CodePPS(
 	return;
 }
 
-#define DECODED_PICTURE_HASH 132
-
 static void CodeSliceHeader(
 	EB_U32         firstLcuAddr,
 	EB_U32         pictureQp,

--- a/Source/Lib/Codec/EbFullLoop.c
+++ b/Source/Lib/Codec/EbFullLoop.c
@@ -353,7 +353,7 @@ void ProductFullLoop(
 					cuStatsPtr->size < 32 ? PF_OFF : contextPtr->pfMdMode);
 
                 if ((cuStatsPtr->size >> 3) < 9)
-				    AdditionKernel_funcPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1][cuStatsPtr->size >> 3](
+				    AdditionKernel_funcPtrArray[!!(ASM_TYPES & PREAVX2_MASK)][cuStatsPtr->size >> 3](
 					    &(candidateBuffer->predictionPtr->bufferY[tuOriginIndex]),
 					    64,
 					    &(((EB_S16*)(contextPtr->transQuantBuffersPtr->tuTransCoeff2Nx2NPtr->bufferY))[tuOriginIndex]),
@@ -380,7 +380,7 @@ void ProductFullLoop(
 					PICTURE_BUFFER_DESC_Y_FLAG);
 			}
 
-			tuFullDistortion[0][DIST_CALC_RESIDUAL] = SpatialFullDistortionKernel_funcPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1][Log2f(cuStatsPtr->size) - 2](
+			tuFullDistortion[0][DIST_CALC_RESIDUAL] = SpatialFullDistortionKernel_funcPtrArray[!!(ASM_TYPES & PREAVX2_MASK)][Log2f(cuStatsPtr->size) - 2](
 				&(inputPicturePtr->bufferY[inputOriginIndex]),
 				inputPicturePtr->strideY,
 				&(candidateBuffer->reconPtr->bufferY[tuOriginIndex]),
@@ -388,7 +388,7 @@ void ProductFullLoop(
 				cuStatsPtr->size,
 				cuStatsPtr->size);
 
-			tuFullDistortion[0][DIST_CALC_PREDICTION] = SpatialFullDistortionKernel_funcPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1][Log2f(cuStatsPtr->size) - 2](
+			tuFullDistortion[0][DIST_CALC_PREDICTION] = SpatialFullDistortionKernel_funcPtrArray[!!(ASM_TYPES & PREAVX2_MASK)][Log2f(cuStatsPtr->size) - 2](
 				&(inputPicturePtr->bufferY[inputOriginIndex]),
 				inputPicturePtr->strideY,
 				&(candidateBuffer->predictionPtr->bufferY[tuOriginIndex]),
@@ -945,7 +945,7 @@ void CuFullDistortionFastTuMode_R (
 
             if (contextPtr->spatialSseFullLoop == EB_TRUE) {
 
-                tuFullDistortion[1][DIST_CALC_RESIDUAL] = SpatialFullDistortionKernel_funcPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1][Log2f(chromaTuSize) - 2](
+                tuFullDistortion[1][DIST_CALC_RESIDUAL] = SpatialFullDistortionKernel_funcPtrArray[!!(ASM_TYPES & PREAVX2_MASK)][Log2f(chromaTuSize) - 2](
                     &(inputPicturePtr->bufferCb[inputCbOriginIndex]),
                     inputPicturePtr->strideCb,
                     &(candidateBuffer->reconPtr->bufferCb[tuChromaOriginIndex]),
@@ -954,7 +954,7 @@ void CuFullDistortionFastTuMode_R (
                     chromaTuSize);
 
 
-                tuFullDistortion[1][DIST_CALC_PREDICTION] = SpatialFullDistortionKernel_funcPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1][Log2f(chromaTuSize) - 2](
+                tuFullDistortion[1][DIST_CALC_PREDICTION] = SpatialFullDistortionKernel_funcPtrArray[!!(ASM_TYPES & PREAVX2_MASK)][Log2f(chromaTuSize) - 2](
                     &(inputPicturePtr->bufferCb[inputCbOriginIndex]),
                     inputPicturePtr->strideCb,
                     &(candidateBuffer->predictionPtr->bufferCb[tuChromaOriginIndex]),
@@ -962,7 +962,7 @@ void CuFullDistortionFastTuMode_R (
                     chromaTuSize,
                     chromaTuSize);
 
-                tuFullDistortion[2][DIST_CALC_RESIDUAL] = SpatialFullDistortionKernel_funcPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1][Log2f(chromaTuSize) - 2](
+                tuFullDistortion[2][DIST_CALC_RESIDUAL] = SpatialFullDistortionKernel_funcPtrArray[!!(ASM_TYPES & PREAVX2_MASK)][Log2f(chromaTuSize) - 2](
                     &(inputPicturePtr->bufferCr[inputCbOriginIndex]),
                     inputPicturePtr->strideCr,
                     &(candidateBuffer->reconPtr->bufferCr[tuChromaOriginIndex]),
@@ -970,7 +970,7 @@ void CuFullDistortionFastTuMode_R (
                     chromaTuSize,
                     chromaTuSize);
 
-                tuFullDistortion[2][DIST_CALC_PREDICTION] = SpatialFullDistortionKernel_funcPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1][Log2f(chromaTuSize) - 2](
+                tuFullDistortion[2][DIST_CALC_PREDICTION] = SpatialFullDistortionKernel_funcPtrArray[!!(ASM_TYPES & PREAVX2_MASK)][Log2f(chromaTuSize) - 2](
                     &(inputPicturePtr->bufferCr[inputCbOriginIndex]),
                     inputPicturePtr->strideCr,
                     &(candidateBuffer->predictionPtr->bufferCr[tuChromaOriginIndex]),

--- a/Source/Lib/Codec/EbFullLoop.c
+++ b/Source/Lib/Codec/EbFullLoop.c
@@ -147,7 +147,7 @@ void ProductUnifiedQuantizeInvQuantizeMd(
 	}
 	else{
 
-	    QiQ_funcPtrArray[(ASM_TYPES & AVX2_MASK) && 1][areaSize >> 3](
+	    QiQ_funcPtrArray[!!(ASM_TYPES & AVX2_MASK)][areaSize >> 3](
 		    coeff,
 		    coeffStride,
 		    quantCoeff,
@@ -537,7 +537,7 @@ void UnifiedQuantizeInvQuantize_R(
             rdoqPmCoreMethod);
 	}else{
 
-		QiQ_funcPtrArray[(ASM_TYPES & AVX2_MASK) && 1][areaSize >> 3](
+		QiQ_funcPtrArray[!!(ASM_TYPES & AVX2_MASK)][areaSize >> 3](
 			coeff,
 			coeffStride,
 			quantCoeff,

--- a/Source/Lib/Codec/EbIntraPrediction.c
+++ b/Source/Lib/Codec/EbIntraPrediction.c
@@ -3171,7 +3171,7 @@ static void IntraModeAngular16bit_27To33(
     EB_S32           intraPredAngle = intraModeAngularTable[mode - INTRA_VERTICAL_MODE];
     refSampMain    = refSamples + (size << 1);
     
-    IntraAngVertical_16bit_funcPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1](
+    IntraAngVertical_16bit_funcPtrArray[!!(ASM_TYPES & PREAVX2_MASK)](
         size, 
         refSampMain,
         predictionPtr,              
@@ -3294,7 +3294,7 @@ static void IntraModeAngular16bit_19To25(
     }
 
    
-	IntraAngVertical_16bit_funcPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1](
+	IntraAngVertical_16bit_funcPtrArray[!!(ASM_TYPES & PREAVX2_MASK)](
         size, 
         refSampMain,
         predictionPtr,              
@@ -3406,7 +3406,7 @@ static void IntraModeAngular16bit_11To17(
     } 
 
   
-   IntraAngHorizontal_16bit_funcPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1](
+   IntraAngHorizontal_16bit_funcPtrArray[!!(ASM_TYPES & PREAVX2_MASK)](
         size, 
         refSampMain,
         predictionPtr,              
@@ -3460,7 +3460,7 @@ static void IntraModeAngular16bit_3To9(
     refSampMain = refSamples-1;
 
       
-	IntraAngHorizontal_16bit_funcPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1](
+	IntraAngHorizontal_16bit_funcPtrArray[!!(ASM_TYPES & PREAVX2_MASK)](
         size, 
         refSampMain,
         predictionPtr,              
@@ -3575,7 +3575,7 @@ static inline void IntraModeAngular16bit_all(
     switch(mode){
         case 34:
 
-            IntraAng34_16bit_funcPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1](
+            IntraAng34_16bit_funcPtrArray[!!(ASM_TYPES & PREAVX2_MASK)](
                 puSize,
                 refSamples,
                 predictionPtr,
@@ -3602,7 +3602,7 @@ static inline void IntraModeAngular16bit_all(
                 AboveReadyFlag);
             break;
         case 18:
-            IntraAng18_16bit_funcPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1](
+            IntraAng18_16bit_funcPtrArray[!!(ASM_TYPES & PREAVX2_MASK)](
                 puSize,
                 refSamples,
                 predictionPtr,
@@ -3629,7 +3629,7 @@ static inline void IntraModeAngular16bit_all(
             break;
         case 2:
             
-            IntraAng2_16bit_funcPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1](
+            IntraAng2_16bit_funcPtrArray[!!(ASM_TYPES & PREAVX2_MASK)](
                 puSize,
                 refSamplesReverse,
                 predictionPtr,
@@ -3755,7 +3755,7 @@ EB_ERRORTYPE IntraPredictionCl(
             yIntraReferenceArray =  (diffMode > intraLumaFilterTable[Log2f(puWidth)-2])? contextPtr->yIntraFilteredReferenceArrayReverse :
                                      contextPtr->yIntraReferenceArrayReverse;
 
-            IntraHorzLuma_funcPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1](
+            IntraHorzLuma_funcPtrArray[!!(ASM_TYPES & PREAVX2_MASK)](
                 puSize,
                 yIntraReferenceArray,
                 &(candidateBufferPtr->predictionPtr->bufferY[puOriginIndex]),
@@ -3842,7 +3842,7 @@ EB_ERRORTYPE IntraPredictionCl(
               
             // Cb Intra Prediction
             if (componentMask & PICTURE_BUFFER_DESC_Cb_FLAG) {
-                IntraVerticalChroma_funcPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1](
+                IntraVerticalChroma_funcPtrArray[!!(ASM_TYPES & PREAVX2_MASK)](
                     chromaPuSize,
                     contextPtr->cbIntraReferenceArray,
                     &(candidateBufferPtr->predictionPtr->bufferCb[puChromaOriginIndex]),
@@ -3852,7 +3852,7 @@ EB_ERRORTYPE IntraPredictionCl(
        
             // Cr Intra Prediction
             if (componentMask & PICTURE_BUFFER_DESC_Cr_FLAG) {
-				IntraVerticalChroma_funcPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1](
+				IntraVerticalChroma_funcPtrArray[!!(ASM_TYPES & PREAVX2_MASK)](
                     chromaPuSize,
                     contextPtr->crIntraReferenceArray,
                     &(candidateBufferPtr->predictionPtr->bufferCr[puChromaOriginIndex]),
@@ -3866,7 +3866,7 @@ EB_ERRORTYPE IntraPredictionCl(
  
             // Cb Intra Prediction
             if (componentMask & PICTURE_BUFFER_DESC_Cb_FLAG) {
-				IntraHorzChroma_funcPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1](
+				IntraHorzChroma_funcPtrArray[!!(ASM_TYPES & PREAVX2_MASK)](
                     chromaPuSize,
                     contextPtr->cbIntraReferenceArrayReverse,
                     &(candidateBufferPtr->predictionPtr->bufferCb[puChromaOriginIndex]),
@@ -3876,7 +3876,7 @@ EB_ERRORTYPE IntraPredictionCl(
 
             // Cr Intra Prediction
             if (componentMask & PICTURE_BUFFER_DESC_Cr_FLAG) {
-				IntraHorzChroma_funcPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1](
+				IntraHorzChroma_funcPtrArray[!!(ASM_TYPES & PREAVX2_MASK)](
                     chromaPuSize,
                     contextPtr->crIntraReferenceArrayReverse,
                     &(candidateBufferPtr->predictionPtr->bufferCr[puChromaOriginIndex]),
@@ -3890,7 +3890,7 @@ EB_ERRORTYPE IntraPredictionCl(
                
             // Cb Intra Prediction
             if (componentMask & PICTURE_BUFFER_DESC_Cb_FLAG) {
-				IntraDCChroma_funcPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1](
+				IntraDCChroma_funcPtrArray[!!(ASM_TYPES & PREAVX2_MASK)](
                     chromaPuSize,
                     contextPtr->cbIntraReferenceArrayReverse,
                     &(candidateBufferPtr->predictionPtr->bufferCb[puChromaOriginIndex]),
@@ -3900,7 +3900,7 @@ EB_ERRORTYPE IntraPredictionCl(
       
             // Cr Intra Prediction
             if (componentMask & PICTURE_BUFFER_DESC_Cr_FLAG) {
-				IntraDCChroma_funcPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1](
+				IntraDCChroma_funcPtrArray[!!(ASM_TYPES & PREAVX2_MASK)](
                     chromaPuSize,
                     contextPtr->crIntraReferenceArrayReverse,
                     &(candidateBufferPtr->predictionPtr->bufferCr[puChromaOriginIndex]),
@@ -4060,7 +4060,7 @@ EB_ERRORTYPE Intra4x4IntraPredictionCl(
             yIntraReferenceArray =  (diffMode > intraLumaFilterTable[Log2f(puWidth)-2])? contextPtr->yIntraFilteredReferenceArrayReverse :
                                      contextPtr->yIntraReferenceArrayReverse;
 
-			IntraHorzLuma_funcPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1](
+			IntraHorzLuma_funcPtrArray[!!(ASM_TYPES & PREAVX2_MASK)](
                 puSize,
                 yIntraReferenceArray,
                 &(candidateBufferPtr->predictionPtr->bufferY[puOriginIndex]),
@@ -4138,7 +4138,7 @@ EB_ERRORTYPE Intra4x4IntraPredictionCl(
               
             // Cb Intra Prediction
             if (componentMask & PICTURE_BUFFER_DESC_Cb_FLAG) {
-				IntraVerticalChroma_funcPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1](
+				IntraVerticalChroma_funcPtrArray[!!(ASM_TYPES & PREAVX2_MASK)](
                     chromaPuSize,
                     contextPtr->cbIntraReferenceArray,
                     &(candidateBufferPtr->predictionPtr->bufferCb[puChromaOriginIndex]),
@@ -4148,7 +4148,7 @@ EB_ERRORTYPE Intra4x4IntraPredictionCl(
        
             // Cr Intra Prediction
             if (componentMask & PICTURE_BUFFER_DESC_Cr_FLAG) {
-				IntraVerticalChroma_funcPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1](
+				IntraVerticalChroma_funcPtrArray[!!(ASM_TYPES & PREAVX2_MASK)](
                     chromaPuSize,
                     contextPtr->crIntraReferenceArray,
                     &(candidateBufferPtr->predictionPtr->bufferCr[puChromaOriginIndex]),
@@ -4162,7 +4162,7 @@ EB_ERRORTYPE Intra4x4IntraPredictionCl(
  
             // Cb Intra Prediction
             if (componentMask & PICTURE_BUFFER_DESC_Cb_FLAG) {
-				IntraHorzChroma_funcPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1](
+				IntraHorzChroma_funcPtrArray[!!(ASM_TYPES & PREAVX2_MASK)](
                     chromaPuSize,
                     contextPtr->cbIntraReferenceArrayReverse,
                     &(candidateBufferPtr->predictionPtr->bufferCb[puChromaOriginIndex]),
@@ -4172,7 +4172,7 @@ EB_ERRORTYPE Intra4x4IntraPredictionCl(
 
             // Cr Intra Prediction
             if (componentMask & PICTURE_BUFFER_DESC_Cr_FLAG) {
-				IntraHorzChroma_funcPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1](
+				IntraHorzChroma_funcPtrArray[!!(ASM_TYPES & PREAVX2_MASK)](
                     chromaPuSize,
                     contextPtr->crIntraReferenceArrayReverse,
                     &(candidateBufferPtr->predictionPtr->bufferCr[puChromaOriginIndex]),
@@ -4186,7 +4186,7 @@ EB_ERRORTYPE Intra4x4IntraPredictionCl(
                
             // Cb Intra Prediction
             if (componentMask & PICTURE_BUFFER_DESC_Cb_FLAG) {
-				IntraDCChroma_funcPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1](
+				IntraDCChroma_funcPtrArray[!!(ASM_TYPES & PREAVX2_MASK)](
                     chromaPuSize,
                     contextPtr->cbIntraReferenceArrayReverse,
                     &(candidateBufferPtr->predictionPtr->bufferCb[puChromaOriginIndex]),
@@ -4196,7 +4196,7 @@ EB_ERRORTYPE Intra4x4IntraPredictionCl(
       
             // Cr Intra Prediction
             if (componentMask & PICTURE_BUFFER_DESC_Cr_FLAG) {
-				IntraDCChroma_funcPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1](
+				IntraDCChroma_funcPtrArray[!!(ASM_TYPES & PREAVX2_MASK)](
                     chromaPuSize,
                     contextPtr->crIntraReferenceArrayReverse,
                     &(candidateBufferPtr->predictionPtr->bufferCr[puChromaOriginIndex]),
@@ -4316,7 +4316,7 @@ EB_ERRORTYPE Intra4x4IntraPredictionOl(
 
     case 3:
         
-		IntraHorzLuma_funcPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1](
+		IntraHorzLuma_funcPtrArray[!!(ASM_TYPES & PREAVX2_MASK)](
             puSize,
             intraRefPtr->yIntraReferenceArrayReverse,
             &(candidateBufferPtr->predictionPtr->bufferY[puOriginIndex]),
@@ -4437,7 +4437,7 @@ EB_ERRORTYPE EncodePassIntraPrediction(
             break;
 
         case EB_INTRA_HORIZONTAL:
-			IntraHorzLuma_funcPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1](
+			IntraHorzLuma_funcPtrArray[!!(ASM_TYPES & PREAVX2_MASK)](
                 puSize,
                 yIntraReferenceArrayReverse,
                 predictionPtr->bufferY + lumaOffset,
@@ -4530,7 +4530,7 @@ EB_ERRORTYPE EncodePassIntraPrediction(
         case EB_INTRA_VERTICAL:
               
             // Cb Intra Prediction
-			IntraVerticalChroma_funcPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1](
+			IntraVerticalChroma_funcPtrArray[!!(ASM_TYPES & PREAVX2_MASK)](
                 puChromaSize,
                 cbIntraReferenceArrayReverse,
                 predictionPtr->bufferCb + chromaOffset,
@@ -4538,7 +4538,7 @@ EB_ERRORTYPE EncodePassIntraPrediction(
                 EB_FALSE);
        
             // Cr Intra Prediction
-			IntraVerticalChroma_funcPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1](
+			IntraVerticalChroma_funcPtrArray[!!(ASM_TYPES & PREAVX2_MASK)](
                 puChromaSize,
                 crIntraReferenceArrayReverse,
                 predictionPtr->bufferCr + chromaOffset,
@@ -4550,7 +4550,7 @@ EB_ERRORTYPE EncodePassIntraPrediction(
         case EB_INTRA_HORIZONTAL:
  
              // Cb Intra Prediction
-			IntraHorzChroma_funcPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1](
+			IntraHorzChroma_funcPtrArray[!!(ASM_TYPES & PREAVX2_MASK)](
                 puChromaSize,
                 cbIntraReferenceArrayReverse,
                 predictionPtr->bufferCb + chromaOffset,
@@ -4559,7 +4559,7 @@ EB_ERRORTYPE EncodePassIntraPrediction(
                          
 
             // Cr Intra Prediction
-			IntraHorzChroma_funcPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1](
+			IntraHorzChroma_funcPtrArray[!!(ASM_TYPES & PREAVX2_MASK)](
                 puChromaSize,
                 crIntraReferenceArrayReverse,
                 predictionPtr->bufferCr + chromaOffset,
@@ -4571,7 +4571,7 @@ EB_ERRORTYPE EncodePassIntraPrediction(
         case EB_INTRA_DC:
                
             // Cb Intra Prediction
-			IntraDCChroma_funcPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1](
+			IntraDCChroma_funcPtrArray[!!(ASM_TYPES & PREAVX2_MASK)](
                 puChromaSize,
                 cbIntraReferenceArrayReverse,
                 predictionPtr->bufferCb + chromaOffset,
@@ -4580,7 +4580,7 @@ EB_ERRORTYPE EncodePassIntraPrediction(
 
       
             // Cr Intra Prediction
-			IntraDCChroma_funcPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1](
+			IntraDCChroma_funcPtrArray[!!(ASM_TYPES & PREAVX2_MASK)](
                 puChromaSize,
                 crIntraReferenceArrayReverse,
                 predictionPtr->bufferCr + chromaOffset,
@@ -4688,7 +4688,7 @@ EB_ERRORTYPE EncodePassIntraPrediction16bit(
         switch(lumaMode) {
 
         case EB_INTRA_PLANAR:
-        IntraPlanar_16bit_funcPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1](
+        IntraPlanar_16bit_funcPtrArray[!!(ASM_TYPES & PREAVX2_MASK)](
                 puSize,
                 yIntraReferenceArrayReverse,
                 (EB_U16*)predictionPtr->bufferY + lumaOffset,
@@ -4697,7 +4697,7 @@ EB_ERRORTYPE EncodePassIntraPrediction16bit(
             break;
 
         case EB_INTRA_DC:
-            IntraDCLuma_16bit_funcPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1](
+            IntraDCLuma_16bit_funcPtrArray[!!(ASM_TYPES & PREAVX2_MASK)](
                 puSize,
                 yIntraReferenceArrayReverse,
                 (EB_U16*)predictionPtr->bufferY + lumaOffset,
@@ -4706,7 +4706,7 @@ EB_ERRORTYPE EncodePassIntraPrediction16bit(
             break;
 
         case EB_INTRA_VERTICAL:
-            IntraVerticalLuma_16bit_funcPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1](
+            IntraVerticalLuma_16bit_funcPtrArray[!!(ASM_TYPES & PREAVX2_MASK)](
                 puSize,
                 yIntraReferenceArrayReverse,
                 (EB_U16*)predictionPtr->bufferY + lumaOffset,
@@ -4716,7 +4716,7 @@ EB_ERRORTYPE EncodePassIntraPrediction16bit(
             break;
 
         case EB_INTRA_HORIZONTAL:
-            IntraHorzLuma_16bit_funcPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1](
+            IntraHorzLuma_16bit_funcPtrArray[!!(ASM_TYPES & PREAVX2_MASK)](
                 puSize,
                 yIntraReferenceArrayReverse,
                 (EB_U16*)predictionPtr->bufferY + lumaOffset,
@@ -4787,14 +4787,14 @@ EB_ERRORTYPE EncodePassIntraPrediction16bit(
 
         switch(chromaModeAdj) {
         case EB_INTRA_PLANAR:
-             IntraPlanar_16bit_funcPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1](
+             IntraPlanar_16bit_funcPtrArray[!!(ASM_TYPES & PREAVX2_MASK)](
                 puChromaSize,
                 cbIntraReferenceArrayReverse,
                 (EB_U16*)predictionPtr->bufferCb + chromaOffset,
                 predictionPtr->strideCb,
                 EB_FALSE);
 
-            IntraPlanar_16bit_funcPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1](
+            IntraPlanar_16bit_funcPtrArray[!!(ASM_TYPES & PREAVX2_MASK)](
                 puChromaSize,
                 crIntraReferenceArrayReverse,
                 (EB_U16*)predictionPtr->bufferCr + chromaOffset,
@@ -4803,14 +4803,14 @@ EB_ERRORTYPE EncodePassIntraPrediction16bit(
             break;
 
         case EB_INTRA_VERTICAL:
-            IntraVerticalChroma_16bit_funcPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1](
+            IntraVerticalChroma_16bit_funcPtrArray[!!(ASM_TYPES & PREAVX2_MASK)](
                 puChromaSize,
                 cbIntraReferenceArrayReverse,
                 (EB_U16*)predictionPtr->bufferCb + chromaOffset,
                 predictionPtr->strideCb,
                 EB_FALSE);
        
-            IntraVerticalChroma_16bit_funcPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1](
+            IntraVerticalChroma_16bit_funcPtrArray[!!(ASM_TYPES & PREAVX2_MASK)](
                 puChromaSize,
                 crIntraReferenceArrayReverse,
                 (EB_U16*)predictionPtr->bufferCr + chromaOffset,
@@ -4819,14 +4819,14 @@ EB_ERRORTYPE EncodePassIntraPrediction16bit(
             break;
 
         case EB_INTRA_HORIZONTAL:
-            IntraHorzChroma_16bit_funcPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1](
+            IntraHorzChroma_16bit_funcPtrArray[!!(ASM_TYPES & PREAVX2_MASK)](
                 puChromaSize,
                 cbIntraReferenceArrayReverse,
                 (EB_U16*)predictionPtr->bufferCb + chromaOffset,
                 predictionPtr->strideCb,
                 EB_FALSE);
                          
-            IntraHorzChroma_16bit_funcPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1](
+            IntraHorzChroma_16bit_funcPtrArray[!!(ASM_TYPES & PREAVX2_MASK)](
                 puChromaSize,
                 crIntraReferenceArrayReverse,
                 (EB_U16*)predictionPtr->bufferCr + chromaOffset,
@@ -4835,14 +4835,14 @@ EB_ERRORTYPE EncodePassIntraPrediction16bit(
             break;
 
         case EB_INTRA_DC:
-            IntraDCChroma_16bit_funcPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1](
+            IntraDCChroma_16bit_funcPtrArray[!!(ASM_TYPES & PREAVX2_MASK)](
                 puChromaSize,
                 cbIntraReferenceArrayReverse,
                 (EB_U16*)predictionPtr->bufferCb + chromaOffset,
                 predictionPtr->strideCb,
                 EB_FALSE);
 
-            IntraDCChroma_16bit_funcPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1](
+            IntraDCChroma_16bit_funcPtrArray[!!(ASM_TYPES & PREAVX2_MASK)](
                 puChromaSize,
                 crIntraReferenceArrayReverse,
                 (EB_U16*)predictionPtr->bufferCr + chromaOffset,
@@ -5348,7 +5348,7 @@ EB_ERRORTYPE IntraPredictionOpenLoop(
 
     case 3:
         
-		IntraHorzLuma_funcPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1](
+		IntraHorzLuma_funcPtrArray[!!(ASM_TYPES & PREAVX2_MASK)](
             cuSize,
             contextPtr->intraRefPtr->yIntraReferenceArrayReverse,
             (&(contextPtr->meContextPtr->lcuBuffer[0])),
@@ -5466,7 +5466,7 @@ EB_ERRORTYPE IntraPredictionOl(
 
 		case 3:
 
-			IntraHorzLuma_funcPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1](
+			IntraHorzLuma_funcPtrArray[!!(ASM_TYPES & PREAVX2_MASK)](
 				puSize,
 				intraRefPtr->yIntraReferenceArrayReverse,
 				&(candidateBufferPtr->predictionPtr->bufferY[puOriginIndex]),
@@ -5550,7 +5550,7 @@ EB_ERRORTYPE IntraPredictionOl(
 
 			// Cb Intra Prediction
 			if (componentMask & PICTURE_BUFFER_DESC_Cb_FLAG) {
-				IntraVerticalChroma_funcPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1](
+				IntraVerticalChroma_funcPtrArray[!!(ASM_TYPES & PREAVX2_MASK)](
 					chromaPuSize,
 					intraRefPtr->cbIntraReferenceArray,
 					&(candidateBufferPtr->predictionPtr->bufferCb[puChromaOriginIndex]),
@@ -5560,7 +5560,7 @@ EB_ERRORTYPE IntraPredictionOl(
 
 			// Cr Intra Prediction
 			if (componentMask & PICTURE_BUFFER_DESC_Cr_FLAG) {
-				IntraVerticalChroma_funcPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1](
+				IntraVerticalChroma_funcPtrArray[!!(ASM_TYPES & PREAVX2_MASK)](
 					chromaPuSize,
 					intraRefPtr->crIntraReferenceArray,
 					&(candidateBufferPtr->predictionPtr->bufferCr[puChromaOriginIndex]),
@@ -5574,7 +5574,7 @@ EB_ERRORTYPE IntraPredictionOl(
 
 			// Cb Intra Prediction
 			if (componentMask & PICTURE_BUFFER_DESC_Cb_FLAG) {
-				IntraHorzChroma_funcPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1](
+				IntraHorzChroma_funcPtrArray[!!(ASM_TYPES & PREAVX2_MASK)](
 					chromaPuSize,
 					intraRefPtr->cbIntraReferenceArrayReverse,
 					&(candidateBufferPtr->predictionPtr->bufferCb[puChromaOriginIndex]),
@@ -5584,7 +5584,7 @@ EB_ERRORTYPE IntraPredictionOl(
 
 			// Cr Intra Prediction
 			if (componentMask & PICTURE_BUFFER_DESC_Cr_FLAG) {
-				IntraHorzChroma_funcPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1](
+				IntraHorzChroma_funcPtrArray[!!(ASM_TYPES & PREAVX2_MASK)](
 					chromaPuSize,
 					intraRefPtr->crIntraReferenceArrayReverse,
 					&(candidateBufferPtr->predictionPtr->bufferCr[puChromaOriginIndex]),
@@ -5598,7 +5598,7 @@ EB_ERRORTYPE IntraPredictionOl(
 
 			// Cb Intra Prediction
 			if (componentMask & PICTURE_BUFFER_DESC_Cb_FLAG) {
-				IntraDCChroma_funcPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1](
+				IntraDCChroma_funcPtrArray[!!(ASM_TYPES & PREAVX2_MASK)](
 					chromaPuSize,
 					intraRefPtr->cbIntraReferenceArrayReverse,
 					&(candidateBufferPtr->predictionPtr->bufferCb[puChromaOriginIndex]),
@@ -5608,7 +5608,7 @@ EB_ERRORTYPE IntraPredictionOl(
 
 			// Cr Intra Prediction
 			if (componentMask & PICTURE_BUFFER_DESC_Cr_FLAG) {
-				IntraDCChroma_funcPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1](
+				IntraDCChroma_funcPtrArray[!!(ASM_TYPES & PREAVX2_MASK)](
 					chromaPuSize,
 					intraRefPtr->crIntraReferenceArrayReverse,
 					&(candidateBufferPtr->predictionPtr->bufferCr[puChromaOriginIndex]),
@@ -5744,7 +5744,7 @@ EB_ERRORTYPE IntraPredOnSrc(
 
         case 3:
 
-			IntraHorzLuma_funcPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1](
+			IntraHorzLuma_funcPtrArray[!!(ASM_TYPES & PREAVX2_MASK)](
                 puSize,
                 intraRefPtr->yIntraReferenceArrayReverse,
                 &(predictionPtr->bufferY[puOriginIndex]),

--- a/Source/Lib/Codec/EbIntraPrediction.c
+++ b/Source/Lib/Codec/EbIntraPrediction.c
@@ -3150,7 +3150,7 @@ static void IntraModeAngular_27To33(
     EB_S32           intraPredAngle = intraModeAngularTable[mode - INTRA_VERTICAL_MODE];
     refSampMain    = refSamples + (size << 1);
 
-	IntraAngVertical_funcPtrArray[(ASM_TYPES & AVX2_MASK) && 1](
+	IntraAngVertical_funcPtrArray[!!(ASM_TYPES & AVX2_MASK)](
         size, 
         refSampMain,
         predictionPtr,              
@@ -3233,7 +3233,7 @@ static void IntraModeAngular_19To25(
     }
 
    
-	IntraAngVertical_funcPtrArray[(ASM_TYPES & AVX2_MASK) && 1](
+	IntraAngVertical_funcPtrArray[!!(ASM_TYPES & AVX2_MASK)](
         size, 
         refSampMain,
         predictionPtr,              
@@ -3351,7 +3351,7 @@ static void IntraModeAngular_11To17(
     } 
 
   
-	IntraAngHorizontal_funcPtrArray[(ASM_TYPES & AVX2_MASK) && 1](
+	IntraAngHorizontal_funcPtrArray[!!(ASM_TYPES & AVX2_MASK)](
         size, 
         refSampMain,
         predictionPtr,              
@@ -3433,7 +3433,7 @@ static void IntraModeAngular_3To9(
     
     refSampMain = refSamples-1;
       
-	IntraAngHorizontal_funcPtrArray[(ASM_TYPES & AVX2_MASK) && 1](
+	IntraAngHorizontal_funcPtrArray[!!(ASM_TYPES & AVX2_MASK)](
         size, 
         refSampMain,
         predictionPtr,              
@@ -3492,7 +3492,7 @@ static inline void IntraModeAngular_all(
     switch(mode){
         case 34:
 
-            IntraAng34_funcPtrArray[(ASM_TYPES & AVX2_MASK) && 1](
+            IntraAng34_funcPtrArray[!!(ASM_TYPES & AVX2_MASK)](
                 puSize,
                 refSamples,
                 predictionPtr,
@@ -3519,7 +3519,7 @@ static inline void IntraModeAngular_all(
                 AboveReadyFlag);
             break;
         case 18:
-            IntraAng18_funcPtrArray[(ASM_TYPES & AVX2_MASK) && 1](
+            IntraAng18_funcPtrArray[!!(ASM_TYPES & AVX2_MASK)](
                 puSize,
                 refSamples,
                 predictionPtr,
@@ -3546,7 +3546,7 @@ static inline void IntraModeAngular_all(
             break;
         case 2:
             
-            IntraAng2_funcPtrArray[(ASM_TYPES & AVX2_MASK) && 1](
+            IntraAng2_funcPtrArray[!!(ASM_TYPES & AVX2_MASK)](
                 puSize,
                 refSamplesReverse,
                 predictionPtr,
@@ -3714,7 +3714,7 @@ EB_ERRORTYPE IntraPredictionCl(
            yIntraReferenceArray =  (diffMode > intraLumaFilterTable[Log2f(puWidth)-2])? contextPtr->yIntraFilteredReferenceArrayReverse :
                                     contextPtr->yIntraReferenceArrayReverse;
 
-		   IntraPlanar_funcPtrArray[(ASM_TYPES & AVX2_MASK) && 1](
+		   IntraPlanar_funcPtrArray[!!(ASM_TYPES & AVX2_MASK)](
                 puSize,
                 yIntraReferenceArray,
                 &(candidateBufferPtr->predictionPtr->bufferY[puOriginIndex]),
@@ -3727,7 +3727,7 @@ EB_ERRORTYPE IntraPredictionCl(
 
             yIntraReferenceArray = contextPtr->yIntraReferenceArrayReverse;
       
-            IntraDCLuma_funcPtrArray[(ASM_TYPES & AVX2_MASK) && 1](
+            IntraDCLuma_funcPtrArray[!!(ASM_TYPES & AVX2_MASK)](
                 puSize,
                 yIntraReferenceArray,
                 &(candidateBufferPtr->predictionPtr->bufferY[puOriginIndex]),
@@ -3742,7 +3742,7 @@ EB_ERRORTYPE IntraPredictionCl(
                                     contextPtr->yIntraReferenceArrayReverse;
               
        
-            IntraVerticalLuma_funcPtrArray[(ASM_TYPES & AVX2_MASK) && 1](
+            IntraVerticalLuma_funcPtrArray[!!(ASM_TYPES & AVX2_MASK)](
                 puSize,
                 yIntraReferenceArray,
                 &(candidateBufferPtr->predictionPtr->bufferY[puOriginIndex]),
@@ -3818,7 +3818,7 @@ EB_ERRORTYPE IntraPredictionCl(
                 
              // Cb Intra Prediction
             if (componentMask & PICTURE_BUFFER_DESC_Cb_FLAG) {
-				IntraPlanar_funcPtrArray[(ASM_TYPES & AVX2_MASK) && 1](
+				IntraPlanar_funcPtrArray[!!(ASM_TYPES & AVX2_MASK)](
                     chromaPuSize,
                     contextPtr->cbIntraReferenceArrayReverse,
                     &(candidateBufferPtr->predictionPtr->bufferCb[puChromaOriginIndex]),
@@ -3828,7 +3828,7 @@ EB_ERRORTYPE IntraPredictionCl(
       
             // Cr Intra Prediction
             if (componentMask & PICTURE_BUFFER_DESC_Cr_FLAG) {
-				IntraPlanar_funcPtrArray[(ASM_TYPES & AVX2_MASK) && 1](
+				IntraPlanar_funcPtrArray[!!(ASM_TYPES & AVX2_MASK)](
                     chromaPuSize,
                     contextPtr->crIntraReferenceArrayReverse,
                     &(candidateBufferPtr->predictionPtr->bufferCr[puChromaOriginIndex]),
@@ -4019,7 +4019,7 @@ EB_ERRORTYPE Intra4x4IntraPredictionCl(
            yIntraReferenceArray =  (diffMode > intraLumaFilterTable[Log2f(puWidth)-2])? contextPtr->yIntraFilteredReferenceArrayReverse :
                                     contextPtr->yIntraReferenceArrayReverse;
 
-		   IntraPlanar_funcPtrArray[(ASM_TYPES & AVX2_MASK) && 1](
+		   IntraPlanar_funcPtrArray[!!(ASM_TYPES & AVX2_MASK)](
                 puSize,
                 yIntraReferenceArray,
                 &(candidateBufferPtr->predictionPtr->bufferY[puOriginIndex]),
@@ -4032,7 +4032,7 @@ EB_ERRORTYPE Intra4x4IntraPredictionCl(
 
             yIntraReferenceArray = contextPtr->yIntraReferenceArrayReverse;
       
-			IntraDCLuma_funcPtrArray[(ASM_TYPES & AVX2_MASK) && 1](
+			IntraDCLuma_funcPtrArray[!!(ASM_TYPES & AVX2_MASK)](
                 puSize,
                 yIntraReferenceArray,
                 &(candidateBufferPtr->predictionPtr->bufferY[puOriginIndex]),
@@ -4047,7 +4047,7 @@ EB_ERRORTYPE Intra4x4IntraPredictionCl(
                                     contextPtr->yIntraReferenceArrayReverse;
               
        
-			IntraVerticalLuma_funcPtrArray[(ASM_TYPES & AVX2_MASK) && 1](
+			IntraVerticalLuma_funcPtrArray[!!(ASM_TYPES & AVX2_MASK)](
                 puSize,
                 yIntraReferenceArray,
                 &(candidateBufferPtr->predictionPtr->bufferY[puOriginIndex]),
@@ -4114,7 +4114,7 @@ EB_ERRORTYPE Intra4x4IntraPredictionCl(
                 
              // Cb Intra Prediction
             if (componentMask & PICTURE_BUFFER_DESC_Cb_FLAG) {
-				IntraPlanar_funcPtrArray[(ASM_TYPES & AVX2_MASK) && 1](
+				IntraPlanar_funcPtrArray[!!(ASM_TYPES & AVX2_MASK)](
                     chromaPuSize,
                     contextPtr->cbIntraReferenceArrayReverse,
                     &(candidateBufferPtr->predictionPtr->bufferCb[puChromaOriginIndex]),
@@ -4124,7 +4124,7 @@ EB_ERRORTYPE Intra4x4IntraPredictionCl(
       
             // Cr Intra Prediction
             if (componentMask & PICTURE_BUFFER_DESC_Cr_FLAG) {
-				IntraPlanar_funcPtrArray[(ASM_TYPES & AVX2_MASK) && 1](
+				IntraPlanar_funcPtrArray[!!(ASM_TYPES & AVX2_MASK)](
                     chromaPuSize,
                     contextPtr->crIntraReferenceArrayReverse,
                     &(candidateBufferPtr->predictionPtr->bufferCr[puChromaOriginIndex]),
@@ -4283,7 +4283,7 @@ EB_ERRORTYPE Intra4x4IntraPredictionOl(
 
     case 0:
         
-		IntraPlanar_funcPtrArray[(ASM_TYPES & AVX2_MASK) && 1](
+		IntraPlanar_funcPtrArray[!!(ASM_TYPES & AVX2_MASK)](
             puSize,
             intraRefPtr->yIntraReferenceArrayReverse,
             &(candidateBufferPtr->predictionPtr->bufferY[puOriginIndex]),
@@ -4294,7 +4294,7 @@ EB_ERRORTYPE Intra4x4IntraPredictionOl(
 
     case 1:
         
-		IntraDCLuma_funcPtrArray[(ASM_TYPES & AVX2_MASK) && 1](
+		IntraDCLuma_funcPtrArray[!!(ASM_TYPES & AVX2_MASK)](
             puSize,
             intraRefPtr->yIntraReferenceArrayReverse,
             &(candidateBufferPtr->predictionPtr->bufferY[puOriginIndex]),
@@ -4305,7 +4305,7 @@ EB_ERRORTYPE Intra4x4IntraPredictionOl(
 
     case 2:
         
-		IntraVerticalLuma_funcPtrArray[(ASM_TYPES & AVX2_MASK) && 1](
+		IntraVerticalLuma_funcPtrArray[!!(ASM_TYPES & AVX2_MASK)](
             puSize,
             intraRefPtr->yIntraReferenceArrayReverse,
             &(candidateBufferPtr->predictionPtr->bufferY[puOriginIndex]),
@@ -4407,7 +4407,7 @@ EB_ERRORTYPE EncodePassIntraPrediction(
         switch(lumaMode) {
 
         case EB_INTRA_PLANAR:
-		IntraPlanar_funcPtrArray[(ASM_TYPES & AVX2_MASK) && 1](
+		IntraPlanar_funcPtrArray[!!(ASM_TYPES & AVX2_MASK)](
                 puSize,
                 yIntraReferenceArrayReverse,
                 predictionPtr->bufferY + lumaOffset,
@@ -4417,7 +4417,7 @@ EB_ERRORTYPE EncodePassIntraPrediction(
             break;
 
         case EB_INTRA_DC:
-			IntraDCLuma_funcPtrArray[(ASM_TYPES & AVX2_MASK) && 1](
+			IntraDCLuma_funcPtrArray[!!(ASM_TYPES & AVX2_MASK)](
                 puSize,
                 yIntraReferenceArrayReverse,
                 predictionPtr->bufferY + lumaOffset,
@@ -4427,7 +4427,7 @@ EB_ERRORTYPE EncodePassIntraPrediction(
             break;
 
         case EB_INTRA_VERTICAL:
-			IntraVerticalLuma_funcPtrArray[(ASM_TYPES & AVX2_MASK) && 1](
+			IntraVerticalLuma_funcPtrArray[!!(ASM_TYPES & AVX2_MASK)](
                 puSize,
                 yIntraReferenceArrayReverse,
                 predictionPtr->bufferY + lumaOffset,
@@ -4510,7 +4510,7 @@ EB_ERRORTYPE EncodePassIntraPrediction(
         switch(chromaModeAdj) {
         case EB_INTRA_PLANAR:
              // Cb Intra Prediction
-			IntraPlanar_funcPtrArray[(ASM_TYPES & AVX2_MASK) && 1](
+			IntraPlanar_funcPtrArray[!!(ASM_TYPES & AVX2_MASK)](
                 puChromaSize,
                 cbIntraReferenceArrayReverse,
                 predictionPtr->bufferCb + chromaOffset,
@@ -4518,7 +4518,7 @@ EB_ERRORTYPE EncodePassIntraPrediction(
                 EB_FALSE);
 
             // Cr Intra Prediction
-			IntraPlanar_funcPtrArray[(ASM_TYPES & AVX2_MASK) && 1](
+			IntraPlanar_funcPtrArray[!!(ASM_TYPES & AVX2_MASK)](
                 puChromaSize,
                 crIntraReferenceArrayReverse,
                 predictionPtr->bufferCr + chromaOffset,
@@ -5315,7 +5315,7 @@ EB_ERRORTYPE IntraPredictionOpenLoop(
 
     case 0:
         
-		IntraPlanar_funcPtrArray[(ASM_TYPES & AVX2_MASK) && 1](
+		IntraPlanar_funcPtrArray[!!(ASM_TYPES & AVX2_MASK)](
             cuSize,
             contextPtr->intraRefPtr->yIntraReferenceArrayReverse,
             (&(contextPtr->meContextPtr->lcuBuffer[0])),
@@ -5326,7 +5326,7 @@ EB_ERRORTYPE IntraPredictionOpenLoop(
 
     case 1:
         
-		IntraDCLuma_funcPtrArray[(ASM_TYPES & AVX2_MASK) && 1](
+		IntraDCLuma_funcPtrArray[!!(ASM_TYPES & AVX2_MASK)](
             cuSize,
             contextPtr->intraRefPtr->yIntraReferenceArrayReverse,
             (&(contextPtr->meContextPtr->lcuBuffer[0])),
@@ -5337,7 +5337,7 @@ EB_ERRORTYPE IntraPredictionOpenLoop(
 
     case 2:
         
-		IntraVerticalLuma_funcPtrArray[(ASM_TYPES & AVX2_MASK) && 1](
+		IntraVerticalLuma_funcPtrArray[!!(ASM_TYPES & AVX2_MASK)](
             cuSize,
             contextPtr->intraRefPtr->yIntraReferenceArrayReverse,
             (&(contextPtr->meContextPtr->lcuBuffer[0])),
@@ -5433,7 +5433,7 @@ EB_ERRORTYPE IntraPredictionOl(
 
 		case 0:
 
-			IntraPlanar_funcPtrArray[(ASM_TYPES & AVX2_MASK) && 1](
+			IntraPlanar_funcPtrArray[!!(ASM_TYPES & AVX2_MASK)](
 				puSize,
 				intraRefPtr->yIntraReferenceArrayReverse,
 				&(candidateBufferPtr->predictionPtr->bufferY[puOriginIndex]),
@@ -5444,7 +5444,7 @@ EB_ERRORTYPE IntraPredictionOl(
 
 		case 1:
 
-			IntraDCLuma_funcPtrArray[(ASM_TYPES & AVX2_MASK) && 1](
+			IntraDCLuma_funcPtrArray[!!(ASM_TYPES & AVX2_MASK)](
 				puSize,
 				intraRefPtr->yIntraReferenceArrayReverse,
 				&(candidateBufferPtr->predictionPtr->bufferY[puOriginIndex]),
@@ -5455,7 +5455,7 @@ EB_ERRORTYPE IntraPredictionOl(
 
 		case 2:
 
-			IntraVerticalLuma_funcPtrArray[(ASM_TYPES & AVX2_MASK) && 1](
+			IntraVerticalLuma_funcPtrArray[!!(ASM_TYPES & AVX2_MASK)](
 				puSize,
 				intraRefPtr->yIntraReferenceArrayReverse,
 				&(candidateBufferPtr->predictionPtr->bufferY[puOriginIndex]),
@@ -5526,7 +5526,7 @@ EB_ERRORTYPE IntraPredictionOl(
 
 			// Cb Intra Prediction
 			if (componentMask & PICTURE_BUFFER_DESC_Cb_FLAG) {
-				IntraPlanar_funcPtrArray[(ASM_TYPES & AVX2_MASK) && 1](
+				IntraPlanar_funcPtrArray[!!(ASM_TYPES & AVX2_MASK)](
 					chromaPuSize,
 					intraRefPtr->cbIntraReferenceArrayReverse,
 					&(candidateBufferPtr->predictionPtr->bufferCb[puChromaOriginIndex]),
@@ -5536,7 +5536,7 @@ EB_ERRORTYPE IntraPredictionOl(
 
 			// Cr Intra Prediction
 			if (componentMask & PICTURE_BUFFER_DESC_Cr_FLAG) {
-				IntraPlanar_funcPtrArray[(ASM_TYPES & AVX2_MASK) && 1](
+				IntraPlanar_funcPtrArray[!!(ASM_TYPES & AVX2_MASK)](
 					chromaPuSize,
 					intraRefPtr->crIntraReferenceArrayReverse,
 					&(candidateBufferPtr->predictionPtr->bufferCr[puChromaOriginIndex]),
@@ -5711,7 +5711,7 @@ EB_ERRORTYPE IntraPredOnSrc(
 
         case 0:
 
-			IntraPlanar_funcPtrArray[(ASM_TYPES & AVX2_MASK) && 1](
+			IntraPlanar_funcPtrArray[!!(ASM_TYPES & AVX2_MASK)](
                 puSize,
                 intraRefPtr->yIntraReferenceArrayReverse,
                 &(predictionPtr->bufferY[puOriginIndex]),
@@ -5722,7 +5722,7 @@ EB_ERRORTYPE IntraPredOnSrc(
 
         case 1:
 
-			IntraDCLuma_funcPtrArray[(ASM_TYPES & AVX2_MASK) && 1](
+			IntraDCLuma_funcPtrArray[!!(ASM_TYPES & AVX2_MASK)](
                 puSize,
                 intraRefPtr->yIntraReferenceArrayReverse,
                 &(predictionPtr->bufferY[puOriginIndex]),
@@ -5733,7 +5733,7 @@ EB_ERRORTYPE IntraPredOnSrc(
 
         case 2:
 
-			IntraVerticalLuma_funcPtrArray[(ASM_TYPES & AVX2_MASK) && 1](
+			IntraVerticalLuma_funcPtrArray[!!(ASM_TYPES & AVX2_MASK)](
                 puSize,
                 intraRefPtr->yIntraReferenceArrayReverse,
                 &(predictionPtr->bufferY[puOriginIndex]),

--- a/Source/Lib/Codec/EbMcp.c
+++ b/Source/Lib/Codec/EbMcp.c
@@ -128,7 +128,7 @@ void UniPredHevcInterpolationMd(
 		fracPosx = posX & 0x03;
 		fracPosy = posY & 0x03;
 
-		uniPredLumaIFFunctionPtrArrayNew[(ASM_TYPES & PREAVX2_MASK) && 1][fracPosx + (fracPosy << 2)](
+		uniPredLumaIFFunctionPtrArrayNew[!!(ASM_TYPES & PREAVX2_MASK)][fracPosx + (fracPosy << 2)](
 			is16bit ? refPic->bufferY + 4 + 4 * refPic->strideY : refPic->bufferY + integPosx + integPosy*refPic->strideY,
 			refPic->strideY,
 			dst->bufferY + dstLumaIndex,
@@ -147,7 +147,7 @@ void UniPredHevcInterpolationMd(
 		fracPosy = posY & 0x07;
 
 
-		uniPredChromaIFFunctionPtrArrayNew[(ASM_TYPES & PREAVX2_MASK) && 1][fracPosx + (fracPosy << 3)](
+		uniPredChromaIFFunctionPtrArrayNew[!!(ASM_TYPES & PREAVX2_MASK)][fracPosx + (fracPosy << 3)](
 			is16bit ? refPic->bufferCb + 2 + 2 * refPic->strideCb : refPic->bufferCb + integPosx + integPosy * refPic->strideCb,
 			refPic->strideCb,
 			dst->bufferCb + dstChromaIndex,
@@ -159,7 +159,7 @@ void UniPredHevcInterpolationMd(
 			fracPosy);
 
 		//doing the chroma Cr interpolation
-		uniPredChromaIFFunctionPtrArrayNew[(ASM_TYPES & PREAVX2_MASK) && 1][fracPosx + (fracPosy << 3)](
+		uniPredChromaIFFunctionPtrArrayNew[!!(ASM_TYPES & PREAVX2_MASK)][fracPosx + (fracPosy << 3)](
 			is16bit ? refPic->bufferCr + 2 + 2 * refPic->strideCr : refPic->bufferCr + integPosx + integPosy * refPic->strideCr,
 			refPic->strideCr,
 			dst->bufferCr + dstChromaIndex,
@@ -205,7 +205,7 @@ void EncodeUniPredInterpolation(
     fracPosx  = posX & 0x03;
     fracPosy  = posY & 0x03;
 
-	uniPredLumaIFFunctionPtrArrayNew[(ASM_TYPES & PREAVX2_MASK) && 1][fracPosx + (fracPosy << 2)](
+	uniPredLumaIFFunctionPtrArrayNew[!!(ASM_TYPES & PREAVX2_MASK)][fracPosx + (fracPosy << 2)](
 		refPic->bufferY + integPosx + integPosy*refPic->strideY,
 		refPic->strideY,
 		dst->bufferY + dstLumaIndex,
@@ -222,7 +222,7 @@ void EncodeUniPredInterpolation(
     fracPosy  = (posY & (0x07 >> (1-subHeightCMinus1))) << (1-subHeightCMinus1);
 
         
-	uniPredChromaIFFunctionPtrArrayNew[(ASM_TYPES & PREAVX2_MASK) && 1][fracPosx + (fracPosy << 3)](
+	uniPredChromaIFFunctionPtrArrayNew[!!(ASM_TYPES & PREAVX2_MASK)][fracPosx + (fracPosy << 3)](
 		refPic->bufferCb + integPosx + integPosy*refPic->strideCb,
 		refPic->strideCb,
 		dst->bufferCb + dstChromaIndex,
@@ -234,7 +234,7 @@ void EncodeUniPredInterpolation(
 		fracPosy);
 
 	//doing the chroma Cr interpolation
-	uniPredChromaIFFunctionPtrArrayNew[(ASM_TYPES & PREAVX2_MASK) && 1][fracPosx + (fracPosy << 3)](
+	uniPredChromaIFFunctionPtrArrayNew[!!(ASM_TYPES & PREAVX2_MASK)][fracPosx + (fracPosy << 3)](
 		refPic->bufferCr + integPosx + integPosy*refPic->strideCr,
 		refPic->strideCr,
 		dst->bufferCr + dstChromaIndex,
@@ -278,7 +278,7 @@ void UniPredInterpolation16bit(
     fracPosx = posX & 0x03;
     fracPosy = posY & 0x03;
 
-	uniPredLuma16bitIFFunctionPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1][fracPosx + (fracPosy << 2)](
+	uniPredLuma16bitIFFunctionPtrArray[!!(ASM_TYPES & PREAVX2_MASK)][fracPosx + (fracPosy << 2)](
 		(EB_U16 *)fullPelBlock->bufferY + 4 + 4 * fullPelBlock->strideY,
 		fullPelBlock->strideY,
 		(EB_U16*)(dst->bufferY) + dstLumaIndex,
@@ -393,7 +393,7 @@ void BiPredHevcInterpolationMd(
 			// Note: SSSE3 Interpolation can only be enabled if 
 			//       SSSE3 clipping functions are enabled
 			//doing the luma interpolation
-			biPredLumaIFFunctionPtrArrayNew[(ASM_TYPES & PREAVX2_MASK) && 1][fracPosx + (fracPosy << 2)](
+			biPredLumaIFFunctionPtrArrayNew[!!(ASM_TYPES & PREAVX2_MASK)][fracPosx + (fracPosy << 2)](
 				is16Bit ? refPicList0->bufferY + 4 + 4 * refPicList0->strideY : refPicList0->bufferY + integPosx + integPosy*refPicList0->strideY,
 				refPicList0->strideY,
 				refList0TempDst,
@@ -409,7 +409,7 @@ void BiPredHevcInterpolationMd(
 			fracPosy = refList1PosY & 0x03;
 
 			//doing the luma interpolation
-			biPredLumaIFFunctionPtrArrayNew[(ASM_TYPES & PREAVX2_MASK) && 1][fracPosx + (fracPosy << 2)](
+			biPredLumaIFFunctionPtrArrayNew[!!(ASM_TYPES & PREAVX2_MASK)][fracPosx + (fracPosy << 2)](
 				is16Bit ? refPicList1->bufferY + 4 + 4 * refPicList1->strideY : refPicList1->bufferY + integPosx + integPosy*refPicList1->strideY,
 				refPicList1->strideY,
 				refList1TempDst,
@@ -418,7 +418,7 @@ void BiPredHevcInterpolationMd(
 				fistPassIFTempDst);
 
 			// bi-pred luma clipping
-			biPredClippingFuncPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1](
+			biPredClippingFuncPtrArray[!!(ASM_TYPES & PREAVX2_MASK)](
 				puWidth,
 				puHeight,
 				refList0TempDst,
@@ -482,7 +482,7 @@ void BiPredHevcInterpolationMd(
 			fracPosy = refList0PosY & 0x07;
 
 			//doing the chroma Cb interpolation
-			biPredChromaIFFunctionPtrArrayNew[(ASM_TYPES & PREAVX2_MASK) && 1][fracPosx + (fracPosy << 3)](
+			biPredChromaIFFunctionPtrArrayNew[!!(ASM_TYPES & PREAVX2_MASK)][fracPosx + (fracPosy << 3)](
 				is16Bit ? refPicList0->bufferCb + 2 + 2 * refPicList0->strideCb : refPicList0->bufferCb + integPosx + integPosy*refPicList0->strideCb,
 				refPicList0->strideCb,
 				refList0TempDst + lumaTempBufSize,
@@ -493,7 +493,7 @@ void BiPredHevcInterpolationMd(
 				fracPosy);
 
 			//doing the chroma Cr interpolation
-			biPredChromaIFFunctionPtrArrayNew[(ASM_TYPES & PREAVX2_MASK) && 1][fracPosx + (fracPosy << 3)](
+			biPredChromaIFFunctionPtrArrayNew[!!(ASM_TYPES & PREAVX2_MASK)][fracPosx + (fracPosy << 3)](
 				is16Bit ? refPicList0->bufferCr + 2 + 2 * refPicList0->strideCr : refPicList0->bufferCr + integPosx + integPosy*refPicList0->strideCr,
 				refPicList0->strideCr,
 				refList0TempDst + lumaTempBufSize + chromaTempBufSize,
@@ -512,7 +512,7 @@ void BiPredHevcInterpolationMd(
 			fracPosy = refList1PosY & 0x07;
 
 			//doing the chroma Cb interpolation
-			biPredChromaIFFunctionPtrArrayNew[(ASM_TYPES & PREAVX2_MASK) && 1][fracPosx + (fracPosy << 3)](
+			biPredChromaIFFunctionPtrArrayNew[!!(ASM_TYPES & PREAVX2_MASK)][fracPosx + (fracPosy << 3)](
 				is16Bit ? refPicList1->bufferCb + 2 + 2 * refPicList1->strideCb : refPicList1->bufferCb + integPosx + integPosy*refPicList1->strideCb,
 				refPicList1->strideCb,
 				refList1TempDst + lumaTempBufSize,
@@ -523,7 +523,7 @@ void BiPredHevcInterpolationMd(
 				fracPosy);
 
 			//doing the chroma Cr interpolation
-			biPredChromaIFFunctionPtrArrayNew[(ASM_TYPES & PREAVX2_MASK) && 1][fracPosx + (fracPosy << 3)](
+			biPredChromaIFFunctionPtrArrayNew[!!(ASM_TYPES & PREAVX2_MASK)][fracPosx + (fracPosy << 3)](
 				is16Bit ? refPicList1->bufferCr + 2 + 2 * refPicList1->strideCr : refPicList1->bufferCr + integPosx + integPosy*refPicList1->strideCr,
 				refPicList1->strideCr,
 				refList1TempDst + lumaTempBufSize + chromaTempBufSize,
@@ -534,7 +534,7 @@ void BiPredHevcInterpolationMd(
 				fracPosy);
 
 			// bi-pred chroma clipping
-			biPredClippingFuncPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1](
+			biPredClippingFuncPtrArray[!!(ASM_TYPES & PREAVX2_MASK)](
 				chromaPuWidth,
 				chromaPuHeight,
 				refList0TempDst + lumaTempBufSize,
@@ -542,7 +542,7 @@ void BiPredHevcInterpolationMd(
 				biDst->bufferCb + dstChromaIndex,
 				biDst->strideCb,
 				ChromaOffset5);
-			biPredClippingFuncPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1](
+			biPredClippingFuncPtrArray[!!(ASM_TYPES & PREAVX2_MASK)](
 				chromaPuWidth,
 				chromaPuHeight,
 				refList0TempDst + lumaTempBufSize + chromaTempBufSize,
@@ -634,7 +634,7 @@ void EncodeBiPredInterpolation(
 		// Note: SSSE3 Interpolation can only be enabled if 
 		//       SSSE3 clipping functions are enabled
 		//doing the luma interpolation
-		biPredLumaIFFunctionPtrArrayNew[(ASM_TYPES & PREAVX2_MASK) && 1][fracPosx + (fracPosy << 2)](
+		biPredLumaIFFunctionPtrArrayNew[!!(ASM_TYPES & PREAVX2_MASK)][fracPosx + (fracPosy << 2)](
 			refPicList0->bufferY + integPosx + integPosy*refPicList0->strideY,
 			refPicList0->strideY,
 			refList0TempDst,
@@ -650,7 +650,7 @@ void EncodeBiPredInterpolation(
 		fracPosy = refList1PosY & 0x03;
 
 		//doing the luma interpolation
-		biPredLumaIFFunctionPtrArrayNew[(ASM_TYPES & PREAVX2_MASK) && 1][fracPosx + (fracPosy << 2)](
+		biPredLumaIFFunctionPtrArrayNew[!!(ASM_TYPES & PREAVX2_MASK)][fracPosx + (fracPosy << 2)](
 			refPicList1->bufferY + integPosx + integPosy*refPicList1->strideY,
 			refPicList1->strideY,
 			refList1TempDst,
@@ -659,7 +659,7 @@ void EncodeBiPredInterpolation(
 			fistPassIFTempDst);
 
 		// bi-pred luma clipping
-		biPredClippingFuncPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1](
+		biPredClippingFuncPtrArray[!!(ASM_TYPES & PREAVX2_MASK)](
 			puWidth,
 			puHeight,
 			refList0TempDst,
@@ -722,7 +722,7 @@ void EncodeBiPredInterpolation(
 		fracPosy = (refList0PosY & (0x07 >> (1-subHeightCMinus1))) << (1-subHeightCMinus1);
 
 		//doing the chroma Cb interpolation
-		biPredChromaIFFunctionPtrArrayNew[(ASM_TYPES & PREAVX2_MASK) && 1][fracPosx + (fracPosy << 3)](
+		biPredChromaIFFunctionPtrArrayNew[!!(ASM_TYPES & PREAVX2_MASK)][fracPosx + (fracPosy << 3)](
 			refPicList0->bufferCb + integPosx + integPosy*refPicList0->strideCb,
 			refPicList0->strideCb,
 			refList0TempDst + lumaTempBufSize,
@@ -733,7 +733,7 @@ void EncodeBiPredInterpolation(
 			fracPosy);
 
 		//doing the chroma Cr interpolation
-		biPredChromaIFFunctionPtrArrayNew[(ASM_TYPES & PREAVX2_MASK) && 1][fracPosx + (fracPosy << 3)](
+		biPredChromaIFFunctionPtrArrayNew[!!(ASM_TYPES & PREAVX2_MASK)][fracPosx + (fracPosy << 3)](
 			refPicList0->bufferCr + integPosx + integPosy*refPicList0->strideCr,
 			refPicList0->strideCr,
 			refList0TempDst + lumaTempBufSize + chromaTempBufSize,
@@ -757,7 +757,7 @@ void EncodeBiPredInterpolation(
 		fracPosy = (refList1PosY & (0x07 >> (1-subHeightCMinus1))) << (1-subHeightCMinus1);
 
 		//doing the chroma Cb interpolation
-		biPredChromaIFFunctionPtrArrayNew[(ASM_TYPES & PREAVX2_MASK) && 1][fracPosx + (fracPosy << 3)](
+		biPredChromaIFFunctionPtrArrayNew[!!(ASM_TYPES & PREAVX2_MASK)][fracPosx + (fracPosy << 3)](
 			refPicList1->bufferCb + integPosx + integPosy*refPicList1->strideCb,
 			refPicList1->strideCb,
 			refList1TempDst + lumaTempBufSize,
@@ -768,7 +768,7 @@ void EncodeBiPredInterpolation(
 			fracPosy);
 
 		//doing the chroma Cr interpolation
-		biPredChromaIFFunctionPtrArrayNew[(ASM_TYPES & PREAVX2_MASK) && 1][fracPosx + (fracPosy << 3)](
+		biPredChromaIFFunctionPtrArrayNew[!!(ASM_TYPES & PREAVX2_MASK)][fracPosx + (fracPosy << 3)](
 			refPicList1->bufferCr + integPosx + integPosy*refPicList1->strideCr,
 			refPicList1->strideCr,
 			refList1TempDst + lumaTempBufSize + chromaTempBufSize,
@@ -779,7 +779,7 @@ void EncodeBiPredInterpolation(
 			fracPosy);
 
 		// bi-pred chroma clipping
-		biPredClippingFuncPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1](
+		biPredClippingFuncPtrArray[!!(ASM_TYPES & PREAVX2_MASK)](
 			chromaPuWidth,
 			chromaPuHeight,
 			refList0TempDst + lumaTempBufSize,
@@ -787,7 +787,7 @@ void EncodeBiPredInterpolation(
 			biDst->bufferCb + dstChromaIndex,
 			biDst->strideCb,
 			ChromaOffset5);
-		biPredClippingFuncPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1](
+		biPredClippingFuncPtrArray[!!(ASM_TYPES & PREAVX2_MASK)](
 			chromaPuWidth,
 			chromaPuHeight,
 			refList0TempDst + lumaTempBufSize + chromaTempBufSize,
@@ -865,7 +865,7 @@ void BiPredInterpolation16bit(
 		fracPosx = refList0PosX & 0x03;
 		fracPosy = refList0PosY & 0x03;
 
-		biPredLumaIFFunctionPtrArrayNew16bit[(ASM_TYPES & PREAVX2_MASK) && 1][fracPosx + (fracPosy << 2)](
+		biPredLumaIFFunctionPtrArrayNew16bit[!!(ASM_TYPES & PREAVX2_MASK)][fracPosx + (fracPosy << 2)](
 			(EB_U16 *)fullPelBlockL0->bufferY + 4 + 4 * fullPelBlockL0->strideY,
 			fullPelBlockL0->strideY,
 			refList0TempDst,
@@ -879,7 +879,7 @@ void BiPredInterpolation16bit(
 		fracPosx = refList1PosX & 0x03;
 		fracPosy = refList1PosY & 0x03;
 
-		biPredLumaIFFunctionPtrArrayNew16bit[(ASM_TYPES & PREAVX2_MASK) && 1][fracPosx + (fracPosy << 2)](
+		biPredLumaIFFunctionPtrArrayNew16bit[!!(ASM_TYPES & PREAVX2_MASK)][fracPosx + (fracPosy << 2)](
 			(EB_U16 *)fullPelBlockL1->bufferY + 4 + 4 * fullPelBlockL1->strideY,
 			fullPelBlockL1->strideY,
 			refList1TempDst,
@@ -887,7 +887,7 @@ void BiPredInterpolation16bit(
 			puHeight,
 			fistPassIFTempDst);
 
-		biPredClipping16bitFuncPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1](
+		biPredClipping16bitFuncPtrArray[!!(ASM_TYPES & PREAVX2_MASK)](
 			puWidth,
 			puHeight,
 			refList0TempDst,
@@ -991,7 +991,7 @@ void BiPredInterpolation16bit(
 		//***********************
 		//      L0+L1
 		//***********************    
-		biPredClipping16bitFuncPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1](
+		biPredClipping16bitFuncPtrArray[!!(ASM_TYPES & PREAVX2_MASK)](
 			chromaPuWidth,
 			chromaPuHeight,
 			refList0TempDst + lumaTempBufSize,
@@ -999,7 +999,7 @@ void BiPredInterpolation16bit(
 			(EB_U16*)biDst->bufferCb + dstChromaIndex,
 			biDst->strideCb);
 
-		biPredClipping16bitFuncPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1](
+		biPredClipping16bitFuncPtrArray[!!(ASM_TYPES & PREAVX2_MASK)](
 			chromaPuWidth,
 			chromaPuHeight,
 			refList0TempDst + lumaTempBufSize + chromaTempBufSize,

--- a/Source/Lib/Codec/EbMcp.c
+++ b/Source/Lib/Codec/EbMcp.c
@@ -294,7 +294,7 @@ void UniPredInterpolation16bit(
     fracPosx  = (posX & (0x07 >> (1 - subWidthCMinus1))) << (1 - subWidthCMinus1);
     fracPosy  = (posY & (0x07 >> (1 - subHeightCMinus1))) << (1 - subHeightCMinus1);
 
-	uniPredChromaIFFunctionPtrArrayNew16bit[(ASM_TYPES & AVX2_MASK) && 1][fracPosx + (fracPosy << 3)](
+	uniPredChromaIFFunctionPtrArrayNew16bit[!!(ASM_TYPES & AVX2_MASK)][fracPosx + (fracPosy << 3)](
 		(EB_U16 *)fullPelBlock->bufferCb + 2 + 2 * fullPelBlock->strideCb,
 		fullPelBlock->strideCb,
 		(EB_U16*)(dst->bufferCb) + dstChromaIndex,
@@ -305,7 +305,7 @@ void UniPredInterpolation16bit(
 		fracPosx,
 		fracPosy);
 
-	uniPredChromaIFFunctionPtrArrayNew16bit[(ASM_TYPES & AVX2_MASK) && 1][fracPosx + (fracPosy << 3)](
+	uniPredChromaIFFunctionPtrArrayNew16bit[!!(ASM_TYPES & AVX2_MASK)][fracPosx + (fracPosy << 3)](
 		(EB_U16 *)fullPelBlock->bufferCr + 2 + 2 * fullPelBlock->strideCr,
 		fullPelBlock->strideCr,
 		(EB_U16*)(dst->bufferCr) + dstChromaIndex,
@@ -936,7 +936,7 @@ void BiPredInterpolation16bit(
 		fracPosx = (refList0PosX & (0x07 >> (1-subWidthCMinus1))) << (1-subWidthCMinus1);
 		fracPosy = (refList0PosY & (0x07 >> (1-subHeightCMinus1))) << (1-subHeightCMinus1);
 
-		biPredChromaIFFunctionPtrArrayNew16bit[(ASM_TYPES & AVX2_MASK) && 1][fracPosx + (fracPosy << 3)](
+		biPredChromaIFFunctionPtrArrayNew16bit[!!(ASM_TYPES & AVX2_MASK)][fracPosx + (fracPosy << 3)](
 			(EB_U16 *)fullPelBlockL0->bufferCb + 2 + 2 * fullPelBlockL0->strideCb,
 			fullPelBlockL0->strideCb,
 			refList0TempDst + lumaTempBufSize,
@@ -946,7 +946,7 @@ void BiPredInterpolation16bit(
 			fracPosx,
 			fracPosy);
 
-		biPredChromaIFFunctionPtrArrayNew16bit[(ASM_TYPES & AVX2_MASK) && 1][fracPosx + (fracPosy << 3)](
+		biPredChromaIFFunctionPtrArrayNew16bit[!!(ASM_TYPES & AVX2_MASK)][fracPosx + (fracPosy << 3)](
 			(EB_U16 *)fullPelBlockL0->bufferCr + 2 + 2 * fullPelBlockL0->strideCr,
 			fullPelBlockL0->strideCr,
 			refList0TempDst + lumaTempBufSize + chromaTempBufSize,
@@ -967,7 +967,7 @@ void BiPredInterpolation16bit(
 		fracPosx = (refList1PosX & (0x07 >> (1-subWidthCMinus1))) << (1-subWidthCMinus1);
 		fracPosy = (refList1PosY & (0x07 >> (1-subHeightCMinus1))) << (1-subHeightCMinus1);
 
-		biPredChromaIFFunctionPtrArrayNew16bit[(ASM_TYPES & AVX2_MASK) && 1][fracPosx + (fracPosy << 3)](
+		biPredChromaIFFunctionPtrArrayNew16bit[!!(ASM_TYPES & AVX2_MASK)][fracPosx + (fracPosy << 3)](
 			(EB_U16 *)fullPelBlockL1->bufferCb + 2 + 2 * fullPelBlockL1->strideCb,
 			fullPelBlockL1->strideCb,
 			refList1TempDst + lumaTempBufSize,
@@ -977,7 +977,7 @@ void BiPredInterpolation16bit(
 			fracPosx,
 			fracPosy);
 
-		biPredChromaIFFunctionPtrArrayNew16bit[(ASM_TYPES & AVX2_MASK) && 1][fracPosx + (fracPosy << 3)](
+		biPredChromaIFFunctionPtrArrayNew16bit[!!(ASM_TYPES & AVX2_MASK)][fracPosx + (fracPosy << 3)](
 			(EB_U16 *)fullPelBlockL1->bufferCr + 2 + 2 * fullPelBlockL1->strideCr,
 			fullPelBlockL1->strideCr,
 			refList1TempDst + lumaTempBufSize + chromaTempBufSize,

--- a/Source/Lib/Codec/EbModeDecision.c
+++ b/Source/Lib/Codec/EbModeDecision.c
@@ -94,7 +94,7 @@ void intraSearchTheseModesOutputBest(
         const EB_U32 puOriginIndex = (contextPtr->cuOriginY & 63) * 64 + (contextPtr->cuOriginX & 63);
 
         //Distortion
-        sadCurr  = (EB_U32)NxMSadKernel_funcPtrArray[(ASM_TYPES & AVX2_MASK) && 1][cuSize >> 3](
+        sadCurr  = (EB_U32)NxMSadKernel_funcPtrArray[!!(ASM_TYPES & AVX2_MASK)][cuSize >> 3](
             src,
             srcStride,
             &(contextPtr->predictionBuffer->bufferY[puOriginIndex]),

--- a/Source/Lib/Codec/EbMotionEstimation.c
+++ b/Source/Lib/Codec/EbMotionEstimation.c
@@ -604,7 +604,7 @@ static void FullPelSearch_LCU(
 
 			//this function will do:  xSearchIndex, +1, +2, ..., +7
 #ifndef NON_AVX512_SUPPORT
-			GetEightHorizontalSearchPointResultsAll85PUs_funcPtrArray[ (ASM_TYPES & AVX512_MASK) && 1 ](
+			GetEightHorizontalSearchPointResultsAll85PUs_funcPtrArray[ !!(ASM_TYPES & AVX512_MASK) ](
 #else
             GetEightHorizontalSearchPointResultsAll85PUs_funcPtrArray[!!(ASM_TYPES & AVX2_MASK)](
 #endif
@@ -1935,7 +1935,7 @@ void HmeOneQuadrantLevel0(
 			searchAreaWidth = (EB_S16)((double)((searchAreaWidth >> 4) << 4));
 		}
 #ifndef NON_AVX512_SUPPORT
-	    if (((searchAreaWidth & 15) == 0) && ((ASM_TYPES & AVX512_MASK) && 1))
+	    if (((searchAreaWidth & 15) == 0) && (!!(ASM_TYPES & AVX512_MASK)))
 #else
         if (((searchAreaWidth & 15) == 0) && (!!(ASM_TYPES & AVX2_MASK)))
 #endif
@@ -2104,7 +2104,7 @@ void HmeLevel0(
 	if (((lcuWidth  & 7) == 0) || (lcuWidth == 4))
 	{
 #ifndef NON_AVX512_SUPPORT
-        if (((searchAreaWidth & 15) == 0) && ((ASM_TYPES & AVX512_MASK) && 1))
+        if (((searchAreaWidth & 15) == 0) && (!!(ASM_TYPES & AVX512_MASK)))
 #else
         if (((searchAreaWidth & 15) == 0) && (!!(ASM_TYPES & AVX2_MASK)))
 #endif

--- a/Source/Lib/Codec/EbMotionEstimation.c
+++ b/Source/Lib/Codec/EbMotionEstimation.c
@@ -347,81 +347,81 @@ static void GetEightHorizontalSearchPointResultsAll85PUs_AVX2_INTRIN(
     //---- 16x16_0
     blockIndex = 0;
     searchPositionIndex = searchPositionTLIndex;
-    GetEightHorizontalSearchPointResults_8x8_16x16_funcPtrArray[(ASM_TYPES & AVX2_MASK) && 1](srcPtr + blockIndex, contextPtr->lcuSrcStride, refPtr + searchPositionIndex, reflumaStride, &pBestSad8x8[0], &pBestMV8x8[0], &pBestSad16x16[0], &pBestMV16x16[0], currMV, &pSad16x16[0 * 8]);
+    GetEightHorizontalSearchPointResults_8x8_16x16_funcPtrArray[!!(ASM_TYPES & AVX2_MASK)](srcPtr + blockIndex, contextPtr->lcuSrcStride, refPtr + searchPositionIndex, reflumaStride, &pBestSad8x8[0], &pBestMV8x8[0], &pBestSad16x16[0], &pBestMV16x16[0], currMV, &pSad16x16[0 * 8]);
     //---- 16x16_1
     blockIndex = blockIndex + 16;
     searchPositionIndex = searchPositionTLIndex + 16;
-    GetEightHorizontalSearchPointResults_8x8_16x16_funcPtrArray[(ASM_TYPES & AVX2_MASK) && 1](srcPtr + blockIndex, contextPtr->lcuSrcStride, refPtr + searchPositionIndex, reflumaStride, &pBestSad8x8[4], &pBestMV8x8[4], &pBestSad16x16[1], &pBestMV16x16[1], currMV, &pSad16x16[1 * 8]);
+    GetEightHorizontalSearchPointResults_8x8_16x16_funcPtrArray[!!(ASM_TYPES & AVX2_MASK)](srcPtr + blockIndex, contextPtr->lcuSrcStride, refPtr + searchPositionIndex, reflumaStride, &pBestSad8x8[4], &pBestMV8x8[4], &pBestSad16x16[1], &pBestMV16x16[1], currMV, &pSad16x16[1 * 8]);
     //---- 16x16_4
     blockIndex = blockIndex + 16;
     searchPositionIndex = searchPositionIndex + 16;
-    GetEightHorizontalSearchPointResults_8x8_16x16_funcPtrArray[(ASM_TYPES & AVX2_MASK) && 1](srcPtr + blockIndex, contextPtr->lcuSrcStride, refPtr + searchPositionIndex, reflumaStride, &pBestSad8x8[16], &pBestMV8x8[16], &pBestSad16x16[4], &pBestMV16x16[4], currMV, &pSad16x16[4 * 8]);
+    GetEightHorizontalSearchPointResults_8x8_16x16_funcPtrArray[!!(ASM_TYPES & AVX2_MASK)](srcPtr + blockIndex, contextPtr->lcuSrcStride, refPtr + searchPositionIndex, reflumaStride, &pBestSad8x8[16], &pBestMV8x8[16], &pBestSad16x16[4], &pBestMV16x16[4], currMV, &pSad16x16[4 * 8]);
     //---- 16x16_5
     blockIndex = blockIndex + 16;
     searchPositionIndex = searchPositionIndex + 16;
-    GetEightHorizontalSearchPointResults_8x8_16x16_funcPtrArray[(ASM_TYPES & AVX2_MASK) && 1](srcPtr + blockIndex, contextPtr->lcuSrcStride, refPtr + searchPositionIndex, reflumaStride, &pBestSad8x8[20], &pBestMV8x8[20], &pBestSad16x16[5], &pBestMV16x16[5], currMV, &pSad16x16[5 * 8]);
+    GetEightHorizontalSearchPointResults_8x8_16x16_funcPtrArray[!!(ASM_TYPES & AVX2_MASK)](srcPtr + blockIndex, contextPtr->lcuSrcStride, refPtr + searchPositionIndex, reflumaStride, &pBestSad8x8[20], &pBestMV8x8[20], &pBestSad16x16[5], &pBestMV16x16[5], currMV, &pSad16x16[5 * 8]);
 
 
 
     //---- 16x16_2
     blockIndex = srcNext16x16Offset;
     searchPositionIndex = searchPositionTLIndex + refNext16x16Offset;
-    GetEightHorizontalSearchPointResults_8x8_16x16_funcPtrArray[(ASM_TYPES & AVX2_MASK) && 1](srcPtr + blockIndex, contextPtr->lcuSrcStride, refPtr + searchPositionIndex, reflumaStride, &pBestSad8x8[8], &pBestMV8x8[8], &pBestSad16x16[2], &pBestMV16x16[2], currMV, &pSad16x16[2 * 8]);
+    GetEightHorizontalSearchPointResults_8x8_16x16_funcPtrArray[!!(ASM_TYPES & AVX2_MASK)](srcPtr + blockIndex, contextPtr->lcuSrcStride, refPtr + searchPositionIndex, reflumaStride, &pBestSad8x8[8], &pBestMV8x8[8], &pBestSad16x16[2], &pBestMV16x16[2], currMV, &pSad16x16[2 * 8]);
     //---- 16x16_3
     blockIndex = blockIndex + 16;
     searchPositionIndex = searchPositionIndex + 16;
-    GetEightHorizontalSearchPointResults_8x8_16x16_funcPtrArray[(ASM_TYPES & AVX2_MASK) && 1](srcPtr + blockIndex, contextPtr->lcuSrcStride, refPtr + searchPositionIndex, reflumaStride, &pBestSad8x8[12], &pBestMV8x8[12], &pBestSad16x16[3], &pBestMV16x16[3], currMV, &pSad16x16[3 * 8]);
+    GetEightHorizontalSearchPointResults_8x8_16x16_funcPtrArray[!!(ASM_TYPES & AVX2_MASK)](srcPtr + blockIndex, contextPtr->lcuSrcStride, refPtr + searchPositionIndex, reflumaStride, &pBestSad8x8[12], &pBestMV8x8[12], &pBestSad16x16[3], &pBestMV16x16[3], currMV, &pSad16x16[3 * 8]);
     //---- 16x16_6
     blockIndex = blockIndex + 16;
     searchPositionIndex = searchPositionIndex + 16;
-    GetEightHorizontalSearchPointResults_8x8_16x16_funcPtrArray[(ASM_TYPES & AVX2_MASK) && 1](srcPtr + blockIndex, contextPtr->lcuSrcStride, refPtr + searchPositionIndex, reflumaStride, &pBestSad8x8[24], &pBestMV8x8[24], &pBestSad16x16[6], &pBestMV16x16[6], currMV, &pSad16x16[6 * 8]);
+    GetEightHorizontalSearchPointResults_8x8_16x16_funcPtrArray[!!(ASM_TYPES & AVX2_MASK)](srcPtr + blockIndex, contextPtr->lcuSrcStride, refPtr + searchPositionIndex, reflumaStride, &pBestSad8x8[24], &pBestMV8x8[24], &pBestSad16x16[6], &pBestMV16x16[6], currMV, &pSad16x16[6 * 8]);
     //---- 16x16_7
     blockIndex = blockIndex + 16;
     searchPositionIndex = searchPositionIndex + 16;
-    GetEightHorizontalSearchPointResults_8x8_16x16_funcPtrArray[(ASM_TYPES & AVX2_MASK) && 1](srcPtr + blockIndex, contextPtr->lcuSrcStride, refPtr + searchPositionIndex, reflumaStride, &pBestSad8x8[28], &pBestMV8x8[28], &pBestSad16x16[7], &pBestMV16x16[7], currMV, &pSad16x16[7 * 8]);
+    GetEightHorizontalSearchPointResults_8x8_16x16_funcPtrArray[!!(ASM_TYPES & AVX2_MASK)](srcPtr + blockIndex, contextPtr->lcuSrcStride, refPtr + searchPositionIndex, reflumaStride, &pBestSad8x8[28], &pBestMV8x8[28], &pBestSad16x16[7], &pBestMV16x16[7], currMV, &pSad16x16[7 * 8]);
 
 
     //---- 16x16_8
     blockIndex = (srcNext16x16Offset << 1);
     searchPositionIndex = searchPositionTLIndex + (refNext16x16Offset << 1);
-    GetEightHorizontalSearchPointResults_8x8_16x16_funcPtrArray[(ASM_TYPES & AVX2_MASK) && 1](srcPtr + blockIndex, contextPtr->lcuSrcStride, refPtr + searchPositionIndex, reflumaStride, &pBestSad8x8[32], &pBestMV8x8[32], &pBestSad16x16[8], &pBestMV16x16[8], currMV, &pSad16x16[8 * 8]);
+    GetEightHorizontalSearchPointResults_8x8_16x16_funcPtrArray[!!(ASM_TYPES & AVX2_MASK)](srcPtr + blockIndex, contextPtr->lcuSrcStride, refPtr + searchPositionIndex, reflumaStride, &pBestSad8x8[32], &pBestMV8x8[32], &pBestSad16x16[8], &pBestMV16x16[8], currMV, &pSad16x16[8 * 8]);
     //---- 16x16_9
     blockIndex = blockIndex + 16;
     searchPositionIndex = searchPositionIndex + 16;
-    GetEightHorizontalSearchPointResults_8x8_16x16_funcPtrArray[(ASM_TYPES & AVX2_MASK) && 1](srcPtr + blockIndex, contextPtr->lcuSrcStride, refPtr + searchPositionIndex, reflumaStride, &pBestSad8x8[36], &pBestMV8x8[36], &pBestSad16x16[9], &pBestMV16x16[9], currMV, &pSad16x16[9 * 8]);
+    GetEightHorizontalSearchPointResults_8x8_16x16_funcPtrArray[!!(ASM_TYPES & AVX2_MASK)](srcPtr + blockIndex, contextPtr->lcuSrcStride, refPtr + searchPositionIndex, reflumaStride, &pBestSad8x8[36], &pBestMV8x8[36], &pBestSad16x16[9], &pBestMV16x16[9], currMV, &pSad16x16[9 * 8]);
     //---- 16x16_12
     blockIndex = blockIndex + 16;
     searchPositionIndex = searchPositionIndex + 16;
-    GetEightHorizontalSearchPointResults_8x8_16x16_funcPtrArray[(ASM_TYPES & AVX2_MASK) && 1](srcPtr + blockIndex, contextPtr->lcuSrcStride, refPtr + searchPositionIndex, reflumaStride, &pBestSad8x8[48], &pBestMV8x8[48], &pBestSad16x16[12], &pBestMV16x16[12], currMV, &pSad16x16[12 * 8]);
+    GetEightHorizontalSearchPointResults_8x8_16x16_funcPtrArray[!!(ASM_TYPES & AVX2_MASK)](srcPtr + blockIndex, contextPtr->lcuSrcStride, refPtr + searchPositionIndex, reflumaStride, &pBestSad8x8[48], &pBestMV8x8[48], &pBestSad16x16[12], &pBestMV16x16[12], currMV, &pSad16x16[12 * 8]);
     //---- 16x1_13
     blockIndex = blockIndex + 16;
     searchPositionIndex = searchPositionIndex + 16;
-    GetEightHorizontalSearchPointResults_8x8_16x16_funcPtrArray[(ASM_TYPES & AVX2_MASK) && 1](srcPtr + blockIndex, contextPtr->lcuSrcStride, refPtr + searchPositionIndex, reflumaStride, &pBestSad8x8[52], &pBestMV8x8[52], &pBestSad16x16[13], &pBestMV16x16[13], currMV, &pSad16x16[13 * 8]);
+    GetEightHorizontalSearchPointResults_8x8_16x16_funcPtrArray[!!(ASM_TYPES & AVX2_MASK)](srcPtr + blockIndex, contextPtr->lcuSrcStride, refPtr + searchPositionIndex, reflumaStride, &pBestSad8x8[52], &pBestMV8x8[52], &pBestSad16x16[13], &pBestMV16x16[13], currMV, &pSad16x16[13 * 8]);
 
 
 
     //---- 16x16_10
     blockIndex = (srcNext16x16Offset * 3);
     searchPositionIndex = searchPositionTLIndex + (refNext16x16Offset * 3);
-    GetEightHorizontalSearchPointResults_8x8_16x16_funcPtrArray[(ASM_TYPES & AVX2_MASK) && 1](srcPtr + blockIndex, contextPtr->lcuSrcStride, refPtr + searchPositionIndex, reflumaStride, &pBestSad8x8[40], &pBestMV8x8[40], &pBestSad16x16[10], &pBestMV16x16[10], currMV, &pSad16x16[10 * 8]);
+    GetEightHorizontalSearchPointResults_8x8_16x16_funcPtrArray[!!(ASM_TYPES & AVX2_MASK)](srcPtr + blockIndex, contextPtr->lcuSrcStride, refPtr + searchPositionIndex, reflumaStride, &pBestSad8x8[40], &pBestMV8x8[40], &pBestSad16x16[10], &pBestMV16x16[10], currMV, &pSad16x16[10 * 8]);
     //---- 16x16_11
     blockIndex = blockIndex + 16;
     searchPositionIndex = searchPositionIndex + 16;
-    GetEightHorizontalSearchPointResults_8x8_16x16_funcPtrArray[(ASM_TYPES & AVX2_MASK) && 1](srcPtr + blockIndex, contextPtr->lcuSrcStride, refPtr + searchPositionIndex, reflumaStride, &pBestSad8x8[44], &pBestMV8x8[44], &pBestSad16x16[11], &pBestMV16x16[11], currMV, &pSad16x16[11 * 8]);
+    GetEightHorizontalSearchPointResults_8x8_16x16_funcPtrArray[!!(ASM_TYPES & AVX2_MASK)](srcPtr + blockIndex, contextPtr->lcuSrcStride, refPtr + searchPositionIndex, reflumaStride, &pBestSad8x8[44], &pBestMV8x8[44], &pBestSad16x16[11], &pBestMV16x16[11], currMV, &pSad16x16[11 * 8]);
     //---- 16x16_14
     blockIndex = blockIndex + 16;
     searchPositionIndex = searchPositionIndex + 16;
-    GetEightHorizontalSearchPointResults_8x8_16x16_funcPtrArray[(ASM_TYPES & AVX2_MASK) && 1](srcPtr + blockIndex, contextPtr->lcuSrcStride, refPtr + searchPositionIndex, reflumaStride, &pBestSad8x8[56], &pBestMV8x8[56], &pBestSad16x16[14], &pBestMV16x16[14], currMV, &pSad16x16[14 * 8]);
+    GetEightHorizontalSearchPointResults_8x8_16x16_funcPtrArray[!!(ASM_TYPES & AVX2_MASK)](srcPtr + blockIndex, contextPtr->lcuSrcStride, refPtr + searchPositionIndex, reflumaStride, &pBestSad8x8[56], &pBestMV8x8[56], &pBestSad16x16[14], &pBestMV16x16[14], currMV, &pSad16x16[14 * 8]);
     //---- 16x16_15
     blockIndex = blockIndex + 16;
     searchPositionIndex = searchPositionIndex + 16;
-    GetEightHorizontalSearchPointResults_8x8_16x16_funcPtrArray[(ASM_TYPES & AVX2_MASK) && 1](srcPtr + blockIndex, contextPtr->lcuSrcStride, refPtr + searchPositionIndex, reflumaStride, &pBestSad8x8[60], &pBestMV8x8[60], &pBestSad16x16[15], &pBestMV16x16[15], currMV, &pSad16x16[15 * 8]);
+    GetEightHorizontalSearchPointResults_8x8_16x16_funcPtrArray[!!(ASM_TYPES & AVX2_MASK)](srcPtr + blockIndex, contextPtr->lcuSrcStride, refPtr + searchPositionIndex, reflumaStride, &pBestSad8x8[60], &pBestMV8x8[60], &pBestSad16x16[15], &pBestMV16x16[15], currMV, &pSad16x16[15 * 8]);
 
 
 
 
     //32x32 and 64x64
-    GetEightHorizontalSearchPointResults_32x32_64x64_funcPtrArray[(ASM_TYPES & AVX2_MASK) && 1](pSad16x16, pBestSad32x32, pBestSad64x64, pBestMV32x32, pBestMV64x64, currMV);
+    GetEightHorizontalSearchPointResults_32x32_64x64_funcPtrArray[!!(ASM_TYPES & AVX2_MASK)](pSad16x16, pBestSad32x32, pBestSad64x64, pBestMV32x32, pBestMV64x64, currMV);
 
 }
 #endif
@@ -606,7 +606,7 @@ static void FullPelSearch_LCU(
 #ifndef NON_AVX512_SUPPORT
 			GetEightHorizontalSearchPointResultsAll85PUs_funcPtrArray[ (ASM_TYPES & AVX512_MASK) && 1 ](
 #else
-            GetEightHorizontalSearchPointResultsAll85PUs_funcPtrArray[(ASM_TYPES & AVX2_MASK) && 1](
+            GetEightHorizontalSearchPointResultsAll85PUs_funcPtrArray[!!(ASM_TYPES & AVX2_MASK)](
 #endif
 				contextPtr,
 				listIndex,
@@ -815,12 +815,12 @@ static void PU_HalfPelRefinement(
         distortionLeftPosition = (contextPtr->fractionalSearchMethod == SSD_SEARCH) ?            
             SpatialFullDistortionKernel_funcPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1][Log2f(puWidth) - 2](&(contextPtr->lcuSrcPtr[puLcuBufferIndex]), contextPtr->lcuSrcStride, &(posbBuffer[searchRegionIndex]), contextPtr->interpolatedStride, puHeight, puWidth) :
             (contextPtr->fractionalSearchMethod == SUB_SAD_SEARCH) ?
-                (NxMSadKernel_funcPtrArray[(ASM_TYPES & AVX2_MASK) && 1][puWidth >> 3](&(contextPtr->lcuSrcPtr[puLcuBufferIndex]), contextPtr->lcuSrcStride << 1, &(posbBuffer[searchRegionIndex]), contextPtr->interpolatedStride << 1, puHeight >> 1, puWidth)) << 1 :
-                NxMSadKernel_funcPtrArray[(ASM_TYPES & AVX2_MASK) && 1][puWidth >> 3](&(contextPtr->lcuSrcPtr[puLcuBufferIndex]), contextPtr->lcuSrcStride, &(posbBuffer[searchRegionIndex]), contextPtr->interpolatedStride, puHeight, puWidth);
+                (NxMSadKernel_funcPtrArray[!!(ASM_TYPES & AVX2_MASK)][puWidth >> 3](&(contextPtr->lcuSrcPtr[puLcuBufferIndex]), contextPtr->lcuSrcStride << 1, &(posbBuffer[searchRegionIndex]), contextPtr->interpolatedStride << 1, puHeight >> 1, puWidth)) << 1 :
+                NxMSadKernel_funcPtrArray[!!(ASM_TYPES & AVX2_MASK)][puWidth >> 3](&(contextPtr->lcuSrcPtr[puLcuBufferIndex]), contextPtr->lcuSrcStride, &(posbBuffer[searchRegionIndex]), contextPtr->interpolatedStride, puHeight, puWidth);
 
         if (contextPtr->fractionalSearchMethod == SSD_SEARCH) {
             if (distortionLeftPosition < *pBestSsd) {
-                *pBestSad = (EB_U32)NxMSadKernel_funcPtrArray[(ASM_TYPES & AVX2_MASK) && 1][puWidth >> 3](&(contextPtr->lcuSrcPtr[puLcuBufferIndex]), contextPtr->lcuSrcStride, &(posbBuffer[searchRegionIndex]), contextPtr->interpolatedStride, puHeight, puWidth);
+                *pBestSad = (EB_U32)NxMSadKernel_funcPtrArray[!!(ASM_TYPES & AVX2_MASK)][puWidth >> 3](&(contextPtr->lcuSrcPtr[puLcuBufferIndex]), contextPtr->lcuSrcStride, &(posbBuffer[searchRegionIndex]), contextPtr->interpolatedStride, puHeight, puWidth);
                 *pBestMV = ((EB_U16)yMvHalf[0] << 16) | ((EB_U16)xMvHalf[0]);
                 *pBestSsd = (EB_U32)distortionLeftPosition;
             }
@@ -838,13 +838,13 @@ static void PU_HalfPelRefinement(
         distortionRightPosition = (contextPtr->fractionalSearchMethod == SSD_SEARCH) ? 
             SpatialFullDistortionKernel_funcPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1][Log2f(puWidth) - 2](&(contextPtr->lcuSrcPtr[puLcuBufferIndex]), contextPtr->lcuSrcStride, &(posbBuffer[searchRegionIndex]), contextPtr->interpolatedStride, puHeight, puWidth) :
             (contextPtr->fractionalSearchMethod == SUB_SAD_SEARCH) ?
-                (NxMSadKernel_funcPtrArray[(ASM_TYPES & AVX2_MASK) && 1][puWidth >> 3](&(contextPtr->lcuSrcPtr[puLcuBufferIndex]), contextPtr->lcuSrcStride << 1, &(posbBuffer[searchRegionIndex]), contextPtr->interpolatedStride << 1, puHeight >> 1, puWidth)) << 1 :
-                 NxMSadKernel_funcPtrArray[(ASM_TYPES & AVX2_MASK) && 1][puWidth >> 3](&(contextPtr->lcuSrcPtr[puLcuBufferIndex]), contextPtr->lcuSrcStride, &(posbBuffer[searchRegionIndex]), contextPtr->interpolatedStride, puHeight, puWidth);
+                (NxMSadKernel_funcPtrArray[!!(ASM_TYPES & AVX2_MASK)][puWidth >> 3](&(contextPtr->lcuSrcPtr[puLcuBufferIndex]), contextPtr->lcuSrcStride << 1, &(posbBuffer[searchRegionIndex]), contextPtr->interpolatedStride << 1, puHeight >> 1, puWidth)) << 1 :
+                 NxMSadKernel_funcPtrArray[!!(ASM_TYPES & AVX2_MASK)][puWidth >> 3](&(contextPtr->lcuSrcPtr[puLcuBufferIndex]), contextPtr->lcuSrcStride, &(posbBuffer[searchRegionIndex]), contextPtr->interpolatedStride, puHeight, puWidth);
 
 
         if (contextPtr->fractionalSearchMethod == SSD_SEARCH) {
             if (distortionRightPosition < *pBestSsd) {
-                *pBestSad = (EB_U32)NxMSadKernel_funcPtrArray[(ASM_TYPES & AVX2_MASK) && 1][puWidth >> 3](&(contextPtr->lcuSrcPtr[puLcuBufferIndex]), contextPtr->lcuSrcStride, &(posbBuffer[searchRegionIndex]), contextPtr->interpolatedStride, puHeight, puWidth);
+                *pBestSad = (EB_U32)NxMSadKernel_funcPtrArray[!!(ASM_TYPES & AVX2_MASK)][puWidth >> 3](&(contextPtr->lcuSrcPtr[puLcuBufferIndex]), contextPtr->lcuSrcStride, &(posbBuffer[searchRegionIndex]), contextPtr->interpolatedStride, puHeight, puWidth);
                 *pBestMV = ((EB_U16)yMvHalf[1] << 16) | ((EB_U16)xMvHalf[1]);
                 *pBestSsd = (EB_U32)distortionRightPosition;
             }
@@ -862,12 +862,12 @@ static void PU_HalfPelRefinement(
         distortionTopPosition = (contextPtr->fractionalSearchMethod == SSD_SEARCH) ? 
             SpatialFullDistortionKernel_funcPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1][Log2f(puWidth) - 2](&(contextPtr->lcuSrcPtr[puLcuBufferIndex]), contextPtr->lcuSrcStride, &(poshBuffer[searchRegionIndex]), contextPtr->interpolatedStride, puHeight, puWidth) :
             (contextPtr->fractionalSearchMethod == SUB_SAD_SEARCH) ?
-                (NxMSadKernel_funcPtrArray[(ASM_TYPES & AVX2_MASK) && 1][puWidth >> 3](&(contextPtr->lcuSrcPtr[puLcuBufferIndex]), contextPtr->lcuSrcStride << 1, &(poshBuffer[searchRegionIndex]), contextPtr->interpolatedStride << 1, puHeight >> 1, puWidth)) << 1 :
-                 NxMSadKernel_funcPtrArray[(ASM_TYPES & AVX2_MASK) && 1][puWidth >> 3](&(contextPtr->lcuSrcPtr[puLcuBufferIndex]), contextPtr->lcuSrcStride, &(poshBuffer[searchRegionIndex]), contextPtr->interpolatedStride, puHeight, puWidth);
+                (NxMSadKernel_funcPtrArray[!!(ASM_TYPES & AVX2_MASK)][puWidth >> 3](&(contextPtr->lcuSrcPtr[puLcuBufferIndex]), contextPtr->lcuSrcStride << 1, &(poshBuffer[searchRegionIndex]), contextPtr->interpolatedStride << 1, puHeight >> 1, puWidth)) << 1 :
+                 NxMSadKernel_funcPtrArray[!!(ASM_TYPES & AVX2_MASK)][puWidth >> 3](&(contextPtr->lcuSrcPtr[puLcuBufferIndex]), contextPtr->lcuSrcStride, &(poshBuffer[searchRegionIndex]), contextPtr->interpolatedStride, puHeight, puWidth);
 
         if (contextPtr->fractionalSearchMethod == SSD_SEARCH) {
             if (distortionTopPosition < *pBestSsd) {
-                *pBestSad = (EB_U32)NxMSadKernel_funcPtrArray[(ASM_TYPES & AVX2_MASK) && 1][puWidth >> 3](&(contextPtr->lcuSrcPtr[puLcuBufferIndex]), contextPtr->lcuSrcStride, &(poshBuffer[searchRegionIndex]), contextPtr->interpolatedStride, puHeight, puWidth);
+                *pBestSad = (EB_U32)NxMSadKernel_funcPtrArray[!!(ASM_TYPES & AVX2_MASK)][puWidth >> 3](&(contextPtr->lcuSrcPtr[puLcuBufferIndex]), contextPtr->lcuSrcStride, &(poshBuffer[searchRegionIndex]), contextPtr->interpolatedStride, puHeight, puWidth);
                 *pBestMV = ((EB_U16)yMvHalf[2] << 16) | ((EB_U16)xMvHalf[2]);
                 *pBestSsd = (EB_U32)distortionTopPosition;
             }
@@ -885,12 +885,12 @@ static void PU_HalfPelRefinement(
         distortionBottomPosition = (contextPtr->fractionalSearchMethod == SSD_SEARCH) ? 
             SpatialFullDistortionKernel_funcPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1][Log2f(puWidth) - 2](&(contextPtr->lcuSrcPtr[puLcuBufferIndex]), contextPtr->lcuSrcStride, &(poshBuffer[searchRegionIndex]), contextPtr->interpolatedStride, puHeight, puWidth) :
             (contextPtr->fractionalSearchMethod == SUB_SAD_SEARCH) ?
-                (NxMSadKernel_funcPtrArray[(ASM_TYPES & AVX2_MASK) && 1][puWidth >> 3](&(contextPtr->lcuSrcPtr[puLcuBufferIndex]), contextPtr->lcuSrcStride << 1, &(poshBuffer[searchRegionIndex]), contextPtr->interpolatedStride << 1, puHeight >> 1, puWidth)) << 1 :
-                NxMSadKernel_funcPtrArray[(ASM_TYPES & AVX2_MASK) && 1][puWidth >> 3](&(contextPtr->lcuSrcPtr[puLcuBufferIndex]), contextPtr->lcuSrcStride, &(poshBuffer[searchRegionIndex]), contextPtr->interpolatedStride, puHeight, puWidth);
+                (NxMSadKernel_funcPtrArray[!!(ASM_TYPES & AVX2_MASK)][puWidth >> 3](&(contextPtr->lcuSrcPtr[puLcuBufferIndex]), contextPtr->lcuSrcStride << 1, &(poshBuffer[searchRegionIndex]), contextPtr->interpolatedStride << 1, puHeight >> 1, puWidth)) << 1 :
+                NxMSadKernel_funcPtrArray[!!(ASM_TYPES & AVX2_MASK)][puWidth >> 3](&(contextPtr->lcuSrcPtr[puLcuBufferIndex]), contextPtr->lcuSrcStride, &(poshBuffer[searchRegionIndex]), contextPtr->interpolatedStride, puHeight, puWidth);
 
         if (contextPtr->fractionalSearchMethod == SSD_SEARCH) {
             if (distortionBottomPosition < *pBestSsd) {
-                *pBestSad = (EB_U32)NxMSadKernel_funcPtrArray[(ASM_TYPES & AVX2_MASK) && 1][puWidth >> 3](&(contextPtr->lcuSrcPtr[puLcuBufferIndex]), contextPtr->lcuSrcStride, &(poshBuffer[searchRegionIndex]), contextPtr->interpolatedStride, puHeight, puWidth);
+                *pBestSad = (EB_U32)NxMSadKernel_funcPtrArray[!!(ASM_TYPES & AVX2_MASK)][puWidth >> 3](&(contextPtr->lcuSrcPtr[puLcuBufferIndex]), contextPtr->lcuSrcStride, &(poshBuffer[searchRegionIndex]), contextPtr->interpolatedStride, puHeight, puWidth);
                 *pBestMV = ((EB_U16)yMvHalf[3] << 16) | ((EB_U16)xMvHalf[3]);
                 *pBestSsd = (EB_U32)distortionBottomPosition;
             }
@@ -908,12 +908,12 @@ static void PU_HalfPelRefinement(
         distortionTopLeftPosition = (contextPtr->fractionalSearchMethod == SSD_SEARCH) ? 
             SpatialFullDistortionKernel_funcPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1][Log2f(puWidth) - 2](&(contextPtr->lcuSrcPtr[puLcuBufferIndex]), contextPtr->lcuSrcStride, &(posjBuffer[searchRegionIndex]), contextPtr->interpolatedStride, puHeight, puWidth) :
             (contextPtr->fractionalSearchMethod == SUB_SAD_SEARCH) ?
-                (NxMSadKernel_funcPtrArray[(ASM_TYPES & AVX2_MASK) && 1][puWidth >> 3](&(contextPtr->lcuSrcPtr[puLcuBufferIndex]), contextPtr->lcuSrcStride << 1, &(posjBuffer[searchRegionIndex]), contextPtr->interpolatedStride << 1, puHeight >> 1, puWidth)) << 1 :
-                NxMSadKernel_funcPtrArray[(ASM_TYPES & AVX2_MASK) && 1][puWidth >> 3](&(contextPtr->lcuSrcPtr[puLcuBufferIndex]), contextPtr->lcuSrcStride, &(posjBuffer[searchRegionIndex]), contextPtr->interpolatedStride, puHeight, puWidth);
+                (NxMSadKernel_funcPtrArray[!!(ASM_TYPES & AVX2_MASK)][puWidth >> 3](&(contextPtr->lcuSrcPtr[puLcuBufferIndex]), contextPtr->lcuSrcStride << 1, &(posjBuffer[searchRegionIndex]), contextPtr->interpolatedStride << 1, puHeight >> 1, puWidth)) << 1 :
+                NxMSadKernel_funcPtrArray[!!(ASM_TYPES & AVX2_MASK)][puWidth >> 3](&(contextPtr->lcuSrcPtr[puLcuBufferIndex]), contextPtr->lcuSrcStride, &(posjBuffer[searchRegionIndex]), contextPtr->interpolatedStride, puHeight, puWidth);
 
         if (contextPtr->fractionalSearchMethod == SSD_SEARCH) {
             if (distortionTopLeftPosition < *pBestSsd) {
-                *pBestSad = (EB_U32)NxMSadKernel_funcPtrArray[(ASM_TYPES & AVX2_MASK) && 1][puWidth >> 3](&(contextPtr->lcuSrcPtr[puLcuBufferIndex]), contextPtr->lcuSrcStride, &(posjBuffer[searchRegionIndex]), contextPtr->interpolatedStride, puHeight, puWidth);
+                *pBestSad = (EB_U32)NxMSadKernel_funcPtrArray[!!(ASM_TYPES & AVX2_MASK)][puWidth >> 3](&(contextPtr->lcuSrcPtr[puLcuBufferIndex]), contextPtr->lcuSrcStride, &(posjBuffer[searchRegionIndex]), contextPtr->interpolatedStride, puHeight, puWidth);
                 *pBestMV = ((EB_U16)yMvHalf[4] << 16) | ((EB_U16)xMvHalf[4]);
                 *pBestSsd = (EB_U32)distortionTopLeftPosition;
             }
@@ -932,12 +932,12 @@ static void PU_HalfPelRefinement(
         distortionTopRightPosition = (contextPtr->fractionalSearchMethod == SSD_SEARCH) ?
             SpatialFullDistortionKernel_funcPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1][Log2f(puWidth) - 2](&(contextPtr->lcuSrcPtr[puLcuBufferIndex]), contextPtr->lcuSrcStride, &(posjBuffer[searchRegionIndex]), contextPtr->interpolatedStride, puHeight, puWidth) :
             (contextPtr->fractionalSearchMethod == SUB_SAD_SEARCH) ?
-                (NxMSadKernel_funcPtrArray[(ASM_TYPES & AVX2_MASK) && 1][puWidth >> 3](&(contextPtr->lcuSrcPtr[puLcuBufferIndex]), contextPtr->lcuSrcStride << 1, &(posjBuffer[searchRegionIndex]), contextPtr->interpolatedStride << 1, puHeight >> 1, puWidth)) << 1 :
-                NxMSadKernel_funcPtrArray[(ASM_TYPES & AVX2_MASK) && 1][puWidth >> 3](&(contextPtr->lcuSrcPtr[puLcuBufferIndex]), contextPtr->lcuSrcStride, &(posjBuffer[searchRegionIndex]), contextPtr->interpolatedStride, puHeight, puWidth);
+                (NxMSadKernel_funcPtrArray[!!(ASM_TYPES & AVX2_MASK)][puWidth >> 3](&(contextPtr->lcuSrcPtr[puLcuBufferIndex]), contextPtr->lcuSrcStride << 1, &(posjBuffer[searchRegionIndex]), contextPtr->interpolatedStride << 1, puHeight >> 1, puWidth)) << 1 :
+                NxMSadKernel_funcPtrArray[!!(ASM_TYPES & AVX2_MASK)][puWidth >> 3](&(contextPtr->lcuSrcPtr[puLcuBufferIndex]), contextPtr->lcuSrcStride, &(posjBuffer[searchRegionIndex]), contextPtr->interpolatedStride, puHeight, puWidth);
 
         if (contextPtr->fractionalSearchMethod == SSD_SEARCH) {
             if (distortionTopRightPosition < *pBestSsd) {
-                *pBestSad = (EB_U32)NxMSadKernel_funcPtrArray[(ASM_TYPES & AVX2_MASK) && 1][puWidth >> 3](&(contextPtr->lcuSrcPtr[puLcuBufferIndex]), contextPtr->lcuSrcStride, &(posjBuffer[searchRegionIndex]), contextPtr->interpolatedStride, puHeight, puWidth);
+                *pBestSad = (EB_U32)NxMSadKernel_funcPtrArray[!!(ASM_TYPES & AVX2_MASK)][puWidth >> 3](&(contextPtr->lcuSrcPtr[puLcuBufferIndex]), contextPtr->lcuSrcStride, &(posjBuffer[searchRegionIndex]), contextPtr->interpolatedStride, puHeight, puWidth);
                 *pBestMV = ((EB_U16)yMvHalf[5] << 16) | ((EB_U16)xMvHalf[5]);
                 *pBestSsd = (EB_U32)distortionTopRightPosition;
             }
@@ -955,12 +955,12 @@ static void PU_HalfPelRefinement(
         distortionBottomRightPosition = (contextPtr->fractionalSearchMethod == SSD_SEARCH) ?
             SpatialFullDistortionKernel_funcPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1][Log2f(puWidth) - 2](&(contextPtr->lcuSrcPtr[puLcuBufferIndex]), contextPtr->lcuSrcStride, &(posjBuffer[searchRegionIndex]), contextPtr->interpolatedStride, puHeight, puWidth) :
             (contextPtr->fractionalSearchMethod == SUB_SAD_SEARCH) ?
-                (NxMSadKernel_funcPtrArray[(ASM_TYPES & AVX2_MASK) && 1][puWidth >> 3](&(contextPtr->lcuSrcPtr[puLcuBufferIndex]), contextPtr->lcuSrcStride << 1, &(posjBuffer[searchRegionIndex]), contextPtr->interpolatedStride << 1, puHeight >> 1, puWidth)) << 1 :
-                NxMSadKernel_funcPtrArray[(ASM_TYPES & AVX2_MASK) && 1][puWidth >> 3](&(contextPtr->lcuSrcPtr[puLcuBufferIndex]), contextPtr->lcuSrcStride, &(posjBuffer[searchRegionIndex]), contextPtr->interpolatedStride, puHeight, puWidth);
+                (NxMSadKernel_funcPtrArray[!!(ASM_TYPES & AVX2_MASK)][puWidth >> 3](&(contextPtr->lcuSrcPtr[puLcuBufferIndex]), contextPtr->lcuSrcStride << 1, &(posjBuffer[searchRegionIndex]), contextPtr->interpolatedStride << 1, puHeight >> 1, puWidth)) << 1 :
+                NxMSadKernel_funcPtrArray[!!(ASM_TYPES & AVX2_MASK)][puWidth >> 3](&(contextPtr->lcuSrcPtr[puLcuBufferIndex]), contextPtr->lcuSrcStride, &(posjBuffer[searchRegionIndex]), contextPtr->interpolatedStride, puHeight, puWidth);
 
         if (contextPtr->fractionalSearchMethod == SSD_SEARCH) {
             if (distortionBottomRightPosition < *pBestSsd) {
-                *pBestSad = (EB_U32)NxMSadKernel_funcPtrArray[(ASM_TYPES & AVX2_MASK) && 1][puWidth >> 3](&(contextPtr->lcuSrcPtr[puLcuBufferIndex]), contextPtr->lcuSrcStride, &(posjBuffer[searchRegionIndex]), contextPtr->interpolatedStride, puHeight, puWidth);
+                *pBestSad = (EB_U32)NxMSadKernel_funcPtrArray[!!(ASM_TYPES & AVX2_MASK)][puWidth >> 3](&(contextPtr->lcuSrcPtr[puLcuBufferIndex]), contextPtr->lcuSrcStride, &(posjBuffer[searchRegionIndex]), contextPtr->interpolatedStride, puHeight, puWidth);
                 *pBestMV = ((EB_U16)yMvHalf[6] << 16) | ((EB_U16)xMvHalf[6]);
                 *pBestSsd = (EB_U32)distortionBottomRightPosition;
             }
@@ -978,12 +978,12 @@ static void PU_HalfPelRefinement(
         distortionBottomLeftPosition = (contextPtr->fractionalSearchMethod == SSD_SEARCH) ?
             SpatialFullDistortionKernel_funcPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1][Log2f(puWidth) - 2](&(contextPtr->lcuSrcPtr[puLcuBufferIndex]), contextPtr->lcuSrcStride, &(posjBuffer[searchRegionIndex]), contextPtr->interpolatedStride, puHeight, puWidth) :
             (contextPtr->fractionalSearchMethod == SUB_SAD_SEARCH) ?
-                (NxMSadKernel_funcPtrArray[(ASM_TYPES & AVX2_MASK) && 1][puWidth >> 3](&(contextPtr->lcuSrcPtr[puLcuBufferIndex]), contextPtr->lcuSrcStride << 1, &(posjBuffer[searchRegionIndex]), contextPtr->interpolatedStride << 1, puHeight >> 1, puWidth)) << 1 :
-                (NxMSadKernel_funcPtrArray[(ASM_TYPES & AVX2_MASK) && 1][puWidth >> 3](&(contextPtr->lcuSrcPtr[puLcuBufferIndex]), contextPtr->lcuSrcStride, &(posjBuffer[searchRegionIndex]), contextPtr->interpolatedStride, puHeight, puWidth));
+                (NxMSadKernel_funcPtrArray[!!(ASM_TYPES & AVX2_MASK)][puWidth >> 3](&(contextPtr->lcuSrcPtr[puLcuBufferIndex]), contextPtr->lcuSrcStride << 1, &(posjBuffer[searchRegionIndex]), contextPtr->interpolatedStride << 1, puHeight >> 1, puWidth)) << 1 :
+                (NxMSadKernel_funcPtrArray[!!(ASM_TYPES & AVX2_MASK)][puWidth >> 3](&(contextPtr->lcuSrcPtr[puLcuBufferIndex]), contextPtr->lcuSrcStride, &(posjBuffer[searchRegionIndex]), contextPtr->interpolatedStride, puHeight, puWidth));
 
         if (contextPtr->fractionalSearchMethod == SSD_SEARCH) {
             if (distortionBottomLeftPosition < *pBestSsd) {
-                *pBestSad = (EB_U32)(NxMSadKernel_funcPtrArray[(ASM_TYPES & AVX2_MASK) && 1][puWidth >> 3](&(contextPtr->lcuSrcPtr[puLcuBufferIndex]), contextPtr->lcuSrcStride, &(posjBuffer[searchRegionIndex]), contextPtr->interpolatedStride, puHeight, puWidth));
+                *pBestSad = (EB_U32)(NxMSadKernel_funcPtrArray[!!(ASM_TYPES & AVX2_MASK)][puWidth >> 3](&(contextPtr->lcuSrcPtr[puLcuBufferIndex]), contextPtr->lcuSrcStride, &(posjBuffer[searchRegionIndex]), contextPtr->interpolatedStride, puHeight, puWidth));
                 *pBestMV = ((EB_U16)yMvHalf[7] << 16) | ((EB_U16)xMvHalf[7]);
                 *pBestSsd = (EB_U32)distortionBottomLeftPosition;
             }
@@ -1937,7 +1937,7 @@ void HmeOneQuadrantLevel0(
 #ifndef NON_AVX512_SUPPORT
 	    if (((searchAreaWidth & 15) == 0) && ((ASM_TYPES & AVX512_MASK) && 1))
 #else
-        if (((searchAreaWidth & 15) == 0) && ((ASM_TYPES & AVX2_MASK) && 1))
+        if (((searchAreaWidth & 15) == 0) && (!!(ASM_TYPES & AVX2_MASK)))
 #endif
 	    {
 #ifndef NON_AVX512_SUPPORT
@@ -2106,7 +2106,7 @@ void HmeLevel0(
 #ifndef NON_AVX512_SUPPORT
         if (((searchAreaWidth & 15) == 0) && ((ASM_TYPES & AVX512_MASK) && 1))
 #else
-        if (((searchAreaWidth & 15) == 0) && ((ASM_TYPES & AVX2_MASK) && 1))
+        if (((searchAreaWidth & 15) == 0) && (!!(ASM_TYPES & AVX2_MASK)))
 #endif
 		{
 #ifndef NON_AVX512_SUPPORT
@@ -2146,7 +2146,7 @@ void HmeLevel0(
 		else
 		    {
 			    // Put the first search location into level0 results
-			    NxMSadLoopKernel_funcPtrArray[(ASM_TYPES & AVX2_MASK) && 1](
+			    NxMSadLoopKernel_funcPtrArray[!!(ASM_TYPES & AVX2_MASK)](
 				    &contextPtr->sixteenthLcuBuffer[0],
 				    contextPtr->sixteenthLcuBufferStride,
 				    &sixteenthRefPicPtr->bufferY[searchRegionIndex],
@@ -2268,7 +2268,7 @@ void HmeLevel1(
 	if (((lcuWidth & 7) == 0) || (lcuWidth == 4))
 	{
 		// Put the first search location into level0 results
-		NxMSadLoopKernel_funcPtrArray[(ASM_TYPES & AVX2_MASK) && 1](
+		NxMSadLoopKernel_funcPtrArray[!!(ASM_TYPES & AVX2_MASK)](
 			&contextPtr->quarterLcuBuffer[0],
 			contextPtr->quarterLcuBufferStride * 2,
 			&quarterRefPicPtr->bufferY[searchRegionIndex],
@@ -2391,7 +2391,7 @@ void HmeLevel2(
 	if ((((lcuWidth & 7) == 0) && (lcuWidth != 40) && (lcuWidth != 56)))
 	{
 		// Put the first search location into level0 results
-		NxMSadLoopKernel_funcPtrArray[(ASM_TYPES & AVX2_MASK) && 1](
+		NxMSadLoopKernel_funcPtrArray[!!(ASM_TYPES & AVX2_MASK)](
 			contextPtr->lcuSrcPtr,
 			contextPtr->lcuSrcStride * 2,
 			&refPicPtr->bufferY[searchRegionIndex],
@@ -2966,7 +2966,7 @@ EB_ERRORTYPE CheckZeroZeroCenter(
 	searchRegionIndex = (EB_S16)refPicPtr->originX + originX +
 		((EB_S16)refPicPtr->originY + originY) * refPicPtr->strideY;
 
-	zeroMvSad = NxMSadKernel_funcPtrArray[(ASM_TYPES & AVX2_MASK) && 1][lcuWidth >> 3](
+	zeroMvSad = NxMSadKernel_funcPtrArray[!!(ASM_TYPES & AVX2_MASK)][lcuWidth >> 3](
 		contextPtr->lcuSrcPtr,
 		contextPtr->lcuSrcStride << subsampleSad,
 		&(refPicPtr->bufferY[searchRegionIndex]),
@@ -3005,7 +3005,7 @@ EB_ERRORTYPE CheckZeroZeroCenter(
 	searchRegionIndex = (EB_S16)(refPicPtr->originX + originX) + *xSearchCenter +
 		((EB_S16)(refPicPtr->originY + originY) + *ySearchCenter) * refPicPtr->strideY;
 
-	hmeMvSad = NxMSadKernel_funcPtrArray[(ASM_TYPES & AVX2_MASK) && 1][lcuWidth >> 3](
+	hmeMvSad = NxMSadKernel_funcPtrArray[!!(ASM_TYPES & AVX2_MASK)][lcuWidth >> 3](
 		contextPtr->lcuSrcPtr,
 		contextPtr->lcuSrcStride << subsampleSad,
 		&(refPicPtr->bufferY[searchRegionIndex]),
@@ -3395,7 +3395,7 @@ static void TestSearchAreaBounds(
         ((EB_S16)refPicPtr->originY + originY) * refPicPtr->strideY;
 
     EB_U32 subsampleSad = 1;
-    EB_U64 zeroMvSad = NxMSadKernel_funcPtrArray[(ASM_TYPES & AVX2_MASK) && 1][lcuWidth >> 3](
+    EB_U64 zeroMvSad = NxMSadKernel_funcPtrArray[!!(ASM_TYPES & AVX2_MASK)][lcuWidth >> 3](
         contextPtr->lcuSrcPtr,
         contextPtr->lcuSrcStride << subsampleSad,
         &(refPicPtr->bufferY[searchRegionIndex]),
@@ -3430,7 +3430,7 @@ static void TestSearchAreaBounds(
         ySearchCenter;
 
 
-    EB_U64 MvASad = NxMSadKernel_funcPtrArray[(ASM_TYPES & AVX2_MASK) && 1][lcuWidth >> 3](
+    EB_U64 MvASad = NxMSadKernel_funcPtrArray[!!(ASM_TYPES & AVX2_MASK)][lcuWidth >> 3](
         contextPtr->lcuSrcPtr,
         contextPtr->lcuSrcStride << subsampleSad,
         &(refPicPtr->bufferY[searchRegionIndex]),
@@ -3475,7 +3475,7 @@ static void TestSearchAreaBounds(
     searchRegionIndex = (EB_S16)(refPicPtr->originX + originX) + xSearchCenter +
         ((EB_S16)(refPicPtr->originY + originY) + ySearchCenter) * refPicPtr->strideY;
 
-    EB_U64 MvBSad = NxMSadKernel_funcPtrArray[(ASM_TYPES & AVX2_MASK) && 1][lcuWidth >> 3](
+    EB_U64 MvBSad = NxMSadKernel_funcPtrArray[!!(ASM_TYPES & AVX2_MASK)][lcuWidth >> 3](
         contextPtr->lcuSrcPtr,
         contextPtr->lcuSrcStride << subsampleSad,
         &(refPicPtr->bufferY[searchRegionIndex]),
@@ -3521,7 +3521,7 @@ static void TestSearchAreaBounds(
     searchRegionIndex = (EB_S16)(refPicPtr->originX + originX) + xSearchCenter +
         ((EB_S16)(refPicPtr->originY + originY) + ySearchCenter) * refPicPtr->strideY;
 
-    EB_U64 MvCSad = NxMSadKernel_funcPtrArray[(ASM_TYPES & AVX2_MASK) && 1][lcuWidth >> 3](
+    EB_U64 MvCSad = NxMSadKernel_funcPtrArray[!!(ASM_TYPES & AVX2_MASK)][lcuWidth >> 3](
         contextPtr->lcuSrcPtr,
         contextPtr->lcuSrcStride << subsampleSad,
         &(refPicPtr->bufferY[searchRegionIndex]),
@@ -3561,7 +3561,7 @@ static void TestSearchAreaBounds(
         ySearchCenter;
     searchRegionIndex = (EB_S16)(refPicPtr->originX + originX) + xSearchCenter +
         ((EB_S16)(refPicPtr->originY + originY) + ySearchCenter) * refPicPtr->strideY;
-    EB_U64 MvDSad = NxMSadKernel_funcPtrArray[(ASM_TYPES & AVX2_MASK) && 1][lcuWidth >> 3](
+    EB_U64 MvDSad = NxMSadKernel_funcPtrArray[!!(ASM_TYPES & AVX2_MASK)][lcuWidth >> 3](
         contextPtr->lcuSrcPtr,
         contextPtr->lcuSrcStride << subsampleSad,
         &(refPicPtr->bufferY[searchRegionIndex]),
@@ -3604,7 +3604,7 @@ static void TestSearchAreaBounds(
         searchRegionIndex = (EB_S16)(refPicPtr->originX + originX) + xSearchCenter +
             ((EB_S16)(refPicPtr->originY + originY) + ySearchCenter) * refPicPtr->strideY;
 
-        EB_U64 directMvSad = NxMSadKernel_funcPtrArray[(ASM_TYPES & AVX2_MASK) && 1][lcuWidth >> 3](
+        EB_U64 directMvSad = NxMSadKernel_funcPtrArray[!!(ASM_TYPES & AVX2_MASK)][lcuWidth >> 3](
             contextPtr->lcuSrcPtr,
             contextPtr->lcuSrcStride << subsampleSad,
             &(refPicPtr->bufferY[searchRegionIndex]),
@@ -4446,7 +4446,7 @@ void IntraOpenLoopSearchTheseModesOutputBest(
 			(EB_U32)mode);
 
 		//Distortion
-		sadArray[candidateIndex] = (EB_U32)NxMSadKernel_funcPtrArray[(ASM_TYPES & AVX2_MASK) && 1][cuSize >> 3]( // Always SAD without weighting 
+		sadArray[candidateIndex] = (EB_U32)NxMSadKernel_funcPtrArray[!!(ASM_TYPES & AVX2_MASK)][cuSize >> 3]( // Always SAD without weighting 
 			src,
 			srcStride,
 			&(contextPtr->meContextPtr->lcuBuffer[0]),
@@ -4761,7 +4761,7 @@ EB_S32 GetInterIntraSadDistance(
         (EB_U32)1);
 
     //Distortion
-	stage1SadArray[0] = (EB_U32)NxMSadKernel_funcPtrArray[(ASM_TYPES & AVX2_MASK) && 1][cuSize >> 3]( // Always SAD without weighting 
+	stage1SadArray[0] = (EB_U32)NxMSadKernel_funcPtrArray[!!(ASM_TYPES & AVX2_MASK)][cuSize >> 3]( // Always SAD without weighting 
         src,
         inputPtr->strideY,
         &(contextPtr->meContextPtr->lcuBuffer[0]),
@@ -4916,7 +4916,7 @@ EB_U32 UpdateNeighborDcIntraPred(
 		contextPtr,
 		(EB_U32)INTRA_DC_MODE);
 
-	distortion = (EB_U32)NxMSadKernel_funcPtrArray[(ASM_TYPES & AVX2_MASK) && 1][cuSize >> 3]( // Always SAD without weighting 
+	distortion = (EB_U32)NxMSadKernel_funcPtrArray[!!(ASM_TYPES & AVX2_MASK)][cuSize >> 3]( // Always SAD without weighting 
 		&(inputPtr->bufferY[(inputPtr->originY + cuOriginY) * inputPtr->strideY + (inputPtr->originX + cuOriginX)]),
 		inputPtr->strideY,
 		&(contextPtr->meContextPtr->lcuBuffer[0]),
@@ -4945,7 +4945,7 @@ EB_ERRORTYPE OpenLoopIntraDC(
 
 	if ((cuSize == 32) || (cuSize == 16) || (cuSize == 8))
 	{
-        if ((ASM_TYPES & AVX2_MASK) && 1)
+        if (!!(ASM_TYPES & AVX2_MASK))
         {
             oisCuPtr[0].distortion = (EB_U32)UpdateNeighborDcIntraPred_AVX2_INTRIN(
                 contextPtr->intraRefPtr->yIntraReferenceArrayReverse,
@@ -5079,7 +5079,7 @@ EB_ERRORTYPE OpenLoopIntraSearchLcu(
 						(EB_U32)EB_INTRA_PLANAR);
 
 					//Distortion
-					oisCuPtr[0].distortion = (EB_U32)NxMSadKernel_funcPtrArray[(ASM_TYPES & AVX2_MASK) && 1][cuSize >> 3]( // Always SAD without weighting 
+					oisCuPtr[0].distortion = (EB_U32)NxMSadKernel_funcPtrArray[!!(ASM_TYPES & AVX2_MASK)][cuSize >> 3]( // Always SAD without weighting 
 						&(inputPtr->bufferY[(inputPtr->originY + cuOriginY) * inputPtr->strideY + (inputPtr->originX + cuOriginX)]),
 						inputPtr->strideY,
 						&(contextPtr->meContextPtr->lcuBuffer[0]),
@@ -5169,7 +5169,7 @@ EB_ERRORTYPE OpenLoopIntraSearchLcu(
 							openLoopIntraCandidateIndex);
 
 						//Distortion
-						sadDistortion = (EB_U32)NxMSadKernel_funcPtrArray[(ASM_TYPES & AVX2_MASK) && 1][cuSize >> 3](
+						sadDistortion = (EB_U32)NxMSadKernel_funcPtrArray[!!(ASM_TYPES & AVX2_MASK)][cuSize >> 3](
 							&(inputPtr->bufferY[(inputPtr->originY + cuOriginY) * inputPtr->strideY + (inputPtr->originX + cuOriginX)]),
 							inputPtr->strideY,
 							&(contextPtr->meContextPtr->lcuBuffer[0]),

--- a/Source/Lib/Codec/EbMotionEstimation.c
+++ b/Source/Lib/Codec/EbMotionEstimation.c
@@ -496,87 +496,87 @@ static void GetSearchPointResults(
 	//---- 16x16 : 0
 	blockIndex = 0;
 	searchPositionIndex = searchPositionTLIndex;
-	SadCalculation_8x8_16x16_funcPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1](srcPtr + blockIndex, srcStride, refPtr + searchPositionIndex, reflumaStride, &pBestSad8x8[0], &pBestSad16x16[0], &pBestMV8x8[0], &pBestMV16x16[0], currMV, &pSad16x16[0]);
+	SadCalculation_8x8_16x16_funcPtrArray[!!(ASM_TYPES & PREAVX2_MASK)](srcPtr + blockIndex, srcStride, refPtr + searchPositionIndex, reflumaStride, &pBestSad8x8[0], &pBestSad16x16[0], &pBestMV8x8[0], &pBestMV16x16[0], currMV, &pSad16x16[0]);
 
 	//---- 16x16 : 1
 	blockIndex = blockIndex + 16;
 	searchPositionIndex = searchPositionTLIndex + 16;
-    SadCalculation_8x8_16x16_funcPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1](srcPtr + blockIndex, srcStride, refPtr + searchPositionIndex, reflumaStride, &pBestSad8x8[4], &pBestSad16x16[1], &pBestMV8x8[4], &pBestMV16x16[1], currMV, &pSad16x16[1]);
+    SadCalculation_8x8_16x16_funcPtrArray[!!(ASM_TYPES & PREAVX2_MASK)](srcPtr + blockIndex, srcStride, refPtr + searchPositionIndex, reflumaStride, &pBestSad8x8[4], &pBestSad16x16[1], &pBestMV8x8[4], &pBestMV16x16[1], currMV, &pSad16x16[1]);
 
     //---- 16x16 : 4
 	blockIndex = blockIndex + 16;
 	searchPositionIndex = searchPositionIndex + 16;
-    SadCalculation_8x8_16x16_funcPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1](srcPtr + blockIndex, srcStride, refPtr + searchPositionIndex, reflumaStride, &pBestSad8x8[16], &pBestSad16x16[4], &pBestMV8x8[16], &pBestMV16x16[4], currMV, &pSad16x16[4]);
+    SadCalculation_8x8_16x16_funcPtrArray[!!(ASM_TYPES & PREAVX2_MASK)](srcPtr + blockIndex, srcStride, refPtr + searchPositionIndex, reflumaStride, &pBestSad8x8[16], &pBestSad16x16[4], &pBestMV8x8[16], &pBestMV16x16[4], currMV, &pSad16x16[4]);
 
 
 	//---- 16x16 : 5
 	blockIndex = blockIndex + 16;
 	searchPositionIndex = searchPositionIndex + 16;
-    SadCalculation_8x8_16x16_funcPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1](srcPtr + blockIndex, srcStride, refPtr + searchPositionIndex, reflumaStride, &pBestSad8x8[20], &pBestSad16x16[5], &pBestMV8x8[20], &pBestMV16x16[5], currMV, &pSad16x16[5]);
+    SadCalculation_8x8_16x16_funcPtrArray[!!(ASM_TYPES & PREAVX2_MASK)](srcPtr + blockIndex, srcStride, refPtr + searchPositionIndex, reflumaStride, &pBestSad8x8[20], &pBestSad16x16[5], &pBestMV8x8[20], &pBestMV16x16[5], currMV, &pSad16x16[5]);
 
 
 	//---- 16x16 : 2
 	blockIndex = srcNext16x16Offset;
 	searchPositionIndex = searchPositionTLIndex + refNext16x16Offset;
-    SadCalculation_8x8_16x16_funcPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1](srcPtr + blockIndex, srcStride, refPtr + searchPositionIndex, reflumaStride, &pBestSad8x8[8], &pBestSad16x16[2], &pBestMV8x8[8], &pBestMV16x16[2], currMV, &pSad16x16[2]);
+    SadCalculation_8x8_16x16_funcPtrArray[!!(ASM_TYPES & PREAVX2_MASK)](srcPtr + blockIndex, srcStride, refPtr + searchPositionIndex, reflumaStride, &pBestSad8x8[8], &pBestSad16x16[2], &pBestMV8x8[8], &pBestMV16x16[2], currMV, &pSad16x16[2]);
 
     //---- 16x16 : 3
 	blockIndex = blockIndex + 16;
 	searchPositionIndex = searchPositionIndex + 16;
-	SadCalculation_8x8_16x16_funcPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1](srcPtr + blockIndex, srcStride, refPtr + searchPositionIndex, reflumaStride, &pBestSad8x8[12], &pBestSad16x16[3], &pBestMV8x8[12], &pBestMV16x16[3], currMV, &pSad16x16[3]);
+	SadCalculation_8x8_16x16_funcPtrArray[!!(ASM_TYPES & PREAVX2_MASK)](srcPtr + blockIndex, srcStride, refPtr + searchPositionIndex, reflumaStride, &pBestSad8x8[12], &pBestSad16x16[3], &pBestMV8x8[12], &pBestMV16x16[3], currMV, &pSad16x16[3]);
 
     //---- 16x16 : 6
 	blockIndex = blockIndex + 16;
 	searchPositionIndex = searchPositionIndex + 16;
-	SadCalculation_8x8_16x16_funcPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1](srcPtr + blockIndex, srcStride, refPtr + searchPositionIndex, reflumaStride, &pBestSad8x8[24], &pBestSad16x16[6], &pBestMV8x8[24], &pBestMV16x16[6], currMV, &pSad16x16[6]);
+	SadCalculation_8x8_16x16_funcPtrArray[!!(ASM_TYPES & PREAVX2_MASK)](srcPtr + blockIndex, srcStride, refPtr + searchPositionIndex, reflumaStride, &pBestSad8x8[24], &pBestSad16x16[6], &pBestMV8x8[24], &pBestMV16x16[6], currMV, &pSad16x16[6]);
 
     //---- 16x16 : 7
 	blockIndex = blockIndex + 16;
 	searchPositionIndex = searchPositionIndex + 16;
-    SadCalculation_8x8_16x16_funcPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1](srcPtr + blockIndex, srcStride, refPtr + searchPositionIndex, reflumaStride, &pBestSad8x8[28], &pBestSad16x16[7], &pBestMV8x8[28], &pBestMV16x16[7], currMV, &pSad16x16[7]);
+    SadCalculation_8x8_16x16_funcPtrArray[!!(ASM_TYPES & PREAVX2_MASK)](srcPtr + blockIndex, srcStride, refPtr + searchPositionIndex, reflumaStride, &pBestSad8x8[28], &pBestSad16x16[7], &pBestMV8x8[28], &pBestMV16x16[7], currMV, &pSad16x16[7]);
 
 
 	//---- 16x16 : 8
 	blockIndex = (srcNext16x16Offset << 1);
 	searchPositionIndex = searchPositionTLIndex + (refNext16x16Offset << 1);
-	SadCalculation_8x8_16x16_funcPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1](srcPtr + blockIndex, srcStride, refPtr + searchPositionIndex, reflumaStride, &pBestSad8x8[32], &pBestSad16x16[8], &pBestMV8x8[32], &pBestMV16x16[8], currMV, &pSad16x16[8]);
+	SadCalculation_8x8_16x16_funcPtrArray[!!(ASM_TYPES & PREAVX2_MASK)](srcPtr + blockIndex, srcStride, refPtr + searchPositionIndex, reflumaStride, &pBestSad8x8[32], &pBestSad16x16[8], &pBestMV8x8[32], &pBestMV16x16[8], currMV, &pSad16x16[8]);
 
     //---- 16x16 : 9
 	blockIndex = blockIndex + 16;
 	searchPositionIndex = searchPositionIndex + 16;
-    SadCalculation_8x8_16x16_funcPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1](srcPtr + blockIndex, srcStride, refPtr + searchPositionIndex, reflumaStride, &pBestSad8x8[36], &pBestSad16x16[9], &pBestMV8x8[36], &pBestMV16x16[9], currMV, &pSad16x16[9]);
+    SadCalculation_8x8_16x16_funcPtrArray[!!(ASM_TYPES & PREAVX2_MASK)](srcPtr + blockIndex, srcStride, refPtr + searchPositionIndex, reflumaStride, &pBestSad8x8[36], &pBestSad16x16[9], &pBestMV8x8[36], &pBestMV16x16[9], currMV, &pSad16x16[9]);
 
     //---- 16x16 : 12
 	blockIndex = blockIndex + 16;
 	searchPositionIndex = searchPositionIndex + 16;
-    SadCalculation_8x8_16x16_funcPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1](srcPtr + blockIndex, srcStride, refPtr + searchPositionIndex, reflumaStride, &pBestSad8x8[48], &pBestSad16x16[12], &pBestMV8x8[48], &pBestMV16x16[12], currMV, &pSad16x16[12]);
+    SadCalculation_8x8_16x16_funcPtrArray[!!(ASM_TYPES & PREAVX2_MASK)](srcPtr + blockIndex, srcStride, refPtr + searchPositionIndex, reflumaStride, &pBestSad8x8[48], &pBestSad16x16[12], &pBestMV8x8[48], &pBestMV16x16[12], currMV, &pSad16x16[12]);
 
     //---- 16x16 : 13
 	blockIndex = blockIndex + 16;
 	searchPositionIndex = searchPositionIndex + 16;
-    SadCalculation_8x8_16x16_funcPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1](srcPtr + blockIndex, srcStride, refPtr + searchPositionIndex, reflumaStride, &pBestSad8x8[52], &pBestSad16x16[13], &pBestMV8x8[52], &pBestMV16x16[13], currMV, &pSad16x16[13]);
+    SadCalculation_8x8_16x16_funcPtrArray[!!(ASM_TYPES & PREAVX2_MASK)](srcPtr + blockIndex, srcStride, refPtr + searchPositionIndex, reflumaStride, &pBestSad8x8[52], &pBestSad16x16[13], &pBestMV8x8[52], &pBestMV16x16[13], currMV, &pSad16x16[13]);
 
 	//---- 16x16 : 10
 	blockIndex = (srcNext16x16Offset * 3);
 	searchPositionIndex = searchPositionTLIndex + (refNext16x16Offset * 3);
-    SadCalculation_8x8_16x16_funcPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1](srcPtr + blockIndex, srcStride, refPtr + searchPositionIndex, reflumaStride, &pBestSad8x8[40], &pBestSad16x16[10], &pBestMV8x8[40], &pBestMV16x16[10], currMV, &pSad16x16[10]);
+    SadCalculation_8x8_16x16_funcPtrArray[!!(ASM_TYPES & PREAVX2_MASK)](srcPtr + blockIndex, srcStride, refPtr + searchPositionIndex, reflumaStride, &pBestSad8x8[40], &pBestSad16x16[10], &pBestMV8x8[40], &pBestMV16x16[10], currMV, &pSad16x16[10]);
 
     //---- 16x16 : 11
 	blockIndex = blockIndex + 16;
 	searchPositionIndex = searchPositionIndex + 16;
-    SadCalculation_8x8_16x16_funcPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1](srcPtr + blockIndex, srcStride, refPtr + searchPositionIndex, reflumaStride, &pBestSad8x8[44], &pBestSad16x16[11], &pBestMV8x8[44], &pBestMV16x16[11], currMV, &pSad16x16[11]);
+    SadCalculation_8x8_16x16_funcPtrArray[!!(ASM_TYPES & PREAVX2_MASK)](srcPtr + blockIndex, srcStride, refPtr + searchPositionIndex, reflumaStride, &pBestSad8x8[44], &pBestSad16x16[11], &pBestMV8x8[44], &pBestMV16x16[11], currMV, &pSad16x16[11]);
 
     //---- 16x16 : 14
 	blockIndex = blockIndex + 16;
 	searchPositionIndex = searchPositionIndex + 16;
-    SadCalculation_8x8_16x16_funcPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1](srcPtr + blockIndex, srcStride, refPtr + searchPositionIndex, reflumaStride, &pBestSad8x8[56], &pBestSad16x16[14], &pBestMV8x8[56], &pBestMV16x16[14], currMV, &pSad16x16[14]);
+    SadCalculation_8x8_16x16_funcPtrArray[!!(ASM_TYPES & PREAVX2_MASK)](srcPtr + blockIndex, srcStride, refPtr + searchPositionIndex, reflumaStride, &pBestSad8x8[56], &pBestSad16x16[14], &pBestMV8x8[56], &pBestMV16x16[14], currMV, &pSad16x16[14]);
 
     //---- 16x16 : 15
 	blockIndex = blockIndex + 16;
 	searchPositionIndex = searchPositionIndex + 16;
-    SadCalculation_8x8_16x16_funcPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1](srcPtr + blockIndex, srcStride, refPtr + searchPositionIndex, reflumaStride, &pBestSad8x8[60], &pBestSad16x16[15], &pBestMV8x8[60], &pBestMV16x16[15], currMV, &pSad16x16[15]);
+    SadCalculation_8x8_16x16_funcPtrArray[!!(ASM_TYPES & PREAVX2_MASK)](srcPtr + blockIndex, srcStride, refPtr + searchPositionIndex, reflumaStride, &pBestSad8x8[60], &pBestSad16x16[15], &pBestMV8x8[60], &pBestMV16x16[15], currMV, &pSad16x16[15]);
 
-	SadCalculation_32x32_64x64_funcPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1](pSad16x16, pBestSad32x32, pBestSad64x64, pBestMV32x32, pBestMV64x64, currMV);
+	SadCalculation_32x32_64x64_funcPtrArray[!!(ASM_TYPES & PREAVX2_MASK)](pSad16x16, pBestSad32x32, pBestSad64x64, pBestMV32x32, pBestMV64x64, currMV);
 
 }
 
@@ -684,7 +684,7 @@ void InterpolateSearchRegionAVC(
 	// Half pel interpolation of the search region using f1 -> posbBuffer
 	if (searchAreaWidthForAsm){
 
-		AvcStyleUniPredLumaIFFunctionPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1][1](
+		AvcStyleUniPredLumaIFFunctionPtrArray[!!(ASM_TYPES & PREAVX2_MASK)][1](
 			searchRegionBuffer - (ME_FILTER_TAP >> 1) * lumaStride - (ME_FILTER_TAP >> 1) + 1,
 			lumaStride,
 			contextPtr->posbBuffer[listIndex][0],
@@ -697,7 +697,7 @@ void InterpolateSearchRegionAVC(
 
 	// Half pel interpolation of the search region using f1 -> poshBuffer
 	if (searchAreaWidthForAsm){
-		AvcStyleUniPredLumaIFFunctionPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1][2](
+		AvcStyleUniPredLumaIFFunctionPtrArray[!!(ASM_TYPES & PREAVX2_MASK)][2](
 			searchRegionBuffer - (ME_FILTER_TAP >> 1) * lumaStride - 1 + lumaStride,
 			lumaStride,
 			contextPtr->poshBuffer[listIndex][0],
@@ -710,7 +710,7 @@ void InterpolateSearchRegionAVC(
 
 	if (searchAreaWidthForAsm){
 		// Half pel interpolation of the search region using f1 -> posjBuffer
-		AvcStyleUniPredLumaIFFunctionPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1][2](
+		AvcStyleUniPredLumaIFFunctionPtrArray[!!(ASM_TYPES & PREAVX2_MASK)][2](
 			contextPtr->posbBuffer[listIndex][0] + contextPtr->interpolatedStride,
 			contextPtr->interpolatedStride,
 			contextPtr->posjBuffer[listIndex][0],
@@ -796,7 +796,7 @@ static void PU_HalfPelRefinement(
 
     // Compute SSD for the best full search candidate
     if (contextPtr->fractionalSearchMethod == SSD_SEARCH) {
-        *pBestSsd = (EB_U32) SpatialFullDistortionKernel_funcPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1][Log2f(puWidth) - 2](
+        *pBestSsd = (EB_U32) SpatialFullDistortionKernel_funcPtrArray[!!(ASM_TYPES & PREAVX2_MASK)][Log2f(puWidth) - 2](
             &(contextPtr->lcuSrcPtr[puLcuBufferIndex]),
             contextPtr->lcuSrcStride,
             &(refBuffer[ySearchIndex * refStride + xSearchIndex]),
@@ -813,7 +813,7 @@ static void PU_HalfPelRefinement(
 		searchRegionIndex = xSearchIndex + (EB_S16)contextPtr->interpolatedStride * ySearchIndex;
 
         distortionLeftPosition = (contextPtr->fractionalSearchMethod == SSD_SEARCH) ?            
-            SpatialFullDistortionKernel_funcPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1][Log2f(puWidth) - 2](&(contextPtr->lcuSrcPtr[puLcuBufferIndex]), contextPtr->lcuSrcStride, &(posbBuffer[searchRegionIndex]), contextPtr->interpolatedStride, puHeight, puWidth) :
+            SpatialFullDistortionKernel_funcPtrArray[!!(ASM_TYPES & PREAVX2_MASK)][Log2f(puWidth) - 2](&(contextPtr->lcuSrcPtr[puLcuBufferIndex]), contextPtr->lcuSrcStride, &(posbBuffer[searchRegionIndex]), contextPtr->interpolatedStride, puHeight, puWidth) :
             (contextPtr->fractionalSearchMethod == SUB_SAD_SEARCH) ?
                 (NxMSadKernel_funcPtrArray[!!(ASM_TYPES & AVX2_MASK)][puWidth >> 3](&(contextPtr->lcuSrcPtr[puLcuBufferIndex]), contextPtr->lcuSrcStride << 1, &(posbBuffer[searchRegionIndex]), contextPtr->interpolatedStride << 1, puHeight >> 1, puWidth)) << 1 :
                 NxMSadKernel_funcPtrArray[!!(ASM_TYPES & AVX2_MASK)][puWidth >> 3](&(contextPtr->lcuSrcPtr[puLcuBufferIndex]), contextPtr->lcuSrcStride, &(posbBuffer[searchRegionIndex]), contextPtr->interpolatedStride, puHeight, puWidth);
@@ -836,7 +836,7 @@ static void PU_HalfPelRefinement(
 		searchRegionIndex++;
 
         distortionRightPosition = (contextPtr->fractionalSearchMethod == SSD_SEARCH) ? 
-            SpatialFullDistortionKernel_funcPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1][Log2f(puWidth) - 2](&(contextPtr->lcuSrcPtr[puLcuBufferIndex]), contextPtr->lcuSrcStride, &(posbBuffer[searchRegionIndex]), contextPtr->interpolatedStride, puHeight, puWidth) :
+            SpatialFullDistortionKernel_funcPtrArray[!!(ASM_TYPES & PREAVX2_MASK)][Log2f(puWidth) - 2](&(contextPtr->lcuSrcPtr[puLcuBufferIndex]), contextPtr->lcuSrcStride, &(posbBuffer[searchRegionIndex]), contextPtr->interpolatedStride, puHeight, puWidth) :
             (contextPtr->fractionalSearchMethod == SUB_SAD_SEARCH) ?
                 (NxMSadKernel_funcPtrArray[!!(ASM_TYPES & AVX2_MASK)][puWidth >> 3](&(contextPtr->lcuSrcPtr[puLcuBufferIndex]), contextPtr->lcuSrcStride << 1, &(posbBuffer[searchRegionIndex]), contextPtr->interpolatedStride << 1, puHeight >> 1, puWidth)) << 1 :
                  NxMSadKernel_funcPtrArray[!!(ASM_TYPES & AVX2_MASK)][puWidth >> 3](&(contextPtr->lcuSrcPtr[puLcuBufferIndex]), contextPtr->lcuSrcStride, &(posbBuffer[searchRegionIndex]), contextPtr->interpolatedStride, puHeight, puWidth);
@@ -860,7 +860,7 @@ static void PU_HalfPelRefinement(
 		searchRegionIndex = xSearchIndex + (EB_S16)contextPtr->interpolatedStride * ySearchIndex;
 
         distortionTopPosition = (contextPtr->fractionalSearchMethod == SSD_SEARCH) ? 
-            SpatialFullDistortionKernel_funcPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1][Log2f(puWidth) - 2](&(contextPtr->lcuSrcPtr[puLcuBufferIndex]), contextPtr->lcuSrcStride, &(poshBuffer[searchRegionIndex]), contextPtr->interpolatedStride, puHeight, puWidth) :
+            SpatialFullDistortionKernel_funcPtrArray[!!(ASM_TYPES & PREAVX2_MASK)][Log2f(puWidth) - 2](&(contextPtr->lcuSrcPtr[puLcuBufferIndex]), contextPtr->lcuSrcStride, &(poshBuffer[searchRegionIndex]), contextPtr->interpolatedStride, puHeight, puWidth) :
             (contextPtr->fractionalSearchMethod == SUB_SAD_SEARCH) ?
                 (NxMSadKernel_funcPtrArray[!!(ASM_TYPES & AVX2_MASK)][puWidth >> 3](&(contextPtr->lcuSrcPtr[puLcuBufferIndex]), contextPtr->lcuSrcStride << 1, &(poshBuffer[searchRegionIndex]), contextPtr->interpolatedStride << 1, puHeight >> 1, puWidth)) << 1 :
                  NxMSadKernel_funcPtrArray[!!(ASM_TYPES & AVX2_MASK)][puWidth >> 3](&(contextPtr->lcuSrcPtr[puLcuBufferIndex]), contextPtr->lcuSrcStride, &(poshBuffer[searchRegionIndex]), contextPtr->interpolatedStride, puHeight, puWidth);
@@ -883,7 +883,7 @@ static void PU_HalfPelRefinement(
 		searchRegionIndex += (EB_S16)contextPtr->interpolatedStride;
 
         distortionBottomPosition = (contextPtr->fractionalSearchMethod == SSD_SEARCH) ? 
-            SpatialFullDistortionKernel_funcPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1][Log2f(puWidth) - 2](&(contextPtr->lcuSrcPtr[puLcuBufferIndex]), contextPtr->lcuSrcStride, &(poshBuffer[searchRegionIndex]), contextPtr->interpolatedStride, puHeight, puWidth) :
+            SpatialFullDistortionKernel_funcPtrArray[!!(ASM_TYPES & PREAVX2_MASK)][Log2f(puWidth) - 2](&(contextPtr->lcuSrcPtr[puLcuBufferIndex]), contextPtr->lcuSrcStride, &(poshBuffer[searchRegionIndex]), contextPtr->interpolatedStride, puHeight, puWidth) :
             (contextPtr->fractionalSearchMethod == SUB_SAD_SEARCH) ?
                 (NxMSadKernel_funcPtrArray[!!(ASM_TYPES & AVX2_MASK)][puWidth >> 3](&(contextPtr->lcuSrcPtr[puLcuBufferIndex]), contextPtr->lcuSrcStride << 1, &(poshBuffer[searchRegionIndex]), contextPtr->interpolatedStride << 1, puHeight >> 1, puWidth)) << 1 :
                 NxMSadKernel_funcPtrArray[!!(ASM_TYPES & AVX2_MASK)][puWidth >> 3](&(contextPtr->lcuSrcPtr[puLcuBufferIndex]), contextPtr->lcuSrcStride, &(poshBuffer[searchRegionIndex]), contextPtr->interpolatedStride, puHeight, puWidth);
@@ -906,7 +906,7 @@ static void PU_HalfPelRefinement(
 		searchRegionIndex = xSearchIndex + (EB_S16)contextPtr->interpolatedStride * ySearchIndex;
 
         distortionTopLeftPosition = (contextPtr->fractionalSearchMethod == SSD_SEARCH) ? 
-            SpatialFullDistortionKernel_funcPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1][Log2f(puWidth) - 2](&(contextPtr->lcuSrcPtr[puLcuBufferIndex]), contextPtr->lcuSrcStride, &(posjBuffer[searchRegionIndex]), contextPtr->interpolatedStride, puHeight, puWidth) :
+            SpatialFullDistortionKernel_funcPtrArray[!!(ASM_TYPES & PREAVX2_MASK)][Log2f(puWidth) - 2](&(contextPtr->lcuSrcPtr[puLcuBufferIndex]), contextPtr->lcuSrcStride, &(posjBuffer[searchRegionIndex]), contextPtr->interpolatedStride, puHeight, puWidth) :
             (contextPtr->fractionalSearchMethod == SUB_SAD_SEARCH) ?
                 (NxMSadKernel_funcPtrArray[!!(ASM_TYPES & AVX2_MASK)][puWidth >> 3](&(contextPtr->lcuSrcPtr[puLcuBufferIndex]), contextPtr->lcuSrcStride << 1, &(posjBuffer[searchRegionIndex]), contextPtr->interpolatedStride << 1, puHeight >> 1, puWidth)) << 1 :
                 NxMSadKernel_funcPtrArray[!!(ASM_TYPES & AVX2_MASK)][puWidth >> 3](&(contextPtr->lcuSrcPtr[puLcuBufferIndex]), contextPtr->lcuSrcStride, &(posjBuffer[searchRegionIndex]), contextPtr->interpolatedStride, puHeight, puWidth);
@@ -930,7 +930,7 @@ static void PU_HalfPelRefinement(
 		searchRegionIndex++;
 
         distortionTopRightPosition = (contextPtr->fractionalSearchMethod == SSD_SEARCH) ?
-            SpatialFullDistortionKernel_funcPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1][Log2f(puWidth) - 2](&(contextPtr->lcuSrcPtr[puLcuBufferIndex]), contextPtr->lcuSrcStride, &(posjBuffer[searchRegionIndex]), contextPtr->interpolatedStride, puHeight, puWidth) :
+            SpatialFullDistortionKernel_funcPtrArray[!!(ASM_TYPES & PREAVX2_MASK)][Log2f(puWidth) - 2](&(contextPtr->lcuSrcPtr[puLcuBufferIndex]), contextPtr->lcuSrcStride, &(posjBuffer[searchRegionIndex]), contextPtr->interpolatedStride, puHeight, puWidth) :
             (contextPtr->fractionalSearchMethod == SUB_SAD_SEARCH) ?
                 (NxMSadKernel_funcPtrArray[!!(ASM_TYPES & AVX2_MASK)][puWidth >> 3](&(contextPtr->lcuSrcPtr[puLcuBufferIndex]), contextPtr->lcuSrcStride << 1, &(posjBuffer[searchRegionIndex]), contextPtr->interpolatedStride << 1, puHeight >> 1, puWidth)) << 1 :
                 NxMSadKernel_funcPtrArray[!!(ASM_TYPES & AVX2_MASK)][puWidth >> 3](&(contextPtr->lcuSrcPtr[puLcuBufferIndex]), contextPtr->lcuSrcStride, &(posjBuffer[searchRegionIndex]), contextPtr->interpolatedStride, puHeight, puWidth);
@@ -953,7 +953,7 @@ static void PU_HalfPelRefinement(
 		searchRegionIndex += (EB_S16)contextPtr->interpolatedStride;
 
         distortionBottomRightPosition = (contextPtr->fractionalSearchMethod == SSD_SEARCH) ?
-            SpatialFullDistortionKernel_funcPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1][Log2f(puWidth) - 2](&(contextPtr->lcuSrcPtr[puLcuBufferIndex]), contextPtr->lcuSrcStride, &(posjBuffer[searchRegionIndex]), contextPtr->interpolatedStride, puHeight, puWidth) :
+            SpatialFullDistortionKernel_funcPtrArray[!!(ASM_TYPES & PREAVX2_MASK)][Log2f(puWidth) - 2](&(contextPtr->lcuSrcPtr[puLcuBufferIndex]), contextPtr->lcuSrcStride, &(posjBuffer[searchRegionIndex]), contextPtr->interpolatedStride, puHeight, puWidth) :
             (contextPtr->fractionalSearchMethod == SUB_SAD_SEARCH) ?
                 (NxMSadKernel_funcPtrArray[!!(ASM_TYPES & AVX2_MASK)][puWidth >> 3](&(contextPtr->lcuSrcPtr[puLcuBufferIndex]), contextPtr->lcuSrcStride << 1, &(posjBuffer[searchRegionIndex]), contextPtr->interpolatedStride << 1, puHeight >> 1, puWidth)) << 1 :
                 NxMSadKernel_funcPtrArray[!!(ASM_TYPES & AVX2_MASK)][puWidth >> 3](&(contextPtr->lcuSrcPtr[puLcuBufferIndex]), contextPtr->lcuSrcStride, &(posjBuffer[searchRegionIndex]), contextPtr->interpolatedStride, puHeight, puWidth);
@@ -976,7 +976,7 @@ static void PU_HalfPelRefinement(
 		searchRegionIndex--;
 
         distortionBottomLeftPosition = (contextPtr->fractionalSearchMethod == SSD_SEARCH) ?
-            SpatialFullDistortionKernel_funcPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1][Log2f(puWidth) - 2](&(contextPtr->lcuSrcPtr[puLcuBufferIndex]), contextPtr->lcuSrcStride, &(posjBuffer[searchRegionIndex]), contextPtr->interpolatedStride, puHeight, puWidth) :
+            SpatialFullDistortionKernel_funcPtrArray[!!(ASM_TYPES & PREAVX2_MASK)][Log2f(puWidth) - 2](&(contextPtr->lcuSrcPtr[puLcuBufferIndex]), contextPtr->lcuSrcStride, &(posjBuffer[searchRegionIndex]), contextPtr->interpolatedStride, puHeight, puWidth) :
             (contextPtr->fractionalSearchMethod == SUB_SAD_SEARCH) ?
                 (NxMSadKernel_funcPtrArray[!!(ASM_TYPES & AVX2_MASK)][puWidth >> 3](&(contextPtr->lcuSrcPtr[puLcuBufferIndex]), contextPtr->lcuSrcStride << 1, &(posjBuffer[searchRegionIndex]), contextPtr->interpolatedStride << 1, puHeight >> 1, puWidth)) << 1 :
                 (NxMSadKernel_funcPtrArray[!!(ASM_TYPES & AVX2_MASK)][puWidth >> 3](&(contextPtr->lcuSrcPtr[puLcuBufferIndex]), contextPtr->lcuSrcStride, &(posjBuffer[searchRegionIndex]), contextPtr->interpolatedStride, puHeight, puWidth));
@@ -1311,12 +1311,12 @@ static void PU_QuarterPelRefinementOnTheFly(
             dist = (contextPtr->fractionalSearchMethod == SSD_SEARCH) ?
                 CombinedAveragingSSD(&(contextPtr->lcuBuffer[puLcuBufferIndex]), MAX_LCU_SIZE, buf1[0] + searchRegionIndex1, buf1Stride[0], buf2[0] + searchRegionIndex2, buf2Stride[0], puHeight, puWidth) :
                 (contextPtr->fractionalSearchMethod == SUB_SAD_SEARCH) ?
-                    (NxMSadAveragingKernel_funcPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1][puWidth >> 3](&(contextPtr->lcuBuffer[puLcuBufferIndex]), MAX_LCU_SIZE << 1, buf1[0] + searchRegionIndex1, buf1Stride[0] << 1, buf2[0] + searchRegionIndex2, buf2Stride[0] << 1, puHeight >> 1, puWidth)) << 1 :
-                    NxMSadAveragingKernel_funcPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1][puWidth >> 3](&(contextPtr->lcuBuffer[puLcuBufferIndex]), MAX_LCU_SIZE, buf1[0] + searchRegionIndex1, buf1Stride[0], buf2[0] + searchRegionIndex2, buf2Stride[0], puHeight, puWidth);
+                    (NxMSadAveragingKernel_funcPtrArray[!!(ASM_TYPES & PREAVX2_MASK)][puWidth >> 3](&(contextPtr->lcuBuffer[puLcuBufferIndex]), MAX_LCU_SIZE << 1, buf1[0] + searchRegionIndex1, buf1Stride[0] << 1, buf2[0] + searchRegionIndex2, buf2Stride[0] << 1, puHeight >> 1, puWidth)) << 1 :
+                    NxMSadAveragingKernel_funcPtrArray[!!(ASM_TYPES & PREAVX2_MASK)][puWidth >> 3](&(contextPtr->lcuBuffer[puLcuBufferIndex]), MAX_LCU_SIZE, buf1[0] + searchRegionIndex1, buf1Stride[0], buf2[0] + searchRegionIndex2, buf2Stride[0], puHeight, puWidth);
 
             if (contextPtr->fractionalSearchMethod == SSD_SEARCH) {
                 if (dist < *pBestSsd) {
-                    *pBestSad = (EB_U32)NxMSadAveragingKernel_funcPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1][puWidth >> 3](&(contextPtr->lcuBuffer[puLcuBufferIndex]), MAX_LCU_SIZE, buf1[0] + searchRegionIndex1, buf1Stride[0], buf2[0] + searchRegionIndex2, buf2Stride[0], puHeight, puWidth);
+                    *pBestSad = (EB_U32)NxMSadAveragingKernel_funcPtrArray[!!(ASM_TYPES & PREAVX2_MASK)][puWidth >> 3](&(contextPtr->lcuBuffer[puLcuBufferIndex]), MAX_LCU_SIZE, buf1[0] + searchRegionIndex1, buf1Stride[0], buf2[0] + searchRegionIndex2, buf2Stride[0], puHeight, puWidth);
                     *pBestMV = ((EB_U16)yMvQuarter[0] << 16) | ((EB_U16)xMvQuarter[0]);
                     *pBestSsd = (EB_U32)dist;
                 }
@@ -1338,12 +1338,12 @@ static void PU_QuarterPelRefinementOnTheFly(
             dist = (contextPtr->fractionalSearchMethod == SSD_SEARCH) ?
                 CombinedAveragingSSD(&(contextPtr->lcuBuffer[puLcuBufferIndex]), MAX_LCU_SIZE, buf1[1] + searchRegionIndex1, buf1Stride[1], buf2[1] + searchRegionIndex2, buf2Stride[1], puHeight, puWidth) :
                 (contextPtr->fractionalSearchMethod == SUB_SAD_SEARCH) ?
-                    (NxMSadAveragingKernel_funcPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1][puWidth >> 3](&(contextPtr->lcuBuffer[puLcuBufferIndex]), MAX_LCU_SIZE << 1, buf1[1] + searchRegionIndex1, buf1Stride[1] << 1, buf2[1] + searchRegionIndex2, buf2Stride[1] << 1, puHeight >> 1, puWidth)) << 1 :
-                    NxMSadAveragingKernel_funcPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1][puWidth >> 3](&(contextPtr->lcuBuffer[puLcuBufferIndex]), MAX_LCU_SIZE, buf1[1] + searchRegionIndex1, buf1Stride[1], buf2[1] + searchRegionIndex2, buf2Stride[1], puHeight, puWidth);
+                    (NxMSadAveragingKernel_funcPtrArray[!!(ASM_TYPES & PREAVX2_MASK)][puWidth >> 3](&(contextPtr->lcuBuffer[puLcuBufferIndex]), MAX_LCU_SIZE << 1, buf1[1] + searchRegionIndex1, buf1Stride[1] << 1, buf2[1] + searchRegionIndex2, buf2Stride[1] << 1, puHeight >> 1, puWidth)) << 1 :
+                    NxMSadAveragingKernel_funcPtrArray[!!(ASM_TYPES & PREAVX2_MASK)][puWidth >> 3](&(contextPtr->lcuBuffer[puLcuBufferIndex]), MAX_LCU_SIZE, buf1[1] + searchRegionIndex1, buf1Stride[1], buf2[1] + searchRegionIndex2, buf2Stride[1], puHeight, puWidth);
 
             if (contextPtr->fractionalSearchMethod == SSD_SEARCH) {
                 if (dist < *pBestSsd) {
-                    *pBestSad = (EB_U32)NxMSadAveragingKernel_funcPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1][puWidth >> 3](&(contextPtr->lcuBuffer[puLcuBufferIndex]), MAX_LCU_SIZE, buf1[1] + searchRegionIndex1, buf1Stride[1], buf2[1] + searchRegionIndex2, buf2Stride[1], puHeight, puWidth);
+                    *pBestSad = (EB_U32)NxMSadAveragingKernel_funcPtrArray[!!(ASM_TYPES & PREAVX2_MASK)][puWidth >> 3](&(contextPtr->lcuBuffer[puLcuBufferIndex]), MAX_LCU_SIZE, buf1[1] + searchRegionIndex1, buf1Stride[1], buf2[1] + searchRegionIndex2, buf2Stride[1], puHeight, puWidth);
                     *pBestMV = ((EB_U16)yMvQuarter[1] << 16) | ((EB_U16)xMvQuarter[1]);
                     *pBestSsd = (EB_U32)dist;
                 }
@@ -1365,12 +1365,12 @@ static void PU_QuarterPelRefinementOnTheFly(
             dist = (contextPtr->fractionalSearchMethod == SSD_SEARCH) ?
                 CombinedAveragingSSD(&(contextPtr->lcuBuffer[puLcuBufferIndex]), MAX_LCU_SIZE, buf1[2] + searchRegionIndex1, buf1Stride[2], buf2[2] + searchRegionIndex2, buf2Stride[2], puHeight, puWidth) :
                 (contextPtr->fractionalSearchMethod == SUB_SAD_SEARCH) ?
-                    (NxMSadAveragingKernel_funcPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1][puWidth >> 3](&(contextPtr->lcuBuffer[puLcuBufferIndex]), MAX_LCU_SIZE << 1, buf1[2] + searchRegionIndex1, buf1Stride[2] << 1, buf2[2] + searchRegionIndex2, buf2Stride[2] << 1, puHeight >> 1, puWidth)) << 1 :
-                    NxMSadAveragingKernel_funcPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1][puWidth >> 3](&(contextPtr->lcuBuffer[puLcuBufferIndex]), MAX_LCU_SIZE, buf1[2] + searchRegionIndex1, buf1Stride[2], buf2[2] + searchRegionIndex2, buf2Stride[2], puHeight, puWidth);
+                    (NxMSadAveragingKernel_funcPtrArray[!!(ASM_TYPES & PREAVX2_MASK)][puWidth >> 3](&(contextPtr->lcuBuffer[puLcuBufferIndex]), MAX_LCU_SIZE << 1, buf1[2] + searchRegionIndex1, buf1Stride[2] << 1, buf2[2] + searchRegionIndex2, buf2Stride[2] << 1, puHeight >> 1, puWidth)) << 1 :
+                    NxMSadAveragingKernel_funcPtrArray[!!(ASM_TYPES & PREAVX2_MASK)][puWidth >> 3](&(contextPtr->lcuBuffer[puLcuBufferIndex]), MAX_LCU_SIZE, buf1[2] + searchRegionIndex1, buf1Stride[2], buf2[2] + searchRegionIndex2, buf2Stride[2], puHeight, puWidth);
 
             if (contextPtr->fractionalSearchMethod == SSD_SEARCH) {
                 if (dist < *pBestSsd) {
-                    *pBestSad = (EB_U32)NxMSadAveragingKernel_funcPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1][puWidth >> 3](&(contextPtr->lcuBuffer[puLcuBufferIndex]), MAX_LCU_SIZE, buf1[2] + searchRegionIndex1, buf1Stride[2], buf2[2] + searchRegionIndex2, buf2Stride[2], puHeight, puWidth);
+                    *pBestSad = (EB_U32)NxMSadAveragingKernel_funcPtrArray[!!(ASM_TYPES & PREAVX2_MASK)][puWidth >> 3](&(contextPtr->lcuBuffer[puLcuBufferIndex]), MAX_LCU_SIZE, buf1[2] + searchRegionIndex1, buf1Stride[2], buf2[2] + searchRegionIndex2, buf2Stride[2], puHeight, puWidth);
                     *pBestMV = ((EB_U16)yMvQuarter[2] << 16) | ((EB_U16)xMvQuarter[2]);
                     *pBestSsd = (EB_U32)dist;
                 }
@@ -1392,12 +1392,12 @@ static void PU_QuarterPelRefinementOnTheFly(
             dist = (contextPtr->fractionalSearchMethod == SSD_SEARCH) ?
                 CombinedAveragingSSD(&(contextPtr->lcuBuffer[puLcuBufferIndex]), MAX_LCU_SIZE, buf1[3] + searchRegionIndex1, buf1Stride[3], buf2[3] + searchRegionIndex2, buf2Stride[3], puHeight, puWidth) :
                 (contextPtr->fractionalSearchMethod == SUB_SAD_SEARCH) ?
-                    (NxMSadAveragingKernel_funcPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1][puWidth >> 3](&(contextPtr->lcuBuffer[puLcuBufferIndex]), MAX_LCU_SIZE << 1, buf1[3] + searchRegionIndex1, buf1Stride[3] << 1, buf2[3] + searchRegionIndex2, buf2Stride[3] << 1, puHeight >> 1, puWidth)) << 1 :
-                    NxMSadAveragingKernel_funcPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1][puWidth >> 3](&(contextPtr->lcuBuffer[puLcuBufferIndex]), MAX_LCU_SIZE, buf1[3] + searchRegionIndex1, buf1Stride[3], buf2[3] + searchRegionIndex2, buf2Stride[3], puHeight, puWidth);
+                    (NxMSadAveragingKernel_funcPtrArray[!!(ASM_TYPES & PREAVX2_MASK)][puWidth >> 3](&(contextPtr->lcuBuffer[puLcuBufferIndex]), MAX_LCU_SIZE << 1, buf1[3] + searchRegionIndex1, buf1Stride[3] << 1, buf2[3] + searchRegionIndex2, buf2Stride[3] << 1, puHeight >> 1, puWidth)) << 1 :
+                    NxMSadAveragingKernel_funcPtrArray[!!(ASM_TYPES & PREAVX2_MASK)][puWidth >> 3](&(contextPtr->lcuBuffer[puLcuBufferIndex]), MAX_LCU_SIZE, buf1[3] + searchRegionIndex1, buf1Stride[3], buf2[3] + searchRegionIndex2, buf2Stride[3], puHeight, puWidth);
 
             if (contextPtr->fractionalSearchMethod == SSD_SEARCH) {
                 if (dist < *pBestSsd) {
-                    *pBestSad = (EB_U32)NxMSadAveragingKernel_funcPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1][puWidth >> 3](&(contextPtr->lcuBuffer[puLcuBufferIndex]), MAX_LCU_SIZE, buf1[3] + searchRegionIndex1, buf1Stride[3], buf2[3] + searchRegionIndex2, buf2Stride[3], puHeight, puWidth);
+                    *pBestSad = (EB_U32)NxMSadAveragingKernel_funcPtrArray[!!(ASM_TYPES & PREAVX2_MASK)][puWidth >> 3](&(contextPtr->lcuBuffer[puLcuBufferIndex]), MAX_LCU_SIZE, buf1[3] + searchRegionIndex1, buf1Stride[3], buf2[3] + searchRegionIndex2, buf2Stride[3], puHeight, puWidth);
                     *pBestMV  = ((EB_U16)yMvQuarter[3] << 16) | ((EB_U16)xMvQuarter[3]);
                     *pBestSsd = (EB_U32)dist;
                 }
@@ -1419,12 +1419,12 @@ static void PU_QuarterPelRefinementOnTheFly(
             dist = (contextPtr->fractionalSearchMethod == SSD_SEARCH) ?
                 CombinedAveragingSSD(&(contextPtr->lcuBuffer[puLcuBufferIndex]), MAX_LCU_SIZE, buf1[4] + searchRegionIndex1, buf1Stride[4], buf2[4] + searchRegionIndex2, buf2Stride[4], puHeight, puWidth) :
                 (contextPtr->fractionalSearchMethod == SUB_SAD_SEARCH) ?
-                    (NxMSadAveragingKernel_funcPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1][puWidth >> 3](&(contextPtr->lcuBuffer[puLcuBufferIndex]), MAX_LCU_SIZE << 1, buf1[4] + searchRegionIndex1, buf1Stride[4] << 1, buf2[4] + searchRegionIndex2, buf2Stride[4] << 1, puHeight >> 1, puWidth)) << 1 :
-                    NxMSadAveragingKernel_funcPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1][puWidth >> 3](&(contextPtr->lcuBuffer[puLcuBufferIndex]), MAX_LCU_SIZE, buf1[4] + searchRegionIndex1, buf1Stride[4], buf2[4] + searchRegionIndex2, buf2Stride[4], puHeight, puWidth);
+                    (NxMSadAveragingKernel_funcPtrArray[!!(ASM_TYPES & PREAVX2_MASK)][puWidth >> 3](&(contextPtr->lcuBuffer[puLcuBufferIndex]), MAX_LCU_SIZE << 1, buf1[4] + searchRegionIndex1, buf1Stride[4] << 1, buf2[4] + searchRegionIndex2, buf2Stride[4] << 1, puHeight >> 1, puWidth)) << 1 :
+                    NxMSadAveragingKernel_funcPtrArray[!!(ASM_TYPES & PREAVX2_MASK)][puWidth >> 3](&(contextPtr->lcuBuffer[puLcuBufferIndex]), MAX_LCU_SIZE, buf1[4] + searchRegionIndex1, buf1Stride[4], buf2[4] + searchRegionIndex2, buf2Stride[4], puHeight, puWidth);
 
             if (contextPtr->fractionalSearchMethod == SSD_SEARCH) {
                 if (dist < *pBestSsd) {
-                    *pBestSad = (EB_U32)NxMSadAveragingKernel_funcPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1][puWidth >> 3](&(contextPtr->lcuBuffer[puLcuBufferIndex]), MAX_LCU_SIZE, buf1[4] + searchRegionIndex1, buf1Stride[4], buf2[4] + searchRegionIndex2, buf2Stride[4], puHeight, puWidth);
+                    *pBestSad = (EB_U32)NxMSadAveragingKernel_funcPtrArray[!!(ASM_TYPES & PREAVX2_MASK)][puWidth >> 3](&(contextPtr->lcuBuffer[puLcuBufferIndex]), MAX_LCU_SIZE, buf1[4] + searchRegionIndex1, buf1Stride[4], buf2[4] + searchRegionIndex2, buf2Stride[4], puHeight, puWidth);
                     *pBestMV = ((EB_U16)yMvQuarter[4] << 16) | ((EB_U16)xMvQuarter[4]);
                     *pBestSsd = (EB_U32)dist;
                 }
@@ -1447,12 +1447,12 @@ static void PU_QuarterPelRefinementOnTheFly(
             dist = (contextPtr->fractionalSearchMethod == SSD_SEARCH) ?
                 CombinedAveragingSSD(&(contextPtr->lcuBuffer[puLcuBufferIndex]), MAX_LCU_SIZE, buf1[5] + searchRegionIndex1, buf1Stride[5], buf2[5] + searchRegionIndex2, buf2Stride[5], puHeight, puWidth) :\
                 (contextPtr->fractionalSearchMethod == SUB_SAD_SEARCH) ?
-                    (NxMSadAveragingKernel_funcPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1][puWidth >> 3](&(contextPtr->lcuBuffer[puLcuBufferIndex]), MAX_LCU_SIZE << 1, buf1[5] + searchRegionIndex1, buf1Stride[5] << 1, buf2[5] + searchRegionIndex2, buf2Stride[5] << 1, puHeight >> 1, puWidth)) << 1 :
-                    NxMSadAveragingKernel_funcPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1][puWidth >> 3](&(contextPtr->lcuBuffer[puLcuBufferIndex]), MAX_LCU_SIZE, buf1[5] + searchRegionIndex1, buf1Stride[5], buf2[5] + searchRegionIndex2, buf2Stride[5], puHeight, puWidth);
+                    (NxMSadAveragingKernel_funcPtrArray[!!(ASM_TYPES & PREAVX2_MASK)][puWidth >> 3](&(contextPtr->lcuBuffer[puLcuBufferIndex]), MAX_LCU_SIZE << 1, buf1[5] + searchRegionIndex1, buf1Stride[5] << 1, buf2[5] + searchRegionIndex2, buf2Stride[5] << 1, puHeight >> 1, puWidth)) << 1 :
+                    NxMSadAveragingKernel_funcPtrArray[!!(ASM_TYPES & PREAVX2_MASK)][puWidth >> 3](&(contextPtr->lcuBuffer[puLcuBufferIndex]), MAX_LCU_SIZE, buf1[5] + searchRegionIndex1, buf1Stride[5], buf2[5] + searchRegionIndex2, buf2Stride[5], puHeight, puWidth);
 
             if (contextPtr->fractionalSearchMethod == SSD_SEARCH) {
                 if (dist < *pBestSsd) {
-                    *pBestSad = (EB_U32)NxMSadAveragingKernel_funcPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1][puWidth >> 3](&(contextPtr->lcuBuffer[puLcuBufferIndex]), MAX_LCU_SIZE, buf1[5] + searchRegionIndex1, buf1Stride[5], buf2[5] + searchRegionIndex2, buf2Stride[5], puHeight, puWidth);
+                    *pBestSad = (EB_U32)NxMSadAveragingKernel_funcPtrArray[!!(ASM_TYPES & PREAVX2_MASK)][puWidth >> 3](&(contextPtr->lcuBuffer[puLcuBufferIndex]), MAX_LCU_SIZE, buf1[5] + searchRegionIndex1, buf1Stride[5], buf2[5] + searchRegionIndex2, buf2Stride[5], puHeight, puWidth);
                     *pBestMV = ((EB_U16)yMvQuarter[5] << 16) | ((EB_U16)xMvQuarter[5]);
                     *pBestSsd = (EB_U32)dist;
                 }
@@ -1474,12 +1474,12 @@ static void PU_QuarterPelRefinementOnTheFly(
             dist = (contextPtr->fractionalSearchMethod == SSD_SEARCH) ?
                 CombinedAveragingSSD(&(contextPtr->lcuBuffer[puLcuBufferIndex]), MAX_LCU_SIZE, buf1[6] + searchRegionIndex1, buf1Stride[6], buf2[6] + searchRegionIndex2, buf2Stride[6], puHeight, puWidth) :
                 (contextPtr->fractionalSearchMethod == SUB_SAD_SEARCH) ?
-                    (NxMSadAveragingKernel_funcPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1][puWidth >> 3](&(contextPtr->lcuBuffer[puLcuBufferIndex]), MAX_LCU_SIZE << 1, buf1[6] + searchRegionIndex1, buf1Stride[6] << 1, buf2[6] + searchRegionIndex2, buf2Stride[6] << 1, puHeight >> 1, puWidth)) << 1 :
-                    NxMSadAveragingKernel_funcPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1][puWidth >> 3](&(contextPtr->lcuBuffer[puLcuBufferIndex]), MAX_LCU_SIZE, buf1[6] + searchRegionIndex1, buf1Stride[6], buf2[6] + searchRegionIndex2, buf2Stride[6], puHeight, puWidth);
+                    (NxMSadAveragingKernel_funcPtrArray[!!(ASM_TYPES & PREAVX2_MASK)][puWidth >> 3](&(contextPtr->lcuBuffer[puLcuBufferIndex]), MAX_LCU_SIZE << 1, buf1[6] + searchRegionIndex1, buf1Stride[6] << 1, buf2[6] + searchRegionIndex2, buf2Stride[6] << 1, puHeight >> 1, puWidth)) << 1 :
+                    NxMSadAveragingKernel_funcPtrArray[!!(ASM_TYPES & PREAVX2_MASK)][puWidth >> 3](&(contextPtr->lcuBuffer[puLcuBufferIndex]), MAX_LCU_SIZE, buf1[6] + searchRegionIndex1, buf1Stride[6], buf2[6] + searchRegionIndex2, buf2Stride[6], puHeight, puWidth);
 
             if (contextPtr->fractionalSearchMethod == SSD_SEARCH) {
                 if (dist < *pBestSsd) {
-                    *pBestSad = (EB_U32)NxMSadAveragingKernel_funcPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1][puWidth >> 3](&(contextPtr->lcuBuffer[puLcuBufferIndex]), MAX_LCU_SIZE, buf1[6] + searchRegionIndex1, buf1Stride[6], buf2[6] + searchRegionIndex2, buf2Stride[6], puHeight, puWidth);
+                    *pBestSad = (EB_U32)NxMSadAveragingKernel_funcPtrArray[!!(ASM_TYPES & PREAVX2_MASK)][puWidth >> 3](&(contextPtr->lcuBuffer[puLcuBufferIndex]), MAX_LCU_SIZE, buf1[6] + searchRegionIndex1, buf1Stride[6], buf2[6] + searchRegionIndex2, buf2Stride[6], puHeight, puWidth);
                     *pBestMV = ((EB_U16)yMvQuarter[6] << 16) | ((EB_U16)xMvQuarter[6]);
                     *pBestSsd = (EB_U32)dist;
                 }
@@ -1501,12 +1501,12 @@ static void PU_QuarterPelRefinementOnTheFly(
             dist = (contextPtr->fractionalSearchMethod == SSD_SEARCH) ?
                 CombinedAveragingSSD(&(contextPtr->lcuBuffer[puLcuBufferIndex]), MAX_LCU_SIZE, buf1[7] + searchRegionIndex1, buf1Stride[7], buf2[7] + searchRegionIndex2, buf2Stride[7], puHeight, puWidth) :
                 (contextPtr->fractionalSearchMethod == SUB_SAD_SEARCH) ?
-                    (NxMSadAveragingKernel_funcPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1][puWidth >> 3](&(contextPtr->lcuBuffer[puLcuBufferIndex]), MAX_LCU_SIZE << 1, buf1[7] + searchRegionIndex1, buf1Stride[7] << 1, buf2[7] + searchRegionIndex2, buf2Stride[7] << 1, puHeight >> 1, puWidth)) << 1 :
-                    NxMSadAveragingKernel_funcPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1][puWidth >> 3](&(contextPtr->lcuBuffer[puLcuBufferIndex]), MAX_LCU_SIZE, buf1[7] + searchRegionIndex1, buf1Stride[7], buf2[7] + searchRegionIndex2, buf2Stride[7], puHeight, puWidth);
+                    (NxMSadAveragingKernel_funcPtrArray[!!(ASM_TYPES & PREAVX2_MASK)][puWidth >> 3](&(contextPtr->lcuBuffer[puLcuBufferIndex]), MAX_LCU_SIZE << 1, buf1[7] + searchRegionIndex1, buf1Stride[7] << 1, buf2[7] + searchRegionIndex2, buf2Stride[7] << 1, puHeight >> 1, puWidth)) << 1 :
+                    NxMSadAveragingKernel_funcPtrArray[!!(ASM_TYPES & PREAVX2_MASK)][puWidth >> 3](&(contextPtr->lcuBuffer[puLcuBufferIndex]), MAX_LCU_SIZE, buf1[7] + searchRegionIndex1, buf1Stride[7], buf2[7] + searchRegionIndex2, buf2Stride[7], puHeight, puWidth);
 
             if (contextPtr->fractionalSearchMethod == SSD_SEARCH) {
                 if (dist < *pBestSsd) {
-                    *pBestSad = (EB_U32)NxMSadAveragingKernel_funcPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1][puWidth >> 3](&(contextPtr->lcuBuffer[puLcuBufferIndex]), MAX_LCU_SIZE, buf1[7] + searchRegionIndex1, buf1Stride[7], buf2[7] + searchRegionIndex2, buf2Stride[7], puHeight, puWidth);
+                    *pBestSad = (EB_U32)NxMSadAveragingKernel_funcPtrArray[!!(ASM_TYPES & PREAVX2_MASK)][puWidth >> 3](&(contextPtr->lcuBuffer[puLcuBufferIndex]), MAX_LCU_SIZE, buf1[7] + searchRegionIndex1, buf1Stride[7], buf2[7] + searchRegionIndex2, buf2Stride[7], puHeight, puWidth);
                     *pBestMV = ((EB_U16)yMvQuarter[7] << 16) | ((EB_U16)xMvQuarter[7]);
                     *pBestSsd = (EB_U32)dist;
                 }
@@ -2589,7 +2589,7 @@ static void QuarterPelCompensation(
 	buf1 = buf1 + puShiftXIndex + puShiftYIndex * refStride1;
 	buf2 = buf2 + puShiftXIndex + puShiftYIndex * refStride2;
 
-	PictureAverageArray[(ASM_TYPES & PREAVX2_MASK) && 1](buf1, refStride1, buf2, refStride2, Dst, DstStride, puWidth, puHeight);
+	PictureAverageArray[!!(ASM_TYPES & PREAVX2_MASK)](buf1, refStride1, buf2, refStride2, Dst, DstStride, puWidth, puHeight);
 
 	return;
 }
@@ -2712,7 +2712,7 @@ EB_U32 BiPredAverging(
 
 	// bi-pred luma
     meCandidate->distortion = (contextPtr->fractionalSearchMethod == SUB_SAD_SEARCH) ?
-        NxMSadAveragingKernel_funcPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1][puWidth >> 3](sourcePic,
+        NxMSadAveragingKernel_funcPtrArray[!!(ASM_TYPES & PREAVX2_MASK)][puWidth >> 3](sourcePic,
             lumaStride << 1,
             ptrList0,
             ptrList0Stride << 1,
@@ -2720,7 +2720,7 @@ EB_U32 BiPredAverging(
             ptrList1Stride << 1,
             puHeight >> 1,
             puWidth) << 1 :
-        NxMSadAveragingKernel_funcPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1][puWidth >> 3](sourcePic,
+        NxMSadAveragingKernel_funcPtrArray[!!(ASM_TYPES & PREAVX2_MASK)][puWidth >> 3](sourcePic,
 		    lumaStride,
 		    ptrList0,
 		    ptrList0Stride,
@@ -4163,7 +4163,7 @@ EB_ERRORTYPE MotionEstimateLcu(
 			{
 				{
 
-					InitializeBuffer_32bits_funcPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1](contextPtr->pLcuBestSad[listIndex][0], 21, 1, MAX_SAD_VALUE);
+					InitializeBuffer_32bits_funcPtrArray[!!(ASM_TYPES & PREAVX2_MASK)](contextPtr->pLcuBestSad[listIndex][0], 21, 1, MAX_SAD_VALUE);
 					contextPtr->pBestSad64x64 = &(contextPtr->pLcuBestSad[listIndex][0][ME_TIER_ZERO_PU_64x64]);
 					contextPtr->pBestSad32x32 = &(contextPtr->pLcuBestSad[listIndex][0][ME_TIER_ZERO_PU_32x32_0]);
 					contextPtr->pBestSad16x16 = &(contextPtr->pLcuBestSad[listIndex][0][ME_TIER_ZERO_PU_16x16_0]);

--- a/Source/Lib/Codec/EbMotionEstimationProcess.c
+++ b/Source/Lib/Codec/EbMotionEstimationProcess.c
@@ -401,7 +401,7 @@ EB_ERRORTYPE ComputeDecimatedZzSad(
 					4);
 
 				// ZZ SAD between 1/16 current & 1/16 collocated
-				decimatedLcuCollocatedSad = NxMSadKernel_funcPtrArray[(ASM_TYPES & AVX2_MASK) && 1][2](
+				decimatedLcuCollocatedSad = NxMSadKernel_funcPtrArray[!!(ASM_TYPES & AVX2_MASK)][2](
 					&(sixteenthDecimatedPicturePtr->bufferY[blkDisplacementDecimated]),
 					sixteenthDecimatedPicturePtr->strideY,
 					contextPtr->meContextPtr->sixteenthLcuBuffer,

--- a/Source/Lib/Codec/EbPictureAnalysisProcess.c
+++ b/Source/Lib/Codec/EbPictureAnalysisProcess.c
@@ -3599,7 +3599,7 @@ void SubSampleLumaGeneratePixelIntensityHistogramBins(
 
 
 			// Initialize bins to 1
-			InitializeBuffer_32bits_funcPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1](pictureControlSetPtr->pictureHistogram[regionInPictureWidthIndex][regionInPictureHeightIndex][0], 64, 0, 1);
+			InitializeBuffer_32bits_funcPtrArray[!!(ASM_TYPES & PREAVX2_MASK)](pictureControlSetPtr->pictureHistogram[regionInPictureWidthIndex][regionInPictureHeightIndex][0], 64, 0, 1);
 
 			regionWidthOffset = (regionInPictureWidthIndex == sequenceControlSetPtr->pictureAnalysisNumberOfRegionsPerWidth - 1) ?
 				inputPicturePtr->width - (sequenceControlSetPtr->pictureAnalysisNumberOfRegionsPerWidth * regionWidth) :
@@ -3658,8 +3658,8 @@ void SubSampleChromaGeneratePixelIntensityHistogramBins(
 
 
             // Initialize bins to 1
-			InitializeBuffer_32bits_funcPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1](pictureControlSetPtr->pictureHistogram[regionInPictureWidthIndex][regionInPictureHeightIndex][1], 64, 0, 1);
-			InitializeBuffer_32bits_funcPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1](pictureControlSetPtr->pictureHistogram[regionInPictureWidthIndex][regionInPictureHeightIndex][2], 64, 0, 1);
+			InitializeBuffer_32bits_funcPtrArray[!!(ASM_TYPES & PREAVX2_MASK)](pictureControlSetPtr->pictureHistogram[regionInPictureWidthIndex][regionInPictureHeightIndex][1], 64, 0, 1);
+			InitializeBuffer_32bits_funcPtrArray[!!(ASM_TYPES & PREAVX2_MASK)](pictureControlSetPtr->pictureHistogram[regionInPictureWidthIndex][regionInPictureHeightIndex][2], 64, 0, 1);
 
             regionWidthOffset = (regionInPictureWidthIndex == sequenceControlSetPtr->pictureAnalysisNumberOfRegionsPerWidth - 1) ?
                 inputPicturePtr->width - (sequenceControlSetPtr->pictureAnalysisNumberOfRegionsPerWidth * regionWidth) :

--- a/Source/Lib/Codec/EbPictureAnalysisProcess.c
+++ b/Source/Lib/Codec/EbPictureAnalysisProcess.c
@@ -253,89 +253,89 @@ EB_U64 ComputeVariance32x32(
 	// (0,0)
 	blockIndex = inputLumaOriginIndex;
 
-	meanOf8x8Blocks[0] = ComputeMeanFunc[0][(ASM_TYPES & AVX2_MASK) && 1](&(inputPaddedPicturePtr->bufferY[blockIndex]), inputPaddedPicturePtr->strideY, 8, 8);
-	meanOf8x8SquaredValuesBlocks[0] = ComputeMeanFunc[1][(ASM_TYPES & AVX2_MASK) && 1](&(inputPaddedPicturePtr->bufferY[blockIndex]), inputPaddedPicturePtr->strideY, 8, 8);
+	meanOf8x8Blocks[0] = ComputeMeanFunc[0][!!(ASM_TYPES & AVX2_MASK)](&(inputPaddedPicturePtr->bufferY[blockIndex]), inputPaddedPicturePtr->strideY, 8, 8);
+	meanOf8x8SquaredValuesBlocks[0] = ComputeMeanFunc[1][!!(ASM_TYPES & AVX2_MASK)](&(inputPaddedPicturePtr->bufferY[blockIndex]), inputPaddedPicturePtr->strideY, 8, 8);
 
 	// (0,1)
 	blockIndex = blockIndex + 8;
-	meanOf8x8Blocks[1] = ComputeMeanFunc[0][(ASM_TYPES & AVX2_MASK) && 1](&(inputPaddedPicturePtr->bufferY[blockIndex]), inputPaddedPicturePtr->strideY, 8, 8);
-	meanOf8x8SquaredValuesBlocks[1] = ComputeMeanFunc[1][(ASM_TYPES & AVX2_MASK) && 1](&(inputPaddedPicturePtr->bufferY[blockIndex]), inputPaddedPicturePtr->strideY, 8, 8);
+	meanOf8x8Blocks[1] = ComputeMeanFunc[0][!!(ASM_TYPES & AVX2_MASK)](&(inputPaddedPicturePtr->bufferY[blockIndex]), inputPaddedPicturePtr->strideY, 8, 8);
+	meanOf8x8SquaredValuesBlocks[1] = ComputeMeanFunc[1][!!(ASM_TYPES & AVX2_MASK)](&(inputPaddedPicturePtr->bufferY[blockIndex]), inputPaddedPicturePtr->strideY, 8, 8);
 
 	// (0,2)
 	blockIndex = blockIndex + 8;
-	meanOf8x8Blocks[2] = ComputeMeanFunc[0][(ASM_TYPES & AVX2_MASK) && 1](&(inputPaddedPicturePtr->bufferY[blockIndex]), inputPaddedPicturePtr->strideY, 8, 8);
-	meanOf8x8SquaredValuesBlocks[2] = ComputeMeanFunc[1][(ASM_TYPES & AVX2_MASK) && 1](&(inputPaddedPicturePtr->bufferY[blockIndex]), inputPaddedPicturePtr->strideY, 8, 8);
+	meanOf8x8Blocks[2] = ComputeMeanFunc[0][!!(ASM_TYPES & AVX2_MASK)](&(inputPaddedPicturePtr->bufferY[blockIndex]), inputPaddedPicturePtr->strideY, 8, 8);
+	meanOf8x8SquaredValuesBlocks[2] = ComputeMeanFunc[1][!!(ASM_TYPES & AVX2_MASK)](&(inputPaddedPicturePtr->bufferY[blockIndex]), inputPaddedPicturePtr->strideY, 8, 8);
 
 	// (0,3)
 	blockIndex = blockIndex + 8;
-	meanOf8x8Blocks[3] = ComputeMeanFunc[0][(ASM_TYPES & AVX2_MASK) && 1](&(inputPaddedPicturePtr->bufferY[blockIndex]), inputPaddedPicturePtr->strideY, 8, 8);
-	meanOf8x8SquaredValuesBlocks[3] = ComputeMeanFunc[1][(ASM_TYPES & AVX2_MASK) && 1](&(inputPaddedPicturePtr->bufferY[blockIndex]), inputPaddedPicturePtr->strideY, 8, 8);
+	meanOf8x8Blocks[3] = ComputeMeanFunc[0][!!(ASM_TYPES & AVX2_MASK)](&(inputPaddedPicturePtr->bufferY[blockIndex]), inputPaddedPicturePtr->strideY, 8, 8);
+	meanOf8x8SquaredValuesBlocks[3] = ComputeMeanFunc[1][!!(ASM_TYPES & AVX2_MASK)](&(inputPaddedPicturePtr->bufferY[blockIndex]), inputPaddedPicturePtr->strideY, 8, 8);
 
 	
 
 	// (1,0)
 	blockIndex = inputLumaOriginIndex + (inputPaddedPicturePtr->strideY << 3);
-	meanOf8x8Blocks[4] = ComputeMeanFunc[0][(ASM_TYPES & AVX2_MASK) && 1](&(inputPaddedPicturePtr->bufferY[blockIndex]), inputPaddedPicturePtr->strideY, 8, 8);
-	meanOf8x8SquaredValuesBlocks[4] = ComputeMeanFunc[1][(ASM_TYPES & AVX2_MASK) && 1](&(inputPaddedPicturePtr->bufferY[blockIndex]), inputPaddedPicturePtr->strideY, 8, 8);
+	meanOf8x8Blocks[4] = ComputeMeanFunc[0][!!(ASM_TYPES & AVX2_MASK)](&(inputPaddedPicturePtr->bufferY[blockIndex]), inputPaddedPicturePtr->strideY, 8, 8);
+	meanOf8x8SquaredValuesBlocks[4] = ComputeMeanFunc[1][!!(ASM_TYPES & AVX2_MASK)](&(inputPaddedPicturePtr->bufferY[blockIndex]), inputPaddedPicturePtr->strideY, 8, 8);
 
 	// (1,1)
 	blockIndex = blockIndex + 8;
-	meanOf8x8Blocks[5] = ComputeMeanFunc[0][(ASM_TYPES & AVX2_MASK) && 1](&(inputPaddedPicturePtr->bufferY[blockIndex]), inputPaddedPicturePtr->strideY, 8, 8);
-	meanOf8x8SquaredValuesBlocks[5] = ComputeMeanFunc[1][(ASM_TYPES & AVX2_MASK) && 1](&(inputPaddedPicturePtr->bufferY[blockIndex]), inputPaddedPicturePtr->strideY, 8, 8);
+	meanOf8x8Blocks[5] = ComputeMeanFunc[0][!!(ASM_TYPES & AVX2_MASK)](&(inputPaddedPicturePtr->bufferY[blockIndex]), inputPaddedPicturePtr->strideY, 8, 8);
+	meanOf8x8SquaredValuesBlocks[5] = ComputeMeanFunc[1][!!(ASM_TYPES & AVX2_MASK)](&(inputPaddedPicturePtr->bufferY[blockIndex]), inputPaddedPicturePtr->strideY, 8, 8);
 
 	// (1,2)
 	blockIndex = blockIndex + 8;
-	meanOf8x8Blocks[6] = ComputeMeanFunc[0][(ASM_TYPES & AVX2_MASK) && 1](&(inputPaddedPicturePtr->bufferY[blockIndex]), inputPaddedPicturePtr->strideY, 8, 8);
-	meanOf8x8SquaredValuesBlocks[6] = ComputeMeanFunc[1][(ASM_TYPES & AVX2_MASK) && 1](&(inputPaddedPicturePtr->bufferY[blockIndex]), inputPaddedPicturePtr->strideY, 8, 8);
+	meanOf8x8Blocks[6] = ComputeMeanFunc[0][!!(ASM_TYPES & AVX2_MASK)](&(inputPaddedPicturePtr->bufferY[blockIndex]), inputPaddedPicturePtr->strideY, 8, 8);
+	meanOf8x8SquaredValuesBlocks[6] = ComputeMeanFunc[1][!!(ASM_TYPES & AVX2_MASK)](&(inputPaddedPicturePtr->bufferY[blockIndex]), inputPaddedPicturePtr->strideY, 8, 8);
 
 	// (1,3)
 	blockIndex = blockIndex + 8;
-	meanOf8x8Blocks[7] = ComputeMeanFunc[0][(ASM_TYPES & AVX2_MASK) && 1](&(inputPaddedPicturePtr->bufferY[blockIndex]), inputPaddedPicturePtr->strideY, 8, 8);
-	meanOf8x8SquaredValuesBlocks[7] = ComputeMeanFunc[1][(ASM_TYPES & AVX2_MASK) && 1](&(inputPaddedPicturePtr->bufferY[blockIndex]), inputPaddedPicturePtr->strideY, 8, 8);
+	meanOf8x8Blocks[7] = ComputeMeanFunc[0][!!(ASM_TYPES & AVX2_MASK)](&(inputPaddedPicturePtr->bufferY[blockIndex]), inputPaddedPicturePtr->strideY, 8, 8);
+	meanOf8x8SquaredValuesBlocks[7] = ComputeMeanFunc[1][!!(ASM_TYPES & AVX2_MASK)](&(inputPaddedPicturePtr->bufferY[blockIndex]), inputPaddedPicturePtr->strideY, 8, 8);
 
 	
 
 	// (2,0)
 	blockIndex = inputLumaOriginIndex + (inputPaddedPicturePtr->strideY << 4);
-	meanOf8x8Blocks[8] = ComputeMeanFunc[0][(ASM_TYPES & AVX2_MASK) && 1](&(inputPaddedPicturePtr->bufferY[blockIndex]), inputPaddedPicturePtr->strideY, 8, 8);
-	meanOf8x8SquaredValuesBlocks[8] = ComputeMeanFunc[1][(ASM_TYPES & AVX2_MASK) && 1](&(inputPaddedPicturePtr->bufferY[blockIndex]), inputPaddedPicturePtr->strideY, 8, 8);
+	meanOf8x8Blocks[8] = ComputeMeanFunc[0][!!(ASM_TYPES & AVX2_MASK)](&(inputPaddedPicturePtr->bufferY[blockIndex]), inputPaddedPicturePtr->strideY, 8, 8);
+	meanOf8x8SquaredValuesBlocks[8] = ComputeMeanFunc[1][!!(ASM_TYPES & AVX2_MASK)](&(inputPaddedPicturePtr->bufferY[blockIndex]), inputPaddedPicturePtr->strideY, 8, 8);
 
 	// (2,1)
 	blockIndex = blockIndex + 8;
-	meanOf8x8Blocks[9] = ComputeMeanFunc[0][(ASM_TYPES & AVX2_MASK) && 1](&(inputPaddedPicturePtr->bufferY[blockIndex]), inputPaddedPicturePtr->strideY, 8, 8);
-	meanOf8x8SquaredValuesBlocks[9] = ComputeMeanFunc[1][(ASM_TYPES & AVX2_MASK) && 1](&(inputPaddedPicturePtr->bufferY[blockIndex]), inputPaddedPicturePtr->strideY, 8, 8);
+	meanOf8x8Blocks[9] = ComputeMeanFunc[0][!!(ASM_TYPES & AVX2_MASK)](&(inputPaddedPicturePtr->bufferY[blockIndex]), inputPaddedPicturePtr->strideY, 8, 8);
+	meanOf8x8SquaredValuesBlocks[9] = ComputeMeanFunc[1][!!(ASM_TYPES & AVX2_MASK)](&(inputPaddedPicturePtr->bufferY[blockIndex]), inputPaddedPicturePtr->strideY, 8, 8);
 
 	// (2,2)
 	blockIndex = blockIndex + 8;
-	meanOf8x8Blocks[10] = ComputeMeanFunc[0][(ASM_TYPES & AVX2_MASK) && 1](&(inputPaddedPicturePtr->bufferY[blockIndex]), inputPaddedPicturePtr->strideY, 8, 8);
-	meanOf8x8SquaredValuesBlocks[10] = ComputeMeanFunc[1][(ASM_TYPES & AVX2_MASK) && 1](&(inputPaddedPicturePtr->bufferY[blockIndex]), inputPaddedPicturePtr->strideY, 8, 8);
+	meanOf8x8Blocks[10] = ComputeMeanFunc[0][!!(ASM_TYPES & AVX2_MASK)](&(inputPaddedPicturePtr->bufferY[blockIndex]), inputPaddedPicturePtr->strideY, 8, 8);
+	meanOf8x8SquaredValuesBlocks[10] = ComputeMeanFunc[1][!!(ASM_TYPES & AVX2_MASK)](&(inputPaddedPicturePtr->bufferY[blockIndex]), inputPaddedPicturePtr->strideY, 8, 8);
 
 	// (2,3)
 	blockIndex = blockIndex + 8;
-	meanOf8x8Blocks[11] = ComputeMeanFunc[0][(ASM_TYPES & AVX2_MASK) && 1](&(inputPaddedPicturePtr->bufferY[blockIndex]), inputPaddedPicturePtr->strideY, 8, 8);
-	meanOf8x8SquaredValuesBlocks[11] = ComputeMeanFunc[1][(ASM_TYPES & AVX2_MASK) && 1](&(inputPaddedPicturePtr->bufferY[blockIndex]), inputPaddedPicturePtr->strideY, 8, 8);
+	meanOf8x8Blocks[11] = ComputeMeanFunc[0][!!(ASM_TYPES & AVX2_MASK)](&(inputPaddedPicturePtr->bufferY[blockIndex]), inputPaddedPicturePtr->strideY, 8, 8);
+	meanOf8x8SquaredValuesBlocks[11] = ComputeMeanFunc[1][!!(ASM_TYPES & AVX2_MASK)](&(inputPaddedPicturePtr->bufferY[blockIndex]), inputPaddedPicturePtr->strideY, 8, 8);
 
 	
 
 	// (3,0)
 	blockIndex = inputLumaOriginIndex + (inputPaddedPicturePtr->strideY << 3) + (inputPaddedPicturePtr->strideY << 4);
-	meanOf8x8Blocks[12] = ComputeMeanFunc[0][(ASM_TYPES & AVX2_MASK) && 1](&(inputPaddedPicturePtr->bufferY[blockIndex]), inputPaddedPicturePtr->strideY, 8, 8);
-	meanOf8x8SquaredValuesBlocks[12] = ComputeMeanFunc[1][(ASM_TYPES & AVX2_MASK) && 1](&(inputPaddedPicturePtr->bufferY[blockIndex]), inputPaddedPicturePtr->strideY, 8, 8);
+	meanOf8x8Blocks[12] = ComputeMeanFunc[0][!!(ASM_TYPES & AVX2_MASK)](&(inputPaddedPicturePtr->bufferY[blockIndex]), inputPaddedPicturePtr->strideY, 8, 8);
+	meanOf8x8SquaredValuesBlocks[12] = ComputeMeanFunc[1][!!(ASM_TYPES & AVX2_MASK)](&(inputPaddedPicturePtr->bufferY[blockIndex]), inputPaddedPicturePtr->strideY, 8, 8);
 
 	// (3,1)
 	blockIndex = blockIndex + 8;
-	meanOf8x8Blocks[13] = ComputeMeanFunc[0][(ASM_TYPES & AVX2_MASK) && 1](&(inputPaddedPicturePtr->bufferY[blockIndex]), inputPaddedPicturePtr->strideY, 8, 8);
-	meanOf8x8SquaredValuesBlocks[13] = ComputeMeanFunc[1][(ASM_TYPES & AVX2_MASK) && 1](&(inputPaddedPicturePtr->bufferY[blockIndex]), inputPaddedPicturePtr->strideY, 8, 8);
+	meanOf8x8Blocks[13] = ComputeMeanFunc[0][!!(ASM_TYPES & AVX2_MASK)](&(inputPaddedPicturePtr->bufferY[blockIndex]), inputPaddedPicturePtr->strideY, 8, 8);
+	meanOf8x8SquaredValuesBlocks[13] = ComputeMeanFunc[1][!!(ASM_TYPES & AVX2_MASK)](&(inputPaddedPicturePtr->bufferY[blockIndex]), inputPaddedPicturePtr->strideY, 8, 8);
 
 	// (3,2)
 	blockIndex = blockIndex + 8;
-	meanOf8x8Blocks[14] = ComputeMeanFunc[0][(ASM_TYPES & AVX2_MASK) && 1](&(inputPaddedPicturePtr->bufferY[blockIndex]), inputPaddedPicturePtr->strideY, 8, 8);
-	meanOf8x8SquaredValuesBlocks[14] = ComputeMeanFunc[1][(ASM_TYPES & AVX2_MASK) && 1](&(inputPaddedPicturePtr->bufferY[blockIndex]), inputPaddedPicturePtr->strideY, 8, 8);
+	meanOf8x8Blocks[14] = ComputeMeanFunc[0][!!(ASM_TYPES & AVX2_MASK)](&(inputPaddedPicturePtr->bufferY[blockIndex]), inputPaddedPicturePtr->strideY, 8, 8);
+	meanOf8x8SquaredValuesBlocks[14] = ComputeMeanFunc[1][!!(ASM_TYPES & AVX2_MASK)](&(inputPaddedPicturePtr->bufferY[blockIndex]), inputPaddedPicturePtr->strideY, 8, 8);
 
 	// (3,3)
 	blockIndex = blockIndex + 8;
-	meanOf8x8Blocks[15] = ComputeMeanFunc[0][(ASM_TYPES & AVX2_MASK) && 1](&(inputPaddedPicturePtr->bufferY[blockIndex]), inputPaddedPicturePtr->strideY, 8, 8);
-	meanOf8x8SquaredValuesBlocks[15] = ComputeMeanFunc[1][(ASM_TYPES & AVX2_MASK) && 1](&(inputPaddedPicturePtr->bufferY[blockIndex]), inputPaddedPicturePtr->strideY, 8, 8);
+	meanOf8x8Blocks[15] = ComputeMeanFunc[0][!!(ASM_TYPES & AVX2_MASK)](&(inputPaddedPicturePtr->bufferY[blockIndex]), inputPaddedPicturePtr->strideY, 8, 8);
+	meanOf8x8SquaredValuesBlocks[15] = ComputeMeanFunc[1][!!(ASM_TYPES & AVX2_MASK)](&(inputPaddedPicturePtr->bufferY[blockIndex]), inputPaddedPicturePtr->strideY, 8, 8);
 
 
 	/////////////////////////////////////////////
@@ -396,23 +396,23 @@ EB_U64 ComputeVariance16x16(
 	// (0,0)
 	blockIndex = inputLumaOriginIndex;
 
-	meanOf8x8Blocks[0] = ComputeMeanFunc[0][(ASM_TYPES & AVX2_MASK) && 1](&(inputPaddedPicturePtr->bufferY[blockIndex]), inputPaddedPicturePtr->strideY, 8, 8);
-	meanOf8x8SquaredValuesBlocks[0] = ComputeMeanFunc[1][(ASM_TYPES & AVX2_MASK) && 1](&(inputPaddedPicturePtr->bufferY[blockIndex]), inputPaddedPicturePtr->strideY, 8, 8);
+	meanOf8x8Blocks[0] = ComputeMeanFunc[0][!!(ASM_TYPES & AVX2_MASK)](&(inputPaddedPicturePtr->bufferY[blockIndex]), inputPaddedPicturePtr->strideY, 8, 8);
+	meanOf8x8SquaredValuesBlocks[0] = ComputeMeanFunc[1][!!(ASM_TYPES & AVX2_MASK)](&(inputPaddedPicturePtr->bufferY[blockIndex]), inputPaddedPicturePtr->strideY, 8, 8);
 
 	// (0,1)
 	blockIndex = blockIndex + 8;
-	meanOf8x8Blocks[1] = ComputeMeanFunc[0][(ASM_TYPES & AVX2_MASK) && 1](&(inputPaddedPicturePtr->bufferY[blockIndex]), inputPaddedPicturePtr->strideY, 8, 8);
-	meanOf8x8SquaredValuesBlocks[1] = ComputeMeanFunc[1][(ASM_TYPES & AVX2_MASK) && 1](&(inputPaddedPicturePtr->bufferY[blockIndex]), inputPaddedPicturePtr->strideY, 8, 8);
+	meanOf8x8Blocks[1] = ComputeMeanFunc[0][!!(ASM_TYPES & AVX2_MASK)](&(inputPaddedPicturePtr->bufferY[blockIndex]), inputPaddedPicturePtr->strideY, 8, 8);
+	meanOf8x8SquaredValuesBlocks[1] = ComputeMeanFunc[1][!!(ASM_TYPES & AVX2_MASK)](&(inputPaddedPicturePtr->bufferY[blockIndex]), inputPaddedPicturePtr->strideY, 8, 8);
 
 	// (1,0)
 	blockIndex = inputLumaOriginIndex + (inputPaddedPicturePtr->strideY << 3);
-	meanOf8x8Blocks[2] = ComputeMeanFunc[0][(ASM_TYPES & AVX2_MASK) && 1](&(inputPaddedPicturePtr->bufferY[blockIndex]), inputPaddedPicturePtr->strideY, 8, 8);
-	meanOf8x8SquaredValuesBlocks[2] = ComputeMeanFunc[1][(ASM_TYPES & AVX2_MASK) && 1](&(inputPaddedPicturePtr->bufferY[blockIndex]), inputPaddedPicturePtr->strideY, 8, 8);
+	meanOf8x8Blocks[2] = ComputeMeanFunc[0][!!(ASM_TYPES & AVX2_MASK)](&(inputPaddedPicturePtr->bufferY[blockIndex]), inputPaddedPicturePtr->strideY, 8, 8);
+	meanOf8x8SquaredValuesBlocks[2] = ComputeMeanFunc[1][!!(ASM_TYPES & AVX2_MASK)](&(inputPaddedPicturePtr->bufferY[blockIndex]), inputPaddedPicturePtr->strideY, 8, 8);
 
 	// (1,1)
 	blockIndex = blockIndex + 8;
-	meanOf8x8Blocks[3] = ComputeMeanFunc[0][(ASM_TYPES & AVX2_MASK) && 1](&(inputPaddedPicturePtr->bufferY[blockIndex]), inputPaddedPicturePtr->strideY, 8, 8);
-	meanOf8x8SquaredValuesBlocks[3] = ComputeMeanFunc[1][(ASM_TYPES & AVX2_MASK) && 1](&(inputPaddedPicturePtr->bufferY[blockIndex]), inputPaddedPicturePtr->strideY, 8, 8);
+	meanOf8x8Blocks[3] = ComputeMeanFunc[0][!!(ASM_TYPES & AVX2_MASK)](&(inputPaddedPicturePtr->bufferY[blockIndex]), inputPaddedPicturePtr->strideY, 8, 8);
+	meanOf8x8SquaredValuesBlocks[3] = ComputeMeanFunc[1][!!(ASM_TYPES & AVX2_MASK)](&(inputPaddedPicturePtr->bufferY[blockIndex]), inputPaddedPicturePtr->strideY, 8, 8);
 
 	variance8x8[0] = meanOf8x8SquaredValuesBlocks[0] - (meanOf8x8Blocks[0] * meanOf8x8Blocks[0]);
 	variance8x8[1] = meanOf8x8SquaredValuesBlocks[1] - (meanOf8x8Blocks[1] * meanOf8x8Blocks[1]);
@@ -458,7 +458,7 @@ EB_U64 ComputeVariance64x64(
 	blockIndex = inputLumaOriginIndex;
 	const EB_U16 strideY = inputPaddedPicturePtr->strideY;
 
-    if ((ASM_TYPES & AVX2_MASK) && 1) {
+    if (!!(ASM_TYPES & AVX2_MASK)) {
 
         ComputeIntermVarFour8x8_AVX2_INTRIN(&(inputPaddedPicturePtr->bufferY[blockIndex]), strideY, &meanOf8x8Blocks[0], &meanOf8x8SquaredValuesBlocks[0]);
 
@@ -1863,7 +1863,7 @@ EB_ERRORTYPE ComputeBlockMeanComputeVariance(
 
     const EB_U16 strideY = inputPaddedPicturePtr->strideY;
 
-    if ((ASM_TYPES & AVX2_MASK) && 1){
+    if (!!(ASM_TYPES & AVX2_MASK)){
 
         ComputeIntermVarFour8x8_AVX2_INTRIN(&(inputPaddedPicturePtr->bufferY[blockIndex]), strideY, &meanOf8x8Blocks[0], &meanOf8x8SquaredValuesBlocks[0]);
 
@@ -2569,7 +2569,7 @@ EB_ERRORTYPE DenoiseInputPicture(
 
 
 			if (lcuOriginX == 0)
-				StrongLumaFilter_funcPtrArray[(ASM_TYPES & AVX2_MASK) && 1](
+				StrongLumaFilter_funcPtrArray[!!(ASM_TYPES & AVX2_MASK)](
 				inputPicturePtr,
 				denoisedPicturePtr,
 				lcuOriginY,
@@ -2602,7 +2602,7 @@ EB_ERRORTYPE DenoiseInputPicture(
             lcuOriginY = lcuParams->originY;
 
 			if (lcuOriginX == 0)
-				StrongChromaFilter_funcPtrArray[(ASM_TYPES & AVX2_MASK) && 1](
+				StrongChromaFilter_funcPtrArray[!!(ASM_TYPES & AVX2_MASK)](
 				inputPicturePtr,
 				denoisedPicturePtr,
 				lcuOriginY >> subHeightCMinus1,
@@ -2655,7 +2655,7 @@ EB_ERRORTYPE DenoiseInputPicture(
             lcuOriginY = lcuParams->originY;
 
 			if (lcuOriginX == 0)
-				WeakChromaFilter_funcPtrArray[(ASM_TYPES & AVX2_MASK) && 1](
+				WeakChromaFilter_funcPtrArray[!!(ASM_TYPES & AVX2_MASK)](
 				inputPicturePtr,
 				denoisedPicturePtr,
 				lcuOriginY >> subHeightCMinus1,
@@ -2758,7 +2758,7 @@ EB_ERRORTYPE DetectInputPictureNoise(
 		EB_U32  noiseOriginIndex = noisePicturePtr->originX + lcuOriginX + noisePicturePtr->originY * noisePicturePtr->strideY;
 
 		if (lcuOriginX == 0)
-			WeakLumaFilter_funcPtrArray[(ASM_TYPES & AVX2_MASK) && 1](
+			WeakLumaFilter_funcPtrArray[!!(ASM_TYPES & AVX2_MASK)](
 			inputPicturePtr,
 			denoisedPicturePtr,
 			noisePicturePtr,
@@ -2930,7 +2930,7 @@ EB_ERRORTYPE SubSampleFilterNoise(
             lcuOriginY = lcuParams->originY;
 
 			if (lcuOriginX == 0)
-				WeakLumaFilter_funcPtrArray[(ASM_TYPES & AVX2_MASK) && 1](
+				WeakLumaFilter_funcPtrArray[!!(ASM_TYPES & AVX2_MASK)](
 				inputPicturePtr,
 				denoisedPicturePtr,
 				noisePicturePtr,
@@ -2964,7 +2964,7 @@ EB_ERRORTYPE SubSampleFilterNoise(
             lcuOriginY = lcuParams->originY;
 
 			if (lcuOriginX == 0)
-				WeakChromaFilter_funcPtrArray[(ASM_TYPES & AVX2_MASK) && 1](
+				WeakChromaFilter_funcPtrArray[!!(ASM_TYPES & AVX2_MASK)](
 				inputPicturePtr,
 				denoisedPicturePtr,
 				lcuOriginY >> subHeightCMinus1,
@@ -3010,7 +3010,7 @@ EB_ERRORTYPE SubSampleFilterNoise(
 			if (lcuParams->isCompleteLcu && pictureControlSetPtr->lcuFlatNoiseArray[lcuIndex] == 1)
 			{
 
-				WeakLumaFilterLcu_funcPtrArray[(ASM_TYPES & AVX2_MASK) && 1](
+				WeakLumaFilterLcu_funcPtrArray[!!(ASM_TYPES & AVX2_MASK)](
 					inputPicturePtr,
 					denoisedPicturePtr,
 					noisePicturePtr,
@@ -3131,7 +3131,7 @@ EB_ERRORTYPE QuarterSampleDetectNoise(
 			block64x64Y = vert64x64Index * 64;
 
 			if (block64x64X == 0)
-				WeakLumaFilter_funcPtrArray[(ASM_TYPES & AVX2_MASK) && 1](
+				WeakLumaFilter_funcPtrArray[!!(ASM_TYPES & AVX2_MASK)](
 				quarterDecimatedPicturePtr,
 				denoisedPicturePtr,
 				noisePicturePtr,
@@ -3275,7 +3275,7 @@ EB_ERRORTYPE SubSampleDetectNoise(
 			block64x64Y = vert64x64Index * 64;
 
 			if (block64x64X == 0)
-				WeakLumaFilter_funcPtrArray[(ASM_TYPES & AVX2_MASK) && 1](
+				WeakLumaFilter_funcPtrArray[!!(ASM_TYPES & AVX2_MASK)](
 				sixteenthDecimatedPicturePtr,
 				denoisedPicturePtr,
 				noisePicturePtr,

--- a/Source/Lib/Codec/EbPictureOperators.c
+++ b/Source/Lib/Codec/EbPictureOperators.c
@@ -286,7 +286,7 @@ EB_ERRORTYPE PictureFastDistortion(
     // Y
     if (componentMask & PICTURE_BUFFER_DESC_Y_FLAG) {
 
-        lumaDistortion[DIST_CALC_RESIDUAL] += NxMSadKernel_funcPtrArray[(ASM_TYPES & AVX2_MASK) && 1][size >> 3](
+        lumaDistortion[DIST_CALC_RESIDUAL] += NxMSadKernel_funcPtrArray[!!(ASM_TYPES & AVX2_MASK)][size >> 3](
             &(input->bufferY[inputLumaOriginIndex]),
             input->strideY,
             &(pred->bufferY[predLumaOriginIndex]),
@@ -298,7 +298,7 @@ EB_ERRORTYPE PictureFastDistortion(
     // Cb
     if (componentMask & PICTURE_BUFFER_DESC_Cb_FLAG) {
 
-        chromaDistortion[DIST_CALC_RESIDUAL] += NxMSadKernel_funcPtrArray[(ASM_TYPES & AVX2_MASK) && 1][chromaSize >> 3]( // Always SAD without weighting
+        chromaDistortion[DIST_CALC_RESIDUAL] += NxMSadKernel_funcPtrArray[!!(ASM_TYPES & AVX2_MASK)][chromaSize >> 3]( // Always SAD without weighting
             &(input->bufferCb[inputChromaOriginIndex]),
             input->strideCb,
             &(pred->bufferCb[predChromaOriginIndex]),
@@ -310,7 +310,7 @@ EB_ERRORTYPE PictureFastDistortion(
     // Cr
     if (componentMask & PICTURE_BUFFER_DESC_Cr_FLAG) {
 
-        chromaDistortion[DIST_CALC_RESIDUAL] += NxMSadKernel_funcPtrArray[(ASM_TYPES & AVX2_MASK) && 1][chromaSize >> 3]( // Always SAD without weighting
+        chromaDistortion[DIST_CALC_RESIDUAL] += NxMSadKernel_funcPtrArray[!!(ASM_TYPES & AVX2_MASK)][chromaSize >> 3]( // Always SAD without weighting
             &(input->bufferCr[inputChromaOriginIndex]),
             input->strideCr,
             &(pred->bufferCr[predChromaOriginIndex]),
@@ -454,7 +454,7 @@ void UnpackL0L1Avg(
         EB_U32  height)
  {
  
-     UnPackAvg_funcPtrArray[(ASM_TYPES & AVX2_MASK) && 1](
+     UnPackAvg_funcPtrArray[!!(ASM_TYPES & AVX2_MASK)](
         ref16L0,
         refL0Stride,
         ref16L1,
@@ -476,7 +476,7 @@ void Extract8BitdataSafeSub(
     )
 {
 
-    UnPack8BITSafeSub_funcPtrArray_16Bit[(ASM_TYPES & AVX2_MASK) && 1](
+    UnPack8BITSafeSub_funcPtrArray_16Bit[!!(ASM_TYPES & AVX2_MASK)](
         in16BitBuffer,
         inStride,
         out8BitBuffer,    
@@ -497,7 +497,7 @@ void UnpackL0L1AvgSafeSub(
  {
      //fix C
 
-     UnPackAvgSafeSub_funcPtrArray[(ASM_TYPES & AVX2_MASK) && 1](
+     UnPackAvgSafeSub_funcPtrArray[!!(ASM_TYPES & AVX2_MASK)](
         ref16L0,
         refL0Stride,
         ref16L1,
@@ -523,7 +523,7 @@ void UnPack2D(
 #ifndef NON_AVX512_SUPPORT
     UnPack2D_funcPtrArray_16Bit[((width & 3) == 0) && ((height & 1)== 0)][(ASM_TYPES & AVX512_MASK) && 1](
 #else
-    UnPack2D_funcPtrArray_16Bit[((width & 3) == 0) && ((height & 1) == 0)][(ASM_TYPES & AVX2_MASK) && 1](
+    UnPack2D_funcPtrArray_16Bit[((width & 3) == 0) && ((height & 1) == 0)][!!(ASM_TYPES & AVX2_MASK)](
 #endif
         in16BitBuffer,
         inStride,
@@ -547,7 +547,7 @@ void Pack2D_SRC(
    )
 {
 	 
-    Pack2D_funcPtrArray_16Bit_SRC[((width & 3) == 0) && ((height & 1)== 0)][(ASM_TYPES & AVX2_MASK) && 1](
+    Pack2D_funcPtrArray_16Bit_SRC[((width & 3) == 0) && ((height & 1)== 0)][!!(ASM_TYPES & AVX2_MASK)](
         in8BitBuffer,
         in8Stride,
         innBitBuffer,
@@ -570,7 +570,7 @@ void CompressedPackLcu(
 )
 {
 
-    CompressedPack_funcPtrArray[((width == 64 || width == 32) ? ((ASM_TYPES & AVX2_MASK) && 1) : EB_ASM_C)](
+    CompressedPack_funcPtrArray[((width == 64 || width == 32) ? (!!(ASM_TYPES & AVX2_MASK)) : EB_ASM_C)](
         in8BitBuffer,
         in8Stride,
         innBitBuffer,
@@ -595,7 +595,7 @@ void CompressedPackBlk(
 {
 
 
-	CompressedPack_funcPtrArray[((width == 64 || width == 32 || width == 16 || width == 8) ? ((ASM_TYPES & AVX2_MASK) && 1) : EB_ASM_C)](
+	CompressedPack_funcPtrArray[((width == 64 || width == 32 || width == 16 || width == 8) ? (!!(ASM_TYPES & AVX2_MASK)) : EB_ASM_C)](
 		in8BitBuffer,
 		in8Stride,
 		innBitBuffer,
@@ -617,7 +617,7 @@ void Conv2bToCPackLcu(
 	EB_U32     height)
 {
 
-	Convert_Unpack_CPack_funcPtrArray[((width == 64 || width == 32) ? ((ASM_TYPES & AVX2_MASK) && 1) : EB_ASM_C)](
+	Convert_Unpack_CPack_funcPtrArray[((width == 64 || width == 32) ? (!!(ASM_TYPES & AVX2_MASK)) : EB_ASM_C)](
 		innBitBuffer,
 		innStride,
 		inCompnBitBuffer,

--- a/Source/Lib/Codec/EbPictureOperators.c
+++ b/Source/Lib/Codec/EbPictureOperators.c
@@ -28,7 +28,7 @@ void PictureAddition(
     EB_U32  height)
 {
 
-	AdditionKernel_funcPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1][width >> 3](
+	AdditionKernel_funcPtrArray[!!(ASM_TYPES & PREAVX2_MASK)][width >> 3](
         predPtr,
         predStride,
         residualPtr,
@@ -63,7 +63,7 @@ EB_ERRORTYPE PictureCopy8Bit(
     // Execute the Kernels
     if (componentMask & PICTURE_BUFFER_DESC_Y_FLAG) {
 
-        PicCopyKernel_funcPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1][areaWidth>>3](
+        PicCopyKernel_funcPtrArray[!!(ASM_TYPES & PREAVX2_MASK)][areaWidth>>3](
             &(src->bufferY[srcLumaOriginIndex]),
             src->strideY,
             &(dst->bufferY[dstLumaOriginIndex]),
@@ -74,7 +74,7 @@ EB_ERRORTYPE PictureCopy8Bit(
 
     if (componentMask & PICTURE_BUFFER_DESC_Cb_FLAG) {
 
-		PicCopyKernel_funcPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1][chromaAreaWidth >> 3](
+		PicCopyKernel_funcPtrArray[!!(ASM_TYPES & PREAVX2_MASK)][chromaAreaWidth >> 3](
             &(src->bufferCb[srcChromaOriginIndex]),
             src->strideCb,
             &(dst->bufferCb[dstChromaOriginIndex]),
@@ -85,7 +85,7 @@ EB_ERRORTYPE PictureCopy8Bit(
 
     if (componentMask & PICTURE_BUFFER_DESC_Cr_FLAG) {
 
-		PicCopyKernel_funcPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1][chromaAreaWidth >> 3](
+		PicCopyKernel_funcPtrArray[!!(ASM_TYPES & PREAVX2_MASK)][chromaAreaWidth >> 3](
             &(src->bufferCr[srcChromaOriginIndex]),
             src->strideCr,
             &(dst->bufferCr[dstChromaOriginIndex]),
@@ -114,7 +114,7 @@ void PictureSubSampledResidual(
     EB_U8    lastLine)    //the last line has correct prediction data, so no duplication to be done.
 {
 
-    ResidualKernelSubSampled_funcPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1][areaWidth>>3](
+    ResidualKernelSubSampled_funcPtrArray[!!(ASM_TYPES & PREAVX2_MASK)][areaWidth>>3](
         input,
         inputStride,
         pred,
@@ -142,7 +142,7 @@ void PictureResidual(
     EB_U32   areaHeight)
 {
 
-    ResidualKernel_funcPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1][areaWidth>>3](
+    ResidualKernel_funcPtrArray[!!(ASM_TYPES & PREAVX2_MASK)][areaWidth>>3](
         input,
         inputStride,
         pred,
@@ -170,7 +170,7 @@ void PictureResidual16bit(
     EB_U32   areaHeight)
 {
 
-    ResidualKernel_funcPtrArray16Bit[(ASM_TYPES & PREAVX2_MASK) && 1](
+    ResidualKernel_funcPtrArray16Bit[!!(ASM_TYPES & PREAVX2_MASK)](
         input,
         inputStride,
         pred,
@@ -193,7 +193,7 @@ EB_U64 ComputeNxMSatd8x8Units_U8(
 	EB_U64 satd = 0;
 	EB_U32 blockIndexInWidth;
 	EB_U32 blockIndexInHeight;
-	EB_SATD_U8_TYPE Compute8x8SatdFunction = Compute8x8Satd_U8_funcPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1];
+	EB_SATD_U8_TYPE Compute8x8SatdFunction = Compute8x8Satd_U8_funcPtrArray[!!(ASM_TYPES & PREAVX2_MASK)];
 
 	for (blockIndexInHeight = 0; blockIndexInHeight < height >> 3; ++blockIndexInHeight) {
 		for (blockIndexInWidth = 0; blockIndexInWidth < width >> 3; ++blockIndexInWidth) {
@@ -349,7 +349,7 @@ EB_ERRORTYPE PictureFullDistortion_R(
     // Y
     if (componentMask & PICTURE_BUFFER_DESC_Y_FLAG) {
 			
-		FullDistortionIntrinsic_funcPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1][countNonZeroCoeffs[0] != 0][mode == INTRA_MODE][areaSize>>3](
+		FullDistortionIntrinsic_funcPtrArray[!!(ASM_TYPES & PREAVX2_MASK)][countNonZeroCoeffs[0] != 0][mode == INTRA_MODE][areaSize>>3](
             &(((EB_S16*) coeff->bufferY)[coeffLumaOriginIndex]),
             coeff->strideY,
             &(((EB_S16*) reconCoeff->bufferY)[coeffLumaOriginIndex]),
@@ -362,7 +362,7 @@ EB_ERRORTYPE PictureFullDistortion_R(
     // Cb
     if (componentMask & PICTURE_BUFFER_DESC_Cb_FLAG) {
         
-		FullDistortionIntrinsic_funcPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1][countNonZeroCoeffs[1] != 0][mode == INTRA_MODE][chromaAreaSize >> 3](
+		FullDistortionIntrinsic_funcPtrArray[!!(ASM_TYPES & PREAVX2_MASK)][countNonZeroCoeffs[1] != 0][mode == INTRA_MODE][chromaAreaSize >> 3](
             &(((EB_S16*) coeff->bufferCb)[coeffChromaOriginIndex]),
             coeff->strideCb,
             &(((EB_S16*) reconCoeff->bufferCb)[coeffChromaOriginIndex]),
@@ -375,7 +375,7 @@ EB_ERRORTYPE PictureFullDistortion_R(
     // Cr
     if (componentMask & PICTURE_BUFFER_DESC_Cr_FLAG) {
 
-		FullDistortionIntrinsic_funcPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1][countNonZeroCoeffs[2] != 0][mode == INTRA_MODE][chromaAreaSize >> 3](
+		FullDistortionIntrinsic_funcPtrArray[!!(ASM_TYPES & PREAVX2_MASK)][countNonZeroCoeffs[2] != 0][mode == INTRA_MODE][chromaAreaSize >> 3](
             &(((EB_S16*) coeff->bufferCr)[coeffChromaOriginIndex]),
             coeff->strideCr,
             &(((EB_S16*) reconCoeff->bufferCr)[coeffChromaOriginIndex]),
@@ -411,7 +411,7 @@ EB_ERRORTYPE PictureFullDistortionLuma(
     lumaDistortion[1]   = 0;
 	
     // Y
-	FullDistortionIntrinsic_funcPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1][countNonZeroCoeffsY != 0][mode == INTRA_MODE][areaSize >> 3](
+	FullDistortionIntrinsic_funcPtrArray[!!(ASM_TYPES & PREAVX2_MASK)][countNonZeroCoeffsY != 0][mode == INTRA_MODE][areaSize >> 3](
         &(((EB_S16*) coeff->bufferY)[coeffLumaOriginIndex]),
         coeff->strideY,
         &(((EB_S16*) reconCoeff->bufferY)[reconCoeffLumaOriginIndex]),
@@ -435,7 +435,7 @@ void extract8Bitdata(
     )
 {
     
-    UnPack8BIT_funcPtrArray_16Bit[((width & 3) == 0) && ((height & 1)== 0)][(ASM_TYPES & PREAVX2_MASK) && 1](
+    UnPack8BIT_funcPtrArray_16Bit[((width & 3) == 0) && ((height & 1)== 0)][!!(ASM_TYPES & PREAVX2_MASK)](
         in16BitBuffer,
         inStride,
         out8BitBuffer,    

--- a/Source/Lib/Codec/EbPictureOperators.c
+++ b/Source/Lib/Codec/EbPictureOperators.c
@@ -521,7 +521,7 @@ void UnPack2D(
     )
 {
 #ifndef NON_AVX512_SUPPORT
-    UnPack2D_funcPtrArray_16Bit[((width & 3) == 0) && ((height & 1)== 0)][(ASM_TYPES & AVX512_MASK) && 1](
+    UnPack2D_funcPtrArray_16Bit[((width & 3) == 0) && ((height & 1)== 0)][!!(ASM_TYPES & AVX512_MASK)](
 #else
     UnPack2D_funcPtrArray_16Bit[((width & 3) == 0) && ((height & 1) == 0)][!!(ASM_TYPES & AVX2_MASK)](
 #endif

--- a/Source/Lib/Codec/EbProductCodingLoop.c
+++ b/Source/Lib/Codec/EbProductCodingLoop.c
@@ -1379,7 +1379,7 @@ void PerformInverseTransformRecon(
                         EB_FALSE,
                         tuSize < 32 ? PF_OFF : contextPtr->pfMdMode);
 
-                    AdditionKernel_funcPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1][tuSize >> 3](
+                    AdditionKernel_funcPtrArray[!!(ASM_TYPES & PREAVX2_MASK)][tuSize >> 3](
                         &(candidateBuffer->predictionPtr->bufferY[tuOriginIndex]),
                         64,
                         &(((EB_S16*)(contextPtr->transQuantBuffersPtr->tuTransCoeff2Nx2NPtr->bufferY))[tuOriginIndex]),
@@ -3251,7 +3251,7 @@ EB_EXTERN EB_ERRORTYPE PerformIntra4x4Search(
                         EB_TRUE,
                         EB_FALSE);
 
-                    AdditionKernel_funcPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1][candidateBuffer->candidatePtr->transformSize >> 3](
+                    AdditionKernel_funcPtrArray[!!(ASM_TYPES & PREAVX2_MASK)][candidateBuffer->candidatePtr->transformSize >> 3](
                         &(candidateBuffer->predictionPtr->bufferY[puOriginIndex]),
                         candidateBuffer->predictionPtr->strideY,
                         &(((EB_S16*)(contextPtr->transQuantBuffersPtr->tuTransCoeff2Nx2NPtr->bufferY))[puOriginIndex]),
@@ -3277,7 +3277,7 @@ EB_EXTERN EB_ERRORTYPE PerformIntra4x4Search(
                         PICTURE_BUFFER_DESC_Y_FLAG);
                 }
 
-                yFullDistortion[0] = SpatialFullDistortionKernel_funcPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1][Log2f(MIN_PU_SIZE) - 2](
+                yFullDistortion[0] = SpatialFullDistortionKernel_funcPtrArray[!!(ASM_TYPES & PREAVX2_MASK)][Log2f(MIN_PU_SIZE) - 2](
                     &(inputPicturePtr->bufferY[inputOriginIndex]),
                     inputPicturePtr->strideY,
                     &(candidateBuffer->reconPtr->bufferY[puOriginIndex]),
@@ -3301,7 +3301,7 @@ EB_EXTERN EB_ERRORTYPE PerformIntra4x4Search(
                             EB_FALSE, // DCT
                             EB_FALSE);
 
-                        AdditionKernel_funcPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1][candidateBuffer->candidatePtr->transformSize >> 3](
+                        AdditionKernel_funcPtrArray[!!(ASM_TYPES & PREAVX2_MASK)][candidateBuffer->candidatePtr->transformSize >> 3](
                             &(candidateBuffer->predictionPtr->bufferCb[puChromaOriginIndex]),
                             candidateBuffer->predictionPtr->strideCb,
                             &(((EB_S16*)(contextPtr->transQuantBuffersPtr->tuTransCoeff2Nx2NPtr->bufferCb))[puChromaOriginIndex]),
@@ -3327,7 +3327,7 @@ EB_EXTERN EB_ERRORTYPE PerformIntra4x4Search(
                             PICTURE_BUFFER_DESC_Cb_FLAG);
                     }
 
-                    cbFullDistortion[0] = SpatialFullDistortionKernel_funcPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1][Log2f(MIN_PU_SIZE) - 2](
+                    cbFullDistortion[0] = SpatialFullDistortionKernel_funcPtrArray[!!(ASM_TYPES & PREAVX2_MASK)][Log2f(MIN_PU_SIZE) - 2](
                         &(inputPicturePtr->bufferCb[inputChromaOriginIndex]),
                         inputPicturePtr->strideCb,
                         &(candidateBuffer->reconPtr->bufferCb[puChromaOriginIndex]),
@@ -3349,7 +3349,7 @@ EB_EXTERN EB_ERRORTYPE PerformIntra4x4Search(
                             EB_FALSE, // DCT
                             EB_FALSE);
 
-                        AdditionKernel_funcPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1][candidateBuffer->candidatePtr->transformSize >> 3](
+                        AdditionKernel_funcPtrArray[!!(ASM_TYPES & PREAVX2_MASK)][candidateBuffer->candidatePtr->transformSize >> 3](
                             &(candidateBuffer->predictionPtr->bufferCr[puChromaOriginIndex]),
                             candidateBuffer->predictionPtr->strideCr,
                             &(((EB_S16*)(contextPtr->transQuantBuffersPtr->tuTransCoeff2Nx2NPtr->bufferCr))[puChromaOriginIndex]),
@@ -3375,7 +3375,7 @@ EB_EXTERN EB_ERRORTYPE PerformIntra4x4Search(
                             PICTURE_BUFFER_DESC_Cr_FLAG);
                     }
 
-                    crFullDistortion[0] = SpatialFullDistortionKernel_funcPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1][Log2f(MIN_PU_SIZE) - 2](
+                    crFullDistortion[0] = SpatialFullDistortionKernel_funcPtrArray[!!(ASM_TYPES & PREAVX2_MASK)][Log2f(MIN_PU_SIZE) - 2](
                         &(inputPicturePtr->bufferCr[inputChromaOriginIndex]),
                         inputPicturePtr->strideCr,
                         &(candidateBuffer->reconPtr->bufferCr[puChromaOriginIndex]),
@@ -3452,7 +3452,7 @@ EB_EXTERN EB_ERRORTYPE PerformIntra4x4Search(
                     BIT_INCREMENT_8BIT,
                     EB_TRUE, // DST
                     EB_FALSE);
-                AdditionKernel_funcPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1][candidateBuffer->candidatePtr->transformSize >> 3](
+                AdditionKernel_funcPtrArray[!!(ASM_TYPES & PREAVX2_MASK)][candidateBuffer->candidatePtr->transformSize >> 3](
                     &(candidateBuffer->predictionPtr->bufferY[puOriginIndex]),
                     candidateBuffer->predictionPtr->strideY,
                     &(((EB_S16*)(contextPtr->transQuantBuffersPtr->tuTransCoeff2Nx2NPtr->bufferY))[puOriginIndex]),
@@ -4113,7 +4113,7 @@ void UpdateMdReconBuffer(
 	LargestCodingUnit_t				*lcuPtr)
 {
 	if ((contextPtr->cuStats->size >> 3) < 9) {
-		PicCopyKernel_funcPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1][contextPtr->cuStats->size >> 3](
+		PicCopyKernel_funcPtrArray[!!(ASM_TYPES & PREAVX2_MASK)][contextPtr->cuStats->size >> 3](
 			&(reconSrcPtr->bufferY[contextPtr->cuStats->originX + contextPtr->cuStats->originY * reconSrcPtr->strideY]),
 			reconSrcPtr->strideY,
 			&(reconDstPtr->bufferY[contextPtr->cuStats->originX + contextPtr->cuStats->originY * reconDstPtr->strideY]),
@@ -4126,7 +4126,7 @@ void UpdateMdReconBuffer(
 			EB_U16  chromaOriginX = contextPtr->cuStats->originX >> 1;
 			EB_U16  chromaOriginY = contextPtr->cuStats->originY >> 1;
 
-			PicCopyKernel_funcPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1][chromaSize >> 3](
+			PicCopyKernel_funcPtrArray[!!(ASM_TYPES & PREAVX2_MASK)][chromaSize >> 3](
 				&(reconSrcPtr->bufferCb[chromaOriginX + chromaOriginY * reconSrcPtr->strideCb]),
 				reconSrcPtr->strideCb,
 				&(reconDstPtr->bufferCb[chromaOriginX + chromaOriginY * reconDstPtr->strideCb]),
@@ -4134,7 +4134,7 @@ void UpdateMdReconBuffer(
 				chromaSize,
 				chromaSize);
 
-			PicCopyKernel_funcPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1][chromaSize >> 3](
+			PicCopyKernel_funcPtrArray[!!(ASM_TYPES & PREAVX2_MASK)][chromaSize >> 3](
 				&(reconSrcPtr->bufferCr[chromaOriginX + chromaOriginY * reconSrcPtr->strideCr]),
 				reconSrcPtr->strideCr,
 				&(reconDstPtr->bufferCr[chromaOriginX + chromaOriginY * reconDstPtr->strideCr]),

--- a/Source/Lib/Codec/EbProductCodingLoop.c
+++ b/Source/Lib/Codec/EbProductCodingLoop.c
@@ -2036,7 +2036,7 @@ void ProductPerformFastLoop(
 					lumaFastDistortion = candidatePtr->meDistortion;
 				else
 					// Y
-					lumaFastDistortion += (NxMSadKernel_funcPtrArray[(ASM_TYPES & AVX2_MASK) && 1][cuSize >> 3] ( 
+					lumaFastDistortion += (NxMSadKernel_funcPtrArray[!!(ASM_TYPES & AVX2_MASK)][cuSize >> 3] ( 
 						inputBufferY,
 						inputStrideY,
 						predBufferY,
@@ -2050,7 +2050,7 @@ void ProductPerformFastLoop(
                     EB_U8 * const inputBufferCb = inputPicturePtr->bufferCb + inputCbOriginIndex;
                     EB_U8 *  const predBufferCb = candidateBuffer->predictionPtr->bufferCb + cuChromaOriginIndex;
 
-					chromaFastDistortion += NxMSadKernel_funcPtrArray[(ASM_TYPES & AVX2_MASK) && 1][cuSize >> 4] ( 
+					chromaFastDistortion += NxMSadKernel_funcPtrArray[!!(ASM_TYPES & AVX2_MASK)][cuSize >> 4] ( 
 						inputBufferCb,
 						inputPicturePtr->strideCb,
 						predBufferCb,
@@ -2062,7 +2062,7 @@ void ProductPerformFastLoop(
                     EB_U8 * const inputBufferCr = inputPicturePtr->bufferCr + inputCrOriginIndex;
                     EB_U8 * const predBufferCr = candidateBuffer->predictionPtr->bufferCr + cuChromaOriginIndex;
 
-                    chromaFastDistortion += NxMSadKernel_funcPtrArray[(ASM_TYPES & AVX2_MASK) && 1][cuSize >> 4] (
+                    chromaFastDistortion += NxMSadKernel_funcPtrArray[!!(ASM_TYPES & AVX2_MASK)][cuSize >> 4] (
                         inputBufferCr,
                         inputPicturePtr->strideCb ,
                         predBufferCr,

--- a/Source/Lib/Codec/EbSampleAdaptiveOffsetGenerationDecision.c
+++ b/Source/Lib/Codec/EbSampleAdaptiveOffsetGenerationDecision.c
@@ -698,7 +698,7 @@ EB_ERRORTYPE SaoGenerationDecision(
 
     if (mmSao) {
         // Y
-        SaoGatherFunctionTableLossy[(ASM_TYPES & PREAVX2_MASK) && 1](
+        SaoGatherFunctionTableLossy[!!(ASM_TYPES & PREAVX2_MASK)](
             &(inputPicturePtr->bufferY[(inputPicturePtr->originY + tbOriginY) * inputPicturePtr->strideY + inputPicturePtr->originX + tbOriginX]),
             inputPicturePtr->strideY,
             &(reconPicturePtr->bufferY[(reconPicturePtr->originY + tbOriginY) * reconPicturePtr->strideY + reconPicturePtr->originX + tbOriginX]),
@@ -711,7 +711,7 @@ EB_ERRORTYPE SaoGenerationDecision(
             saoStats->eoCount[0]);
 
         // U
-        SaoGatherFunctionTableLossy[(ASM_TYPES & PREAVX2_MASK) && 1](
+        SaoGatherFunctionTableLossy[!!(ASM_TYPES & PREAVX2_MASK)](
             &(inputPicturePtr->bufferCb[(((inputPicturePtr->originY + tbOriginY) * inputPicturePtr->strideCb) >> subHeightCMinus1) + ((inputPicturePtr->originX + tbOriginX) >> subWidthCMinus1)]),
             inputPicturePtr->strideCb,
             &(reconPicturePtr->bufferCb[(((reconPicturePtr->originY + tbOriginY) * reconPicturePtr->strideCb) >> subHeightCMinus1) + ((reconPicturePtr->originX + tbOriginX) >> subWidthCMinus1)]),
@@ -724,7 +724,7 @@ EB_ERRORTYPE SaoGenerationDecision(
             saoStats->eoCount[1]);
 
         // V
-        SaoGatherFunctionTableLossy[(ASM_TYPES & PREAVX2_MASK) && 1](
+        SaoGatherFunctionTableLossy[!!(ASM_TYPES & PREAVX2_MASK)](
             &(inputPicturePtr->bufferCr[(((inputPicturePtr->originY + tbOriginY) * inputPicturePtr->strideCr) >> subHeightCMinus1) + ((inputPicturePtr->originX + tbOriginX) >> subWidthCMinus1)]),
             inputPicturePtr->strideCr,
             &(reconPicturePtr->bufferCr[(((reconPicturePtr->originY + tbOriginY) * reconPicturePtr->strideCr) >> subHeightCMinus1) + ((reconPicturePtr->originX + tbOriginX) >> subHeightCMinus1)]),
@@ -773,7 +773,7 @@ EB_ERRORTYPE SaoGenerationDecision(
         if (pictureControlSetPtr->temporalLayerIndex == 0) {
             // Y
             {
-                SaoGatherFunctionTableLossy_90_45_135[(ASM_TYPES & PREAVX2_MASK) && 1](
+                SaoGatherFunctionTableLossy_90_45_135[!!(ASM_TYPES & PREAVX2_MASK)](
                     &(inputPicturePtr->bufferY[(inputPicturePtr->originY + tbOriginY) * inputPicturePtr->strideY + inputPicturePtr->originX + tbOriginX]),
                     inputPicturePtr->strideY,
                     &(reconPicturePtr->bufferY[(reconPicturePtr->originY + tbOriginY) * reconPicturePtr->strideY + reconPicturePtr->originX + tbOriginX]),
@@ -788,7 +788,7 @@ EB_ERRORTYPE SaoGenerationDecision(
 
         if (pictureControlSetPtr->temporalLayerIndex == 1) {
             // Y
-            SaoGatherFunctionTableLossy_90_45_135[(ASM_TYPES & PREAVX2_MASK) && 1](
+            SaoGatherFunctionTableLossy_90_45_135[!!(ASM_TYPES & PREAVX2_MASK)](
                 &(inputPicturePtr->bufferY[(inputPicturePtr->originY + tbOriginY) * inputPicturePtr->strideY + inputPicturePtr->originX + tbOriginX]),
                 inputPicturePtr->strideY,
                 &(reconPicturePtr->bufferY[(reconPicturePtr->originY + tbOriginY) * reconPicturePtr->strideY + reconPicturePtr->originX + tbOriginX]),
@@ -1069,7 +1069,7 @@ EB_ERRORTYPE SaoGenerationDecision16bit(
 			//; Requirement: lcuHeight > 2
 
 			{
-                SaoGatherFunctionTable_90_45_135_16bit_SSE2[(ASM_TYPES & PREAVX2_MASK) && 1][((lcuWidth & 15) == 0) || (lcuWidth == 28) || (lcuWidth == 56)](
+                SaoGatherFunctionTable_90_45_135_16bit_SSE2[!!(ASM_TYPES & PREAVX2_MASK)][((lcuWidth & 15) == 0) || (lcuWidth == 28) || (lcuWidth == 56)](
                     (EB_U16*)inputLcuPtr->bufferY,
                     inputLcuPtr->strideY,
                     (EB_U16*)(recon16->bufferY) + (recon16->originY + tbOriginY)*recon16->strideY + (recon16->originX + tbOriginX),
@@ -1082,7 +1082,7 @@ EB_ERRORTYPE SaoGenerationDecision16bit(
 		}
 
 		if (pictureControlSetPtr->temporalLayerIndex == 1) {
-            SaoGatherFunctionTable_90_45_135_16bit_SSE2[(ASM_TYPES & PREAVX2_MASK) && 1][((lcuWidth & 15) == 0) || (lcuWidth == 28) || (lcuWidth == 56)](
+            SaoGatherFunctionTable_90_45_135_16bit_SSE2[!!(ASM_TYPES & PREAVX2_MASK)][((lcuWidth & 15) == 0) || (lcuWidth == 28) || (lcuWidth == 56)](
                 (EB_U16*)inputLcuPtr->bufferY,
                 inputLcuPtr->strideY,
                 (EB_U16*)(recon16->bufferY) + (recon16->originY + tbOriginY)*recon16->strideY + (recon16->originX + tbOriginX),

--- a/Source/Lib/Codec/EbTransforms.c
+++ b/Source/Lib/Codec/EbTransforms.c
@@ -2195,7 +2195,7 @@ void MaskTransformCoeffs(
 	
 	depthIndex = depthIndex < 4 ? depthIndex : 0;
 
-	MatMul_funcPtrArray[(ASM_TYPES & AVX2_MASK) && 1][activeAreaSize >> 3](
+	MatMul_funcPtrArray[!!(ASM_TYPES & AVX2_MASK)][activeAreaSize >> 3](
         coeff,
         coeffStride,
         &MaskingMatrix[pmpMaskingClass][pmpMaskingLevelEncDec][depthIndex][0],
@@ -2278,7 +2278,7 @@ void PerformTwoStagePm(
     *yCountNonZeroCoeffs = 0;
 
     // Do the Quantization to avoid extra compute for areas without non zero coefficient
-	QiQ_funcPtrArray[(ASM_TYPES & AVX2_MASK) && 1][activeAreaSize >> 3](
+	QiQ_funcPtrArray[!!(ASM_TYPES & AVX2_MASK)][activeAreaSize >> 3](
         coeff,
         coeffStride,
         quantCoeff,
@@ -2511,7 +2511,7 @@ void PerformTwoStagePm(
                         EbPMCand_t  *pmCand = &pmCandBuffer[canDi];
 						
 						//There is Mismatch between ASM vs C !
-						MatMulOut_funcPtrArray[(ASM_TYPES & AVX2_MASK) && 1](
+						MatMulOut_funcPtrArray[!!(ASM_TYPES & AVX2_MASK)](
 							&coeff[blkOffset],
 							coeffStride,
 							pmCand->trCoeff,
@@ -2529,7 +2529,7 @@ void PerformTwoStagePm(
 						}
 
 
-						QiQ_funcPtrArray[(ASM_TYPES & AVX2_MASK) && 1][blkAreaSize >> 3](
+						QiQ_funcPtrArray[!!(ASM_TYPES & AVX2_MASK)][blkAreaSize >> 3](
                             pmCand->trCoeff,
                             PM_STRIDE,
                             pmCand->quCoeff,
@@ -2643,7 +2643,7 @@ void DecoupledQuantizeInvQuantizeLoops(
 	adptive_qp_offset = q_offset;
 	coeffLocation = 0;
 	*nonzerocoeff = 0;
-	QiQ_funcPtrArray[(ASM_TYPES & AVX2_MASK) && 1][areaSize >> 3](
+	QiQ_funcPtrArray[!!(ASM_TYPES & AVX2_MASK)][areaSize >> 3](
 		coeff,
         coeffStride,
         quantCoeff,
@@ -2846,7 +2846,7 @@ void DecoupledQuantizeInvQuantizeLoops(
 						EbPMCand_t  *pmCand = &pmCandBuffer[canDi];
 
 						//There is Mismatch between ASM vs C !
-						MatMulOut_funcPtrArray[(ASM_TYPES & AVX2_MASK) && 1](
+						MatMulOut_funcPtrArray[!!(ASM_TYPES & AVX2_MASK)](
 							&coeff[blkOffset],
 							coeffStride,
 							pmCand->trCoeff,
@@ -2864,7 +2864,7 @@ void DecoupledQuantizeInvQuantizeLoops(
 						}
 
 
-						QiQ_funcPtrArray[(ASM_TYPES & AVX2_MASK) && 1][blkAreaSize >> 3](
+						QiQ_funcPtrArray[!!(ASM_TYPES & AVX2_MASK)][blkAreaSize >> 3](
 							pmCand->trCoeff,
 							PM_STRIDE,
 							pmCand->quCoeff,
@@ -3128,7 +3128,7 @@ void UnifiedQuantizeInvQuantize(
             }
             //QiQ SSSE3 is hardcoded 
             //QiQ   Use this for SW	
-			QiQ_funcPtrArray[(ASM_TYPES & AVX2_MASK) && 1][activeAreaSize >> 3](
+			QiQ_funcPtrArray[!!(ASM_TYPES & AVX2_MASK)][activeAreaSize >> 3](
                 coeff,
                 coeffStride,
                 quantCoeff,
@@ -3169,7 +3169,7 @@ void UnifiedQuantizeInvQuantize(
 
             } else {
 
-				QiQ_funcPtrArray[(ASM_TYPES & AVX2_MASK) && 1][activeAreaSize >> 3](
+				QiQ_funcPtrArray[!!(ASM_TYPES & AVX2_MASK)][activeAreaSize >> 3](
                     coeff,
                     coeffStride,
                     quantCoeff,
@@ -3274,7 +3274,7 @@ EB_ERRORTYPE EstimateTransform(
     EB_U32 transformSizeFlag = Log2f(TRANSFORM_MAX_SIZE) - Log2f(transformSize);
 
     if (transCoeffShape == DEFAULT_SHAPE) {
-		(*transformFunctionTableEstimate[(ASM_TYPES & AVX2_MASK) && 1][transformSizeFlag + dstTansformFlag])(
+		(*transformFunctionTableEstimate[!!(ASM_TYPES & AVX2_MASK)][transformSizeFlag + dstTansformFlag])(
             residualBuffer,
             residualStride,
             coeffBuffer,
@@ -3286,7 +3286,7 @@ EB_ERRORTYPE EstimateTransform(
 
     else if (transCoeffShape == N2_SHAPE) {
 
-		(*PfreqN2TransformTable0[(ASM_TYPES & AVX2_MASK) && 1][transformSizeFlag + dstTansformFlag])(
+		(*PfreqN2TransformTable0[!!(ASM_TYPES & AVX2_MASK)][transformSizeFlag + dstTansformFlag])(
             residualBuffer,
             residualStride,
             coeffBuffer,
@@ -3297,7 +3297,7 @@ EB_ERRORTYPE EstimateTransform(
 
     else if (transCoeffShape == N4_SHAPE) {
 
-		(*PfreqN4TransformTable0[(ASM_TYPES & AVX2_MASK) && 1][transformSizeFlag + dstTansformFlag])(
+		(*PfreqN4TransformTable0[!!(ASM_TYPES & AVX2_MASK)][transformSizeFlag + dstTansformFlag])(
             residualBuffer,
             residualStride,
             coeffBuffer,
@@ -3309,7 +3309,7 @@ EB_ERRORTYPE EstimateTransform(
 
         EB_S32 sumResidual;
 
-		sumResidual = SumResidual_funcPtrArray[(ASM_TYPES & AVX2_MASK) && 1](
+		sumResidual = SumResidual_funcPtrArray[!!(ASM_TYPES & AVX2_MASK)](
             residualBuffer,
             transformSize,
             residualStride);
@@ -3348,7 +3348,7 @@ EB_ERRORTYPE EncodeTransform(
     EB_U32 transformSizeFlag = Log2f(TRANSFORM_MAX_SIZE) - Log2f(transformSize);
 
     if (transCoeffShape == DEFAULT_SHAPE) {
-        if (!(((ASM_TYPES & AVX2_MASK) && 1))) { // C Only
+        if (!((!!(ASM_TYPES & AVX2_MASK)))) { // C Only
             (*transformFunctionTableEncode0[((ASM_TYPES & PREAVX2_MASK) && 1)][transformSizeFlag + dstTransformFlag])(
                 residualBuffer,
                 residualStride,
@@ -3371,8 +3371,8 @@ EB_ERRORTYPE EncodeTransform(
     }
 
     else if (transCoeffShape == N2_SHAPE) {
-            if (!(((ASM_TYPES & AVX2_MASK) && 1))) { // C Only
-                (*PfreqN2TransformTable0[((ASM_TYPES & AVX2_MASK) && 1)][transformSizeFlag + dstTransformFlag])(
+            if (!((!!(ASM_TYPES & AVX2_MASK)))) { // C Only
+                (*PfreqN2TransformTable0[(!!(ASM_TYPES & AVX2_MASK))][transformSizeFlag + dstTransformFlag])(
                     residualBuffer,
                     residualStride,
                     coeffBuffer,
@@ -3382,7 +3382,7 @@ EB_ERRORTYPE EncodeTransform(
                     );
             }
             else {
-                (*PfreqN2TransformTable1[/*ASM_TYPES*/((bitIncrement & 2) ? EB_ASM_C : ((ASM_TYPES & AVX2_MASK) && 1))][transformSizeFlag + dstTransformFlag])(
+                (*PfreqN2TransformTable1[/*ASM_TYPES*/((bitIncrement & 2) ? EB_ASM_C : (!!(ASM_TYPES & AVX2_MASK)))][transformSizeFlag + dstTransformFlag])(
                     residualBuffer,
                     residualStride,
                     coeffBuffer,
@@ -3394,8 +3394,8 @@ EB_ERRORTYPE EncodeTransform(
     }
 
     else if (transCoeffShape == N4_SHAPE) {
-        if (!(((ASM_TYPES & AVX2_MASK) && 1))) { // C Only
-            (*PfreqN4TransformTable0[(ASM_TYPES & AVX2_MASK) && 1][transformSizeFlag + dstTransformFlag])(
+        if (!((!!(ASM_TYPES & AVX2_MASK)))) { // C Only
+            (*PfreqN4TransformTable0[!!(ASM_TYPES & AVX2_MASK)][transformSizeFlag + dstTransformFlag])(
                 residualBuffer,
                 residualStride,
                 coeffBuffer,
@@ -3404,7 +3404,7 @@ EB_ERRORTYPE EncodeTransform(
                 bitIncrement);
         }
         else {
-            (*PfreqN4TransformTable1[/*ASM_TYPES*/((bitIncrement & 2) ? EB_ASM_C : ((ASM_TYPES & AVX2_MASK) && 1))][transformSizeFlag + dstTransformFlag])(
+            (*PfreqN4TransformTable1[/*ASM_TYPES*/((bitIncrement & 2) ? EB_ASM_C : (!!(ASM_TYPES & AVX2_MASK)))][transformSizeFlag + dstTransformFlag])(
                 residualBuffer,
                 residualStride,
                 coeffBuffer,
@@ -3418,7 +3418,7 @@ EB_ERRORTYPE EncodeTransform(
 
         EB_S32 sumResidual;
 
-		sumResidual = SumResidual_funcPtrArray[(ASM_TYPES & AVX2_MASK) && 1](
+		sumResidual = SumResidual_funcPtrArray[!!(ASM_TYPES & AVX2_MASK)](
             residualBuffer,
             transformSize,
             residualStride);
@@ -3520,7 +3520,7 @@ EB_ERRORTYPE EncodeInvTransform(
         invTranformedDcCoef = (EB_S16) CLIP3(MIN_NEG_16BIT_NUM, MAX_POS_16BIT_NUM,((64 * dcCoef + offset1st) >> shift1st));
         invTranformedDcCoef = (EB_S16) CLIP3(MIN_NEG_16BIT_NUM, MAX_POS_16BIT_NUM,((64 * invTranformedDcCoef + offset2nd) >> shift2nd));
 
-		memset16bitBlock_funcPtrArray[(ASM_TYPES & AVX2_MASK) && 1](
+		memset16bitBlock_funcPtrArray[!!(ASM_TYPES & AVX2_MASK)](
             reconBuffer,
             reconStride,
             transformSize,

--- a/Source/Lib/Codec/EbTransforms.c
+++ b/Source/Lib/Codec/EbTransforms.c
@@ -2547,7 +2547,7 @@ void PerformTwoStagePm(
 						EB_U64 sse[2];
                         EB_U64 coeffBits = 0;
 
-						FullDistortionIntrinsic_funcPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1][pmCand->nzCoeff != 0][1][blkAreaSize >> 3](
+						FullDistortionIntrinsic_funcPtrArray[!!(ASM_TYPES & PREAVX2_MASK)][pmCand->nzCoeff != 0][1][blkAreaSize >> 3](
                             &coeff[blkOffset],
                             coeffStride,
                             pmCand->iqCoeff,
@@ -2561,7 +2561,7 @@ void PerformTwoStagePm(
                         sse[DIST_CALC_RESIDUAL] = (sse[DIST_CALC_RESIDUAL] + (EB_U64)(1 << (shift - 1))) >> shift;
 
 						if (pmCand->nzCoeff)						
-							CoeffRateEst4x4_funcPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1][componentType != COMPONENT_LUMA](
+							CoeffRateEst4x4_funcPtrArray[!!(ASM_TYPES & PREAVX2_MASK)][componentType != COMPONENT_LUMA](
 								pictureControlSetPtr->cabacCost,
 								NULL,
 								4,
@@ -2709,7 +2709,7 @@ void DecoupledQuantizeInvQuantizeLoops(
 								if (!first_non_zero_coef_done) {
 									first_non_zero_coef_done = EB_TRUE;
 
-									EstimateQuantizedCoefficients[1][(ASM_TYPES & PREAVX2_MASK) && 1](
+									EstimateQuantizedCoefficients[1][!!(ASM_TYPES & PREAVX2_MASK)](
 										CabacCost,
 										cabacEncodeCtxPtr,
 										areaSize,
@@ -2731,7 +2731,7 @@ void DecoupledQuantizeInvQuantizeLoops(
 						}
 						else {
 							if (*nonzerocoeff) {
-								EstimateQuantizedCoefficients[1][(ASM_TYPES & PREAVX2_MASK) && 1](
+								EstimateQuantizedCoefficients[1][!!(ASM_TYPES & PREAVX2_MASK)](
 									CabacCost,
 									cabacEncodeCtxPtr,
 									areaSize,
@@ -2882,7 +2882,7 @@ void DecoupledQuantizeInvQuantizeLoops(
 						EB_U64 sse[2];
 						EB_U64 coeffBits = 0;
 
-						FullDistortionIntrinsic_funcPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1][pmCand->nzCoeff != 0][1][blkAreaSize >> 3](
+						FullDistortionIntrinsic_funcPtrArray[!!(ASM_TYPES & PREAVX2_MASK)][pmCand->nzCoeff != 0][1][blkAreaSize >> 3](
 							&coeff[blkOffset],
 							coeffStride,
 							pmCand->iqCoeff,
@@ -2896,7 +2896,7 @@ void DecoupledQuantizeInvQuantizeLoops(
 						sse[DIST_CALC_RESIDUAL] = (sse[DIST_CALC_RESIDUAL] + (EB_U64)(1 << (shift - 1))) >> shift;
 
 						if (pmCand->nzCoeff)
-							CoeffRateEst4x4_funcPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1][componentType != COMPONENT_LUMA](
+							CoeffRateEst4x4_funcPtrArray[!!(ASM_TYPES & PREAVX2_MASK)][componentType != COMPONENT_LUMA](
 							CabacCost,
 							NULL,
 							4,
@@ -3349,7 +3349,7 @@ EB_ERRORTYPE EncodeTransform(
 
     if (transCoeffShape == DEFAULT_SHAPE) {
         if (!((!!(ASM_TYPES & AVX2_MASK)))) { // C Only
-            (*transformFunctionTableEncode0[((ASM_TYPES & PREAVX2_MASK) && 1)][transformSizeFlag + dstTransformFlag])(
+            (*transformFunctionTableEncode0[(!!(ASM_TYPES & PREAVX2_MASK))][transformSizeFlag + dstTransformFlag])(
                 residualBuffer,
                 residualStride,
                 coeffBuffer,
@@ -3359,7 +3359,7 @@ EB_ERRORTYPE EncodeTransform(
                 );
         }
         else {
-            (*transformFunctionTableEncode1[/*ASM_TYPES*/((bitIncrement & 2) ? EB_ASM_C : ((ASM_TYPES & PREAVX2_MASK) && 1))][transformSizeFlag + dstTransformFlag])(
+            (*transformFunctionTableEncode1[/*ASM_TYPES*/((bitIncrement & 2) ? EB_ASM_C : (!!(ASM_TYPES & PREAVX2_MASK)))][transformSizeFlag + dstTransformFlag])(
                 residualBuffer,
                 residualStride,
                 coeffBuffer,
@@ -3464,7 +3464,7 @@ EB_ERRORTYPE EstimateInvTransform(
     //   but in order to avoid extra copying, it is overwritten in place. The
     //   input(residualBuffer) is the LCU residual buffer
     if (partialFrequencyN2Flag == EB_FALSE) {
-		(*invTransformFunctionTableEstimate[(ASM_TYPES & PREAVX2_MASK) && 1][transformSizeFlag + dstTransformFlag])(
+		(*invTransformFunctionTableEstimate[!!(ASM_TYPES & PREAVX2_MASK)][transformSizeFlag + dstTransformFlag])(
             coeffBuffer,
             coeffStride,
             reconBuffer,
@@ -3534,7 +3534,7 @@ EB_ERRORTYPE EncodeInvTransform(
         // The input of this function is the quantized_inversequantized transformed residual
         //   but in order to avoid extra copying, it is overwritten in place. The
         //   input(residualBuffer) is the LCU residual buffer
-		(*invTransformFunctionTableEncode[(ASM_TYPES & PREAVX2_MASK) && 1][transformSizeFlag + dstTransformFlag])(
+		(*invTransformFunctionTableEncode[!!(ASM_TYPES & PREAVX2_MASK)][transformSizeFlag + dstTransformFlag])(
             coeffBuffer,
             coeffStride,
             reconBuffer,
@@ -3621,21 +3621,21 @@ void PfZeroOutUselessQuadrants(
     EB_U32  transformCoeffStride,
     EB_U32  quadrantSize) {
 
-    PicZeroOutCoef_funcPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1][quadrantSize >> 3](
+    PicZeroOutCoef_funcPtrArray[!!(ASM_TYPES & PREAVX2_MASK)][quadrantSize >> 3](
         transformCoeffBuffer,
         transformCoeffStride,
         quadrantSize,
         quadrantSize,
         quadrantSize);
 
-    PicZeroOutCoef_funcPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1][quadrantSize >> 3](
+    PicZeroOutCoef_funcPtrArray[!!(ASM_TYPES & PREAVX2_MASK)][quadrantSize >> 3](
         transformCoeffBuffer,
         transformCoeffStride,
         quadrantSize * transformCoeffStride,
         quadrantSize,
         quadrantSize);
 
-    PicZeroOutCoef_funcPtrArray[(ASM_TYPES & PREAVX2_MASK) && 1][quadrantSize >> 3](
+    PicZeroOutCoef_funcPtrArray[!!(ASM_TYPES & PREAVX2_MASK)][quadrantSize >> 3](
         transformCoeffBuffer,
         transformCoeffStride,
         quadrantSize * transformCoeffStride + quadrantSize,


### PR DESCRIPTION
(1) Remove duplicate definition of `DECODED_PICTURE_HASH`.
 - Firstly defined in `Lib/Codec/EbDefinitions.h` line 815.

(2) to (4) Optimize function pointers to utilize `!!(x)` instead of `x && 1`.