### PR TITLE
Formatting rework and renaming

### DIFF
--- a/Config/Sample.cfg
+++ b/Config/Sample.cfg
@@ -1,120 +1,118 @@
 # Copyright(c) 2018 Intel Corporation 
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 
-#====================== File I/O ===============================
-InputFile                       : in.yuv                  # input yuv 420 file path
-StreamFile                      : SVTStream.265           # Output bit stream file path
-ErrorFile                       : SVTEncoderLog.log       # Error log displaying configuration or encode errors
-#ReconFile                      : SVTRecon.yuv            # Output reconstructed video [disabled by default]
-UseQpFile                       : 0                       # When set to 1, overwrite the encoder picture qp assignment using qp values in QpFile (0: OFF, 1: ON)
-QpFile                          : SVTQPFile.txt           # File with rows of QP values corresponding to QP values for each frame
+# ====================== File I/O ===============================
+InputFile                       : in.yuv                # Input yuv 420 file path
+StreamFile                      : SVTStream.265         # Output bit stream file path
+ErrorFile                       : SVTEncoderLog.log     # Error log displaying configuration or encode errors
+#ReconFile                      : SVTRecon.yuv          # Output reconstructed video [disabled by default]
+UseQpFile                       : 0                     # When set to 1, overwrite the encoder picture qp assignment using qp values in QpFile (0: OFF, 1: ON)
+QpFile                          : SVTQPFile.txt         # File with rows of QP values corresponding to QP values for each frame
 
+# ====================== Tiles ===============================
+TileRowCount                    : 1                     # Number of row tiles 
+TileColumnCount                 : 1                     # Number of column tiles
 
-TileRowCount                    : 1     # number of row tiles 
-TileColumnCount                 : 1     # number of column tiles
+# ====================== Encoding Presets ===============================
+EncoderMode                     : 9                     # Encoder Preset [0,12] 0 = highest quality, 12 = highest speed, 9 = default 
+                                                        # (not all resolutions support all 13 presets, please refer to section 3.4 in the users guide for more info)
+#LatencyMode                     : 0                    # Low Latency Mode (0: OFF, 1: ON) Deprecated
+SpeedControlFlag                : 0                     # Enable the speed control (0: OFF, 1: ON), encoder will do the best effort to run in real-time mode at the best quality using all resources available. 
+                                                        # The target speed is set to FrameRate. 
+                                                        # Injector will be set to 1 FrameRateNumerator is set to FrameRate
 
-#====================== Encoding Presets ===============================
-EncoderMode                     : 9             # Encoder Preset [0,12] 0 = highest quality, 12 = highest speed, 9 = default (not all resolutions support all 13 presets, please refer to section 3.4 in the users guide for more info)
-LatencyMode                     : 0             # Low Latency Mode (0: OFF, 1: ON)
-SpeedControlFlag                : 0             # Enable the speed control (0: OFF, 1: ON), encoder will do the best effort to run in real-time mode at the best quality using all resources available. 
-                                                # The target speed is set to FrameRate. 
-                                                # Injector will be set to 1 FrameRateNumerator is set to FrameRate
+# ====================== Bit-depth ===============================
+EncoderBitDepth                 : 8                     # Input and output bit-depth along with the encoder operating bit-depth (8: 8-bit , 10: 10-bit)	 
+CompressedTenBitFormat          : 0                     # Off-line packing of the 2bits: requires a compressed 10bit input (0: OFF, 1: ON)
+#EncoderColorFormat             : YUV420                # Encoder Color Format YUV420
 
-#====================== Bit-depth ===============================
-EncoderBitDepth                 : 8             # Input and output bit-depth along with the encoder operating bit-depth (8: 8-bit , 10: 10-bit)	 
-CompressedTenBitFormat          : 0             # Off-line packing of the 2bits: requires a compressed 10bit input (0: OFF, 1: ON)
+# ====================== Source Definitions ===================
+SourceWidth                     : 1920                  # [64 - 8192]
+SourceHeight                    : 1080                  # [64 - 4320]
+FrameToBeEncoded                : 0                     # Number of frames to be coded (0 for all frames in file)
+BufferedInput                   : -1                    # Buffers N-frames to avoid reading from disk. Use -1 to not buffer. 
 
-#====================== Source Definitions ===================
-SourceWidth                     : 1920          # [64 - 8192]
-SourceHeight                    : 1080          # [64 - 4320]
-FrameToBeEncoded                : 0             # Number of frames to be coded (0 for all frames in file)
-BufferedInput                   : -1            # Buffers N-frames to avoid reading from disk. Use -1 to not buffer. 
+# ====================== Annex A Definitions ======================
+Profile                         : 2                     # 1: Main, 2: Main 10
+Tier                            : 0                     # 0: Main, 1: High 
+Level                           : 0                     # 0: Level determined by the encoder, [1, 2, 2.1,3, 3.1, 4, 4.1, 5, 5.1, 6, 6.1, 6.2]: Level configurable  
 
-#====================== Annex A definitions ======================
-Profile                         : 2             # 1: Main, 2: Main 10
-Tier                            : 0             # 0: Main, 1: High 
-Level                           : 0             # 0: Level determined by the encoder, [1, 2, 2.1,3, 3.1, 4, 4.1, 5, 5.1, 6, 6.1, 6.2]: Level configurable  
+# ====================== Frame Rate ===============================
+FrameRate                       : 60                    # Frame Rate per second
+FrameRateNumerator              : 0                     # Frame Rate Numerator
+FrameRateDenominator            : 0                     # Frame Rate Denominator
+Injector                        : 0                     # Enable injection of input frames at the specified frame rate (0: OFF, 1: ON)
+InjectorFrameRate               : 60                    # Frame Rate used for the injector. Recommended to match the encoder speed 
 
-#====================== Frame Rate ===============================
-FrameRate                       : 60            # Frame Rate per second
-FrameRateNumerator              : 0             # Frame Rate Numerator
-FrameRateDenominator            : 0             # Frame Rate Denominator
-Injector                        : 0             # Enable injection of input frames at the specified frame rate (0: OFF, 1: ON)
-InjectorFrameRate               : 60            # Frame Rate used for the injector. Recommended to match the encoder speed 
+# ====================== Interlaced Video ===============================
+InterlacedVideo                 : 0                     # SEI messages for interlaced video (0: OFF, 1: ON)
+SeparateFields                  : 0                     # Separate the Top and Bottom fields of the input video (0: OFF, 1: ON)
 
-#====================== Interlaced Video ===============================
-InterlacedVideo                 : 0             # SEI messages for interlaced video (0: OFF, 1: ON)
-SeparateFields                  : 0             # Separate the Top and Bottom fields of the input video (0: OFF, 1: ON)
+# ====================== Coding Structure ===============================
+HierarchicalLevels              : 3                     # Minigop Size = (2^HierarchicalLevels) (e.g. 3 == > 7B pyramid, 2 == > 3B Pyramid) [0-3]
+BaseLayerSwitchMode             : 0                     # 0 : Use B-frames in the base layer pointing to the same past picture, 1 : Use P-frames in the base layer
+PredStructure                   : 2				        # 0: Low Delay P, 1: Low Delay B, 2: Random Access
+IntraPeriod                     : -2                    # Period of I-Frame (-1 = only first, -2 = auto) [-2 - 255]
+IntraRefreshType                : 1                     # Random Accesss 1:CRA, 2:IDR (when IntraPeriod > 0) - [1-2]
 
-#====================== Coding Structure ===============================
-HierarchicalLevels              : 3             # Minigop Size = (2^HierarchicalLevels) (e.g. 3 == > 7B pyramid, 2 == > 3B Pyramid) [0-3]
-BaseLayerSwitchMode             : 0             # 0 : Use B-frames in the base layer pointing to the same past picture
-                                                # 1 : Use P-frames in the base layer
-PredStructure                   : 2				# 0: Low Delay P
-												# 1: Low Delay B
-												# 2: Random Access
+# ====================== Quantization ===============================
+QP                              : 32                    # Quantization parameter - [0-51]
 
-IntraPeriod                     : -2            # Period of I-Frame (-1 = only first, -2 = auto) [-2 - 255]
-IntraRefreshType                : 1             # Random Accesss 1:CRA, 2:IDR (when IntraPeriod > 0) - [1-2]
+# ====================== Deblock Filter ===============================
+LoopFilterDisable               : 0                     # Disable loop filter (0=Filter, 1=No Filter)
 
-#====================== Quantization ===============================
-QP                              : 32            # Quantization parameter - [0-51]
+# ====================== Sample Adaptive Offset ===============================
+SAO                             : 1                     # Enable SAO  (0: OFF, 1: ON)
 
-#====================== Deblock Filter ===============================
-LoopFilterDisable               : 0             # Disable loop filter (0=Filter, 1=No Filter)
+# ====================== ME Tools ===============================
+UseDefaultMeHme                 : 1                     # Use Default ME HME Params (0: Overwrite , 1: Default)
+HME                             : 1                     # Enable HME (0: OFF, 1: ON)
 
-#====================== Sample Adaptive Offset ===============================
-SAO                             : 1             # Enable SAO  (0: OFF, 1: ON)
+# ====================== ME Parameters ===============================
+SearchAreaWidth                 : 16                    # Number of search positions in the horizontal direction - [1-256]
+SearchAreaHeight                : 7                     # Number of search positions in the vertical direction - [1-256]
 
-#====================== ME Tools ===============================
-UseDefaultMeHme                 : 1             # Use Default ME HME Params (0: Overwrite , 1: Default)
-HME                             : 1             # Enable HME (0: OFF, 1: ON)
+# ====================== MD Parameters ===============================
+ConstrainedIntra                : 0                     # Enable the use of Constrained Intra which results in sending two PPSs (0: OFF, 1: ON)
 
-#======================ME Parameters ===============================
-SearchAreaWidth                 : 16            # Number of search positions in the horizontal direction - [1-256]
+# ====================== Rate Control ===============================
+RateControlMode                 : 0                     # Rate control mode (0: OFF(CQP), 1: VBR)
+TargetBitRate                   : 7000000               # Target Bit Rate (in bits per second)
+MaxQpAllowed                    : 48                    # maximum allowed QP when rate control is on - [0-51]
+MinQpAllowed                    : 10                    # minimum allowed QP when rate control is on - [0-51]
+LookAheadDistance               : 17                    # Enable Look Ahead [0-250]
+SceneChangeDetection            : 1                     # Enable Scene Change Detection (0: OFF, 1: ON)
 
-SearchAreaHeight                : 7             # Number of search positions in the vertical direction - [1-256]
+# ====================== Tune ===============================
+Tune                            : 1                     # Tune (0=SQ - visually optimized mode, 1=OQ - PSNR / SSIM optimized mode, 2=VMAF - VMAF optimized mode) 
 
-#====================== MD Parameters ===============================
-ConstrainedIntra                : 0             # Enable the use of Constrained Intra which results in sending two PPSs (0: OFF, 1: ON)
-
-#====================== Rate Control ===============================
-RateControlMode                 : 0             # Rate control mode (0: OFF(CQP), 1: VBR)
-TargetBitRate                   : 7000000       # Target Bit Rate (in bits per second)
-MaxQpAllowed                    : 48            # maximum allowed QP when rate control is on - [0-51]
-MinQpAllowed                    : 10            # minimum allowed QP when rate control is on - [0-51]
-LookAheadDistance               : 17            # Enable Look Ahead [0-250]
-SceneChangeDetection            : 1             # Enable Scene Change Detection (0: OFF, 1: ON)
-
-#====================== Tune ===============================
-Tune                            : 1             # Tune (0=SQ - visually optimized mode, 1=OQ - PSNR / SSIM optimized mode, 2=VMAF - VMAF optimized mode) 
-
-#====================== Adaptive QP Params ===============================
-BitRateReduction                : 1            # BitRate Reduction (only applicable when Tune is set to 0) (0= OFF, 1=ON )
-ImproveSharpness                : 1             # Improve sharpness (only applicable when Tune is set to 0) (0= OFF, 1=ON )
+# ====================== Adaptive QP Params ===============================
+BitRateReduction                : 1                     # BitRate Reduction (only applicable when Tune is set to 0) (0= OFF, 1=ON )
+ImproveSharpness                : 1                     # Improve sharpness (only applicable when Tune is set to 0) (0= OFF, 1=ON )
 
 # ====================== Optional Features ===============================
-VideoUsabilityInfo              : 0             # Extra Information to enhance the use of video for display purposes..etc (0= OFF, 1=ON )
-HighDynamicRangeInput           : 0             # Signals that the input yuv is HDR BT2020 using SMPTE ST2048 (requires VideoUsabilityInfo to be set to 1) (Only applicable for 10bit input) (0= OFF, 1=ON )
-AccessUnitDelimiter             : 0             # Used to simplify the detection of boundary between access units (0= OFF, 1=ON )
-BufferingPeriod                 : 0             # SEI message (0= OFF, 1=ON )
-PictureTiming                   : 0             # SEI message (0= OFF, 1=ON ). If 1, VideoUsabilityInfo should be also set to 1.
-RegisteredUserData              : 0             # SEI message (0= OFF, 1=ON )
-UnregisteredUserData            : 0             # SEI message (0= OFF, 1=ON )
-RecoveryPoint                   : 0             # SEI message (0= OFF, 1=ON )
-TemporalId                      : 1             # 0: OFF, 1: Insert temporal ID in NAL units 
-SwitchThreadsToRtPriority       : 1             # 0: OFF, 1: Switch threads to real time priority (works on Linux only)
-FPSInVPS                        : 0             # 0: OFF, 1: Enable VPS timing info 
-MaxCLL                          : 0             # SEI message (0=OFF,  1=ON ) 
-MaxFALL                         : 0             # SEI message (0=OFF,  1=ON )
-UseMasterDisplay                : 0             # SEI message. Enables or disables the MasterDisplayColorVolume (0=OFF, 1=ON )
+VideoUsabilityInfo              : 0                     # Extra Information to enhance the use of video for display purposes..etc (0= OFF, 1=ON )
+HighDynamicRangeInput           : 0                     # Signals that the input yuv is HDR BT2020 using SMPTE ST2048 (requires VideoUsabilityInfo to be set to 1) (Only applicable for 10bit input) (0= OFF, 1=ON )
+AccessUnitDelimiter             : 0                     # Used to simplify the detection of boundary between access units (0= OFF, 1=ON )
+BufferingPeriod                 : 0                     # SEI message (0= OFF, 1=ON )
+PictureTiming                   : 0                     # SEI message (0= OFF, 1=ON ). If 1, VideoUsabilityInfo should be also set to 1.
+RegisteredUserData              : 0                     # SEI message (0= OFF, 1=ON )
+UnregisteredUserData            : 0                     # SEI message (0= OFF, 1=ON )
+RecoveryPoint                   : 0                     # SEI message (0= OFF, 1=ON )
+TemporalId                      : 1                     # 0: OFF, 1: Insert temporal ID in NAL units 
+SwitchThreadsToRtPriority       : 1                     # 0: OFF, 1: Switch threads to real time priority (works on Linux only)
+FPSInVPS                        : 0                     # 0: OFF, 1: Enable VPS timing info 
+MaxCLL                          : 0                     # SEI message (0=OFF,  1=ON ) 
+MaxFALL                         : 0                     # SEI message (0=OFF,  1=ON )
+UseMasterDisplay                : 0                     # SEI message. Enables or disables the MasterDisplayColorVolume (0=OFF, 1=ON )
 MasterDisplay                   : G(0,0)B(0,0)R(0,0)WP(0,0)L(0,0)
-                                                # SEI message. Signals SMPTE ST 2086 display info in the format "G(%hu,%hu)B(%hu,%hu)R(%hu,%hu)WP(%hu,%hu)L(%u,%u)" where %hu,%u are unsigned 16bit and 32 bit integers
-DolbyVisionProfile              : 0             # SEI message (0=OFF, 8.1 or 81 : Send bitstreams compliant to Dolby Vision Profile 81)
-DolbyVisionRpuFile              : Dolby.txt     # SEI message. Dolby Vision RPU metadata file path.
-NaluFile                        : Nalu.txt      # SEI message. CEA 608/708 dynamic metadata file path.
+                                                        # SEI message. Signals SMPTE ST 2086 display info in the format 
+                                                        # "G(%hu,%hu)B(%hu,%hu)R(%hu,%hu)WP(%hu,%hu)L(%u,%u)" where %hu,%u are unsigned 16bit and 32 bit integers
+DolbyVisionProfile              : 0                     # SEI message (0=OFF, 8.1 or 81 : Send bitstreams compliant to Dolby Vision Profile 81)
+DolbyVisionRpuFile              : Dolby.txt             # SEI message. Dolby Vision RPU metadata file path.
+NaluFile                        : Nalu.txt              # SEI message. CEA 608/708 dynamic metadata file path.
 
 # ====================== Platform Specific Flags ===============================
-AsmType                         : 1             # Assembly instruction set (0: non-AVX2, 1: up to AVX512 (Default: set based on platform capabilities))
-TargetSocket                    : -1            # For dual socket systems, this can specify which socket the encoder runs on (-1=Both Sockets, 0=Socket 0, 1=Socket 1)
-LogicalProcessors               : 0             # The number of logical processor which encoder threads run on [0-N] (N is maximum number of logical processor)
+AsmType                         : 1                     # Assembly instruction set (0: non-AVX2, 1: up to AVX512 (Default: set based on platform capabilities))
+TargetSocket                    : -1                    # For dual socket systems, this can specify which socket the encoder runs on (-1=Both Sockets, 0=Socket 0, 1=Socket 1)
+LogicalProcessors               : 0                     # The number of logical processor which encoder threads run on [0-N] (N is maximum number of logical processor)

--- a/Docs/svt-hevc_encoder_user_guide.md
+++ b/Docs/svt-hevc_encoder_user_guide.md
@@ -299,7 +299,7 @@ The encoder parameters present in the Sample.cfg file are listed in this table b
 | **RecoveryPoint** | -recovery-point | [0,1] | 0 | SEI message, 0 = OFF, 1 = ON |
 | **TemporalId** | -temporal-id | [0,1] | 1 | 0 = OFF, 1 = Insert temporal ID in NAL units |
 | **AsmType** | -asm | [0,1] | 1 | Assembly instruction set <br>(0: C Only, 1: Automatically select highest assembly instruction set supported) |
-| **LogicalProcessorNumber** | -lp | [0, total number of logical processor] | 0 | The number of logical processor which encoder threads run on.Refer to Appendix A.2 |
+| **LogicalProcessors** | -lp | [0, total number of logical processor] | 0 | The number of logical processor which encoder threads run on.Refer to Appendix A.2 |
 | **TargetSocket** | -ss | [-1,1] | -1 | For dual socket systems, this can specify which socket the encoder runs on.Refer to Appendix A.2 |
 | **SwitchThreadsToRtPriority** | -rt | [0,1] | 1 | Enables or disables threads to real time priority, 0 = OFF, 1 = ON (only works on Linux) |
 | **FPSInVPS** | -fpsinvps | [0,1] | 0 | Enables or disables the VPS timing info, 0 = OFF, 1 = ON |
@@ -363,7 +363,7 @@ The above section is not needed for Windows\* as it does not perform the CPU uti
 
 The SVT-HEVC encoder achieves the best performance when restricting each channel to only one socket on either Windows\* or Linux\* operating systems. For example, when running four channels on a dual socket system, it&#39;s best to pin two channels to each socket and not split every channel on both sockets.
 
-LogicalProcessorNumber (-lp) and TargetSocket (-ss) parameters can be used to management the threads. Or you can use OS commands like below.
+LogicalProcessors (-lp) and TargetSocket (-ss) parameters can be used to management the threads. Or you can use OS commands like below.
 
 For example, in order to run a 6-stream 4kp60 simultaneous encode on a Xeon Platinum 8180 system the following command lines should be used:
 
@@ -437,13 +437,13 @@ In the SVT-HEVC code, the GOP structure is constructed in the Picture Decision p
 
 ### 2. Thread management parameters
 
-LogicalProcessorNumber (-lp) and TargetSocket (-ss) parameters are used to management thread affinity on Windows and Ubuntu OS. These are some examples how you use them together.
+LogicalProcessors (-lp) and TargetSocket (-ss) parameters are used to management thread affinity on Windows and Ubuntu OS. These are some examples how you use them together.
 
-If LogicalProcessorNumber and TargetSocket are not set, threads are managed by OS thread scheduler.
+If LogicalProcessors and TargetSocket are not set, threads are managed by OS thread scheduler.
 
 >SvtHevcEncApp.exe -i in.yuv -w 3840 -h 2160 –lp 40
 
-If only LogicalProcessorNumber is set, threads run on 40 logical processors. Threads may run on dual sockets if 40 is larger than logical processor number of a socket.
+If only LogicalProcessors is set, threads run on 40 logical processors. Threads may run on dual sockets if 40 is larger than logical processor number of a socket.
 
 NOTE: On Windows, thread affinity can be set only by group on system with more than 64 logical processors. So, if 40 is larger than logical processor number of a single socket, threads run on all logical processors of both sockets.
 
@@ -453,7 +453,7 @@ If only TargetSocket is set, threads run on all the logical processors of socket
 
 >SvtHevcEncApp.exe -i in.yuv -w 3840 -h 2160 –lp 20 –ss 0
 
-If both LogicalProcessorNumber and TargetSocket are set, threads run on 20 logical processors of socket 0. Threads guaranteed to run only on socket 0 if 20 is larger than logical processor number of socket 0.
+If both LogicalProcessors and TargetSocket are set, threads run on 20 logical processors of socket 0. Threads guaranteed to run only on socket 0 if 20 is larger than logical processor number of socket 0.
 
 
 

--- a/Source/App/EbAppConfig.c
+++ b/Source/App/EbAppConfig.c
@@ -173,7 +173,7 @@ static void SetFrameRate                        (const char *value, EbConfig_t *
 static void SetFrameRateNumerator               (const char *value, EbConfig_t *cfg) {cfg->frameRateNumerator               = strtoul(value, NULL, 0);};
 static void SetFrameRateDenominator             (const char *value, EbConfig_t *cfg) {cfg->frameRateDenominator             = strtoul(value, NULL, 0);};
 static void SetEncoderBitDepth                  (const char *value, EbConfig_t *cfg) {cfg->encoderBitDepth                  = strtoul(value, NULL, 0);}
-static void SetEncoderColorFormat               (const char *value, EbConfig_t *cfg) {cfg->encoderColorFormat = strtoul(value, NULL, 0);}
+static void SetEncoderColorFormat               (const char *value, EbConfig_t *cfg) {cfg->encoderColorFormat               = strtoul(value, NULL, 0);}
 static void SetcompressedTenBitFormat           (const char *value, EbConfig_t *cfg) {cfg->compressedTenBitFormat           = strtoul(value, NULL, 0);}
 static void SetBaseLayerSwitchMode              (const char *value, EbConfig_t *cfg) {cfg->baseLayerSwitchMode              = (EB_BOOL) strtoul(value, NULL, 0);};
 static void SetencMode                          (const char *value, EbConfig_t *cfg) {cfg->encMode                          = (uint8_t)strtoul(value, NULL, 0);};
@@ -265,85 +265,94 @@ typedef struct config_entry_s {
  * Config Entry Array
  **********************************/
 config_entry_t config_entry[] = {
-
     // File I/O
     { SINGLE_INPUT, INPUT_FILE_TOKEN, "InputFile", SetCfgInputFile },
-    { SINGLE_INPUT, OUTPUT_BITSTREAM_TOKEN,   "StreamFile",       SetCfgStreamFile },
+    { SINGLE_INPUT, OUTPUT_BITSTREAM_TOKEN, "StreamFile", SetCfgStreamFile },
     { SINGLE_INPUT, ERROR_FILE_TOKEN, "ErrorFile", SetCfgErrorFile },
     { SINGLE_INPUT, OUTPUT_RECON_TOKEN, "ReconFile", SetCfgReconFile },
+    { SINGLE_INPUT, USE_QP_FILE_TOKEN, "UseQpFile", SetCfgUseQpFile },
     { SINGLE_INPUT, QP_FILE_TOKEN, "QpFile", SetCfgQpFile },
 
-    // Interlaced Video
-    { SINGLE_INPUT, INTERLACED_VIDEO_TOKEN , "InterlacedVideo" , SetInterlacedVideo },
-    { SINGLE_INPUT, SEPERATE_FILDS_TOKEN, "SeperateFields", SetSeperateFields },
-
-    // Picture Dimensions
-    { SINGLE_INPUT, WIDTH_TOKEN, "SourceWidth", SetCfgSourceWidth },
-    { SINGLE_INPUT, HEIGHT_TOKEN, "SourceHeight", SetCfgSourceHeight },
-
-    // Prediction Structure
-    { SINGLE_INPUT, NUMBER_OF_PICTURES_TOKEN, "FrameToBeEncoded", SetCfgFramesToBeEncoded },
-    { SINGLE_INPUT, BUFFERED_INPUT_TOKEN, "BufferedInput", SetBufferedInput },
-    { SINGLE_INPUT, BASE_LAYER_SWITCH_MODE_TOKEN, "BaseLayerSwitchMode", SetBaseLayerSwitchMode },
-    { SINGLE_INPUT, ENCMODE_TOKEN, "EncoderMode", SetencMode},
-    { SINGLE_INPUT, INTRA_PERIOD_TOKEN, "IntraPeriod", SetCfgIntraPeriod },
-    { SINGLE_INPUT, INTRA_REFRESH_TYPE_TOKEN, "IntraRefreshType", SetCfgIntraRefreshType },
-    { SINGLE_INPUT, FRAME_RATE_TOKEN, "FrameRate", SetFrameRate },
-    { SINGLE_INPUT, FRAME_RATE_NUMERATOR_TOKEN, "FrameRateNumerator", SetFrameRateNumerator },
-    { SINGLE_INPUT, FRAME_RATE_DENOMINATOR_TOKEN, "FrameRateDenominator", SetFrameRateDenominator },
-    { SINGLE_INPUT, ENCODER_BIT_DEPTH, "EncoderBitDepth", SetEncoderBitDepth },
-    { SINGLE_INPUT, ENCODER_COLOR_FORMAT, "EncoderColorFormat", SetEncoderColorFormat},
-	{ SINGLE_INPUT, INPUT_COMPRESSED_TEN_BIT_FORMAT, "CompressedTenBitFormat", SetcompressedTenBitFormat },
-	{ SINGLE_INPUT, HIERARCHICAL_LEVELS_TOKEN, "HierarchicalLevels", SetHierarchicalLevels },
-
-	{ SINGLE_INPUT, PRED_STRUCT_TOKEN, "PredStructure", SetCfgPredStructure },
-
-
-    // Rate Control
-    { SINGLE_INPUT, SCENE_CHANGE_DETECTION_TOKEN, "SceneChangeDetection", SetSceneChangeDetection},
-    { SINGLE_INPUT, QP_TOKEN, "QP", SetCfgQp },
-
-    { SINGLE_INPUT, USE_QP_FILE_TOKEN, "UseQpFile", SetCfgUseQpFile },
 #if 1//TILES
      { SINGLE_INPUT, TILE_ROW_COUNT_TOKEN, "TileRowCount", SetCfgTileRowCount },
      { SINGLE_INPUT, TILE_COL_COUNT_TOKEN, "TileColumnCount", SetCfgTileColumnCount },
 #endif
 
+    // Encoding Presets
+    { SINGLE_INPUT, ENCMODE_TOKEN, "EncoderMode", SetencMode },
+//    { SINGLE_INPUT, LATENCY_MODE, "LatencyMode", SetLatencyMode },
+    { SINGLE_INPUT, SPEED_CONTROL_TOKEN, "SpeedControlFlag", SpeedControlFlag },
+
+    // Bit-depth
+    { SINGLE_INPUT, ENCODER_BIT_DEPTH, "EncoderBitDepth", SetEncoderBitDepth },
+	{ SINGLE_INPUT, INPUT_COMPRESSED_TEN_BIT_FORMAT, "CompressedTenBitFormat", SetcompressedTenBitFormat },
+    { SINGLE_INPUT, ENCODER_COLOR_FORMAT, "EncoderColorFormat", SetEncoderColorFormat },
+
+    // Source Definitions
+    { SINGLE_INPUT, WIDTH_TOKEN, "SourceWidth", SetCfgSourceWidth },
+    { SINGLE_INPUT, HEIGHT_TOKEN, "SourceHeight", SetCfgSourceHeight },
+    { SINGLE_INPUT, NUMBER_OF_PICTURES_TOKEN, "FrameToBeEncoded", SetCfgFramesToBeEncoded },
+    { SINGLE_INPUT, BUFFERED_INPUT_TOKEN, "BufferedInput", SetBufferedInput },
+
+    // Annex A parameters
+    { SINGLE_INPUT, PROFILE_TOKEN, "Profile", SetProfile },
+    { SINGLE_INPUT, TIER_TOKEN, "Tier", SetTier },
+    { SINGLE_INPUT, LEVEL_TOKEN, "Level", SetLevel },
+
+    // Frame Rate
+    { SINGLE_INPUT, FRAME_RATE_TOKEN, "FrameRate", SetFrameRate },
+    { SINGLE_INPUT, FRAME_RATE_NUMERATOR_TOKEN, "FrameRateNumerator", SetFrameRateNumerator },
+    { SINGLE_INPUT, FRAME_RATE_DENOMINATOR_TOKEN, "FrameRateDenominator", SetFrameRateDenominator },
+    { SINGLE_INPUT, INJECTOR_TOKEN, "Injector", SetInjector },
+    { SINGLE_INPUT, INJECTOR_FRAMERATE_TOKEN, "InjectorFrameRate", SetInjectorFrameRate },
+
+    // Interlaced Video
+    { SINGLE_INPUT, INTERLACED_VIDEO_TOKEN, "InterlacedVideo", SetInterlacedVideo },
+    { SINGLE_INPUT, SEPERATE_FILDS_TOKEN, "SeperateFields", SetSeperateFields },
+
+    // Coding Structure
+	{ SINGLE_INPUT, HIERARCHICAL_LEVELS_TOKEN, "HierarchicalLevels", SetHierarchicalLevels },
+    { SINGLE_INPUT, BASE_LAYER_SWITCH_MODE_TOKEN, "BaseLayerSwitchMode", SetBaseLayerSwitchMode },
+	{ SINGLE_INPUT, PRED_STRUCT_TOKEN, "PredStructure", SetCfgPredStructure },
+    { SINGLE_INPUT, INTRA_PERIOD_TOKEN, "IntraPeriod", SetCfgIntraPeriod },
+    { SINGLE_INPUT, INTRA_REFRESH_TYPE_TOKEN, "IntraRefreshType", SetCfgIntraRefreshType },
+
+    // Quantization
+    { SINGLE_INPUT, QP_TOKEN, "QP", SetCfgQp },
+
+    // Deblock Filter
+    { SINGLE_INPUT, LOOP_FILTER_DISABLE_TOKEN, "LoopFilterDisable", SetDisableDlfFlag },
+
+    // Sample Adaptive Offset
+    { SINGLE_INPUT, SAO_ENABLE_TOKEN, "SAO", SetEnableSaoFlag },
+
+    // Me Tools
+    { SINGLE_INPUT, USE_DEFAULT_ME_HME_TOKEN, "UseDefaultMeHme", SetCfgUseDefaultMeHme },
+    { SINGLE_INPUT, HME_ENABLE_TOKEN, "HME", SetEnableHmeFlag },
+
+    // Me Parameters
+    { SINGLE_INPUT, SEARCH_AREA_WIDTH_TOKEN, "SearchAreaWidth", SetCfgSearchAreaWidth },
+    { SINGLE_INPUT, SEARCH_AREA_HEIGHT_TOKEN, "SearchAreaHeight", SetCfgSearchAreaHeight },
+
+    // MD Parameters         
+    { SINGLE_INPUT, CONSTRAINED_INTRA_ENABLE_TOKEN, "ConstrainedIntra", SetEnableConstrainedIntra },
+
+    // Rate Control
     { SINGLE_INPUT, RATE_CONTROL_ENABLE_TOKEN, "RateControlMode", SetRateControlMode },
-    { SINGLE_INPUT, LOOK_AHEAD_DIST_TOKEN, "LookAheadDistance",                             SetLookAheadDistance},
     { SINGLE_INPUT, TARGET_BIT_RATE_TOKEN, "TargetBitRate", SetTargetBitRate },
     { SINGLE_INPUT, MAX_QP_TOKEN, "MaxQpAllowed", SetMaxQpAllowed },
     { SINGLE_INPUT, MIN_QP_TOKEN, "MinQpAllowed", SetMinQpAllowed },
-
-    // DLF
-    { SINGLE_INPUT, LOOP_FILTER_DISABLE_TOKEN, "LoopFilterDisable", SetDisableDlfFlag },
-
-    // SAO
-    { SINGLE_INPUT, SAO_ENABLE_TOKEN, "SAO", SetEnableSaoFlag },
-
-    // ME Tools
-    { SINGLE_INPUT, USE_DEFAULT_ME_HME_TOKEN, "UseDefaultMeHme", SetCfgUseDefaultMeHme },
-    { SINGLE_INPUT, HME_ENABLE_TOKEN, "HME", SetEnableHmeFlag },
-                                                
-    // ME Parameters                                  
-    { SINGLE_INPUT, SEARCH_AREA_WIDTH_TOKEN, "SearchAreaWidth", SetCfgSearchAreaWidth },
-    { SINGLE_INPUT, SEARCH_AREA_HEIGHT_TOKEN, "SearchAreaHeight", SetCfgSearchAreaHeight },
-                                                      
-    // MD Parameters         
-    { SINGLE_INPUT, CONSTRAINED_INTRA_ENABLE_TOKEN, "ConstrainedIntra", SetEnableConstrainedIntra},
+    { SINGLE_INPUT, LOOK_AHEAD_DIST_TOKEN, "LookAheadDistance", SetLookAheadDistance },
+    { SINGLE_INPUT, SCENE_CHANGE_DETECTION_TOKEN, "SceneChangeDetection", SetSceneChangeDetection },
 
     // Tune
     { SINGLE_INPUT, TUNE_TOKEN, "Tune", SetCfgTune },
 
-    // Thread Management
-    { SINGLE_INPUT, THREAD_MGMNT, "LogicalProcessors", SetLogicalProcessors },
-    { SINGLE_INPUT, TARGET_SOCKET, "TargetSocket", SetTargetSocket },
-    { SINGLE_INPUT, SWITCHTHREADSTOREALTIME_TOKEN, "SwitchThreadsToRtPriority", SetSwitchThreadsToRtPriority },
+    // Adaptive QP Params
+	{ SINGLE_INPUT, BITRATE_REDUCTION_TOKEN, "BitRateReduction", SetBitRateReduction },
+    { SINGLE_INPUT, IMPROVE_SHARPNESS_TOKEN,"ImproveSharpness", SetImproveSharpness },
 
     // Optional Features
-
-	{ SINGLE_INPUT, BITRATE_REDUCTION_TOKEN, "BitRateReduction", SetBitRateReduction },
-    { SINGLE_INPUT, IMPROVE_SHARPNESS_TOKEN,"ImproveSharpness", SetImproveSharpness},
     { SINGLE_INPUT, VIDEO_USE_INFO_TOKEN, "VideoUsabilityInfo", SetVideoUsabilityInfo },
     { SINGLE_INPUT, HDR_INPUT_TOKEN, "HighDynamicRangeInput", SetHighDynamicRangeInput },
     { SINGLE_INPUT, ACCESS_UNIT_DELM_TOKEN, "AccessUnitDelimiter", SetAccessUnitDelimiter },
@@ -352,6 +361,9 @@ config_entry_t config_entry[] = {
     { SINGLE_INPUT, REG_USER_DATA_TOKEN, "RegisteredUserData", SetRegisteredUserDataSEI },
     { SINGLE_INPUT, UNREG_USER_DATA_TOKEN, "UnregisteredUserData", SetUnRegisteredUserDataSEI },
     { SINGLE_INPUT, RECOVERY_POINT_TOKEN, "RecoveryPoint", SetRecoveryPointSEI },
+    { SINGLE_INPUT, TEMPORAL_ID, "TemporalId", SetEnableTemporalId },
+    { SINGLE_INPUT, SWITCHTHREADSTOREALTIME_TOKEN, "SwitchThreadsToRtPriority", SetSwitchThreadsToRtPriority },
+    { SINGLE_INPUT, FPSINVPS_TOKEN, "FPSInVPS", SetFpsInVps },
     { SINGLE_INPUT, MAXCLL_TOKEN, "MaxCLL", SetMaxCLL },
     { SINGLE_INPUT, MAXFALL_TOKEN, "MaxFALL", SetMaxFALL },
     { SINGLE_INPUT, USE_MASTER_DISPLAY_TOKEN, "UseMasterDisplay", SetMasterDisplayFlag },
@@ -359,25 +371,14 @@ config_entry_t config_entry[] = {
     { SINGLE_INPUT, DOLBY_VISION_PROFILE_TOKEN, "DolbyVisionProfile", SetDolbyVisionProfile },
     { SINGLE_INPUT, DOLBY_VISION_RPU_FILE_TOKEN, "DolbyVisionRpuFile", SetCfgDolbyVisionRpuFile },
     { SINGLE_INPUT, NALU_FILE_TOKEN, "NaluFile", SetNaluFile },
-    { SINGLE_INPUT, TEMPORAL_ID, "TemporalId", SetEnableTemporalId },
-    { SINGLE_INPUT, FPSINVPS_TOKEN, "FPSInVPS", SetFpsInVps },
-    // Latency
-    { SINGLE_INPUT, INJECTOR_TOKEN, "Injector", SetInjector },
-    { SINGLE_INPUT, INJECTOR_FRAMERATE_TOKEN, "InjectorFrameRate", SetInjectorFrameRate },
 
-    { SINGLE_INPUT, SPEED_CONTROL_TOKEN, "SpeedControlFlag", SpeedControlFlag },
-
-    // Annex A parameters
-    { SINGLE_INPUT, PROFILE_TOKEN, "Profile", SetProfile },
-    { SINGLE_INPUT, TIER_TOKEN, "Tier", SetTier },
-    { SINGLE_INPUT, LEVEL_TOKEN, "Level", SetLevel },
-//    { SINGLE_INPUT, LATENCY_MODE, "LatencyMode", SetLatencyMode },
-
-    // Asm Type
+    // Platform Specific Flags
     { SINGLE_INPUT, ASM_TYPE_TOKEN, "AsmType", SetAsmType },
+    { SINGLE_INPUT, TARGET_SOCKET, "TargetSocket", SetTargetSocket },
+    { SINGLE_INPUT, THREAD_MGMNT, "LogicalProcessors", SetLogicalProcessors },
 
     // Termination
-    {SINGLE_INPUT,NULL,  NULL,                                NULL}
+    { SINGLE_INPUT, NULL, NULL, NULL }
 };
 
 /**********************************
@@ -385,135 +386,155 @@ config_entry_t config_entry[] = {
  **********************************/
 void EbConfigCtor(EbConfig_t *configPtr)
 {
-    configPtr->configFile                           = NULL;
-    configPtr->inputFile                            = NULL;
-    configPtr->bitstreamFile                        = NULL;
-    configPtr->reconFile                            = NULL;
-    configPtr->errorLogFile                         = stderr;
-    configPtr->qpFile                               = NULL;
+    // File I/O
+    configPtr->configFile                               = NULL;
+    configPtr->inputFile                                = NULL;
+    configPtr->bitstreamFile                            = NULL;
+    configPtr->errorLogFile                             = stderr;
+    configPtr->reconFile                                = NULL;
+    configPtr->useQpFile                                = EB_FALSE;
+    configPtr->qpFile                                   = NULL;
 
+#if 1//TILES
+    configPtr->tileColumnCount                          = 1;
+    configPtr->tileRowCount                             = 1;
+#endif
 
-    configPtr->frameRate                            = 60;
-    configPtr->frameRateNumerator                   = 0;
-    configPtr->frameRateDenominator                 = 0;
-    configPtr->encoderBitDepth                      = 8;
-    configPtr->encoderColorFormat                   = EB_YUV420;
-	  configPtr->compressedTenBitFormat			          = 0;
-    configPtr->sourceWidth                          = 0;
-    configPtr->sourceHeight                         = 0;
-    configPtr->inputPaddedWidth                     = 0;
-    configPtr->inputPaddedHeight                    = 0;
-    configPtr->framesToBeEncoded                    = 0;
-    configPtr->bufferedInput                        = -1;
-    configPtr->sequenceBuffer                       = 0;
-    configPtr->latencyMode                          = 0;
+    // Encoding Presets
+	configPtr->encMode								    = 9;
+    //configPtr->latencyMode                              = 0; // Deprecated
+    configPtr->speedControlFlag                         = 0;
+
+    // Bit-depth
+    configPtr->encoderBitDepth                          = 8;
+    configPtr->compressedTenBitFormat			        = 0;
+    configPtr->encoderColorFormat                       = EB_YUV420;
+
+    // Source Definitions
+    configPtr->sourceWidth                              = 0;
+    configPtr->sourceHeight                             = 0;
+    configPtr->framesToBeEncoded                        = 0;
+    configPtr->bufferedInput                            = -1;
+
+    // Annex A Definitions
+    configPtr->profile                                  = 2;
+    configPtr->tier                                     = 0;
+    configPtr->level                                    = 0;
+
+    // Frame Rate
+    configPtr->frameRate                                = 60;
+    configPtr->frameRateNumerator                       = 0;
+    configPtr->frameRateDenominator                     = 0;
+    configPtr->injector                                 = 0;
+    configPtr->injectorFrameRate                        = 60 << 16;
 
     // Interlaced Video
-    configPtr->interlacedVideo                      = EB_FALSE;
-    configPtr->separateFields                       = EB_FALSE;
-    configPtr->qp                                   = 32;
-    configPtr->useQpFile                            = EB_FALSE;
-#if 1//TILES
-    configPtr->tileColumnCount = 1;
-    configPtr->tileRowCount = 1;
-#endif
-    configPtr->sceneChangeDetection                 = 1;
-    configPtr->rateControlMode                      = 0;
-    configPtr->lookAheadDistance                    = (uint32_t)~0;
-    configPtr->targetBitRate                        = 7000000;
-    configPtr->maxQpAllowed                         = 48;
-    configPtr->minQpAllowed                         = 10;
-    configPtr->baseLayerSwitchMode                  = 0;
-	  configPtr->encMode								              = 9;
-    configPtr->intraPeriod                          = -2;
-    configPtr->intraRefreshType                     = 1;
-	  configPtr->hierarchicalLevels					          = 3;
-	  configPtr->predStructure						            = 2;
-    configPtr->disableDlfFlag                       = EB_FALSE;
-    configPtr->enableSaoFlag                        = EB_TRUE;
-    configPtr->useDefaultMeHme                      = EB_TRUE;
-    configPtr->enableHmeFlag                        = EB_TRUE;
-    configPtr->searchAreaWidth                      = 16;
-    configPtr->searchAreaHeight                     = 7;
-    configPtr->constrainedIntra                     = EB_FALSE;
-    configPtr->tune                                 = 1; // OQ By Default
-    // Thresholds
-    configPtr->videoUsabilityInfo                   = 0;
-    configPtr->highDynamicRangeInput                = 0;
-    configPtr->accessUnitDelimiter                  = 0;
-    configPtr->bufferingPeriodSEI                   = 0;
-    configPtr->pictureTimingSEI                     = 0;
+    configPtr->interlacedVideo                          = EB_FALSE;
+    configPtr->separateFields                           = EB_FALSE;
 
-    configPtr->bitRateReduction					    = EB_TRUE;
-    configPtr->improveSharpness                     = EB_TRUE;
-    configPtr->registeredUserDataSeiFlag            = EB_FALSE;
-    configPtr->unregisteredUserDataSeiFlag          = EB_FALSE;
-    configPtr->recoveryPointSeiFlag                 = EB_FALSE;
-    configPtr->enableTemporalId                     = 1;
+    // Coding Structure
+	configPtr->hierarchicalLevels					    = 3;
+    configPtr->baseLayerSwitchMode                      = 0;
+	configPtr->predStructure						    = 2;
+    configPtr->intraPeriod                              = -2;
+    configPtr->intraRefreshType                         = 1;
 
-    // SEI
-    configPtr->maxCLL                               = 0;
-    configPtr->maxFALL                              = 0;
-    configPtr->useMasteringDisplayColorVolume       = EB_FALSE;
-    configPtr->useNaluFile                          = EB_FALSE;
-    configPtr->dolbyVisionProfile                   = 0;
-    configPtr->dolbyVisionRpuFile                   = NULL;
-    configPtr->naluFile                             = NULL;
-    configPtr->displayPrimaryX[0]                   = 0;
-    configPtr->displayPrimaryX[1]                   = 0;
-    configPtr->displayPrimaryX[2]                   = 0;
-    configPtr->displayPrimaryY[0]                   = 0;
-    configPtr->displayPrimaryY[1]                   = 0;
-    configPtr->displayPrimaryY[2]                   = 0;
-    configPtr->whitePointX                          = 0;
-    configPtr->whitePointY                          = 0;
-    configPtr->maxDisplayMasteringLuminance         = 0;
-    configPtr->minDisplayMasteringLuminance         = 0;
+    // Quantization
+    configPtr->qp                                       = 32;
 
-    configPtr->switchThreadsToRtPriority            = EB_TRUE;
-    configPtr->fpsInVps                             = EB_FALSE;
+    // Sample Adaptive Offset
+    configPtr->enableSaoFlag                            = EB_TRUE;
 
-    // Annex A parameters
-    configPtr->profile                              = 2;
-    configPtr->tier                                 = 0;
-    configPtr->level                                = 0;
+    // ME Tools
+    configPtr->useDefaultMeHme                          = EB_TRUE;
+    configPtr->enableHmeFlag                            = EB_TRUE;
 
-    // Latency
-    configPtr->injector                                     = 0;
-    configPtr->injectorFrameRate                            = 60 << 16;
-    configPtr->speedControlFlag                             = 0;
+    // ME Parameters
+    configPtr->searchAreaWidth                          = 16;
+    configPtr->searchAreaHeight                         = 7;
 
+    // MD Parameters
+    configPtr->constrainedIntra                         = EB_FALSE;
+
+    // Rate Control
+    configPtr->rateControlMode                          = 0;
+    configPtr->targetBitRate                            = 7000000;
+    configPtr->maxQpAllowed                             = 48;
+    configPtr->minQpAllowed                             = 10;
+    configPtr->lookAheadDistance                        = (uint32_t)~0;
+    configPtr->sceneChangeDetection                     = 1;
+
+    // Tune
+    configPtr->tune                                     = 1;
+
+    // Adaptive QP Params
+    configPtr->bitRateReduction					        = EB_TRUE;
+    configPtr->improveSharpness                         = EB_TRUE;
+
+    // Optional Features
+    configPtr->videoUsabilityInfo                       = 0;
+    configPtr->highDynamicRangeInput                    = 0;
+    configPtr->accessUnitDelimiter                      = 0;
+    configPtr->bufferingPeriodSEI                       = 0;
+    configPtr->pictureTimingSEI                         = 0;
+    configPtr->registeredUserDataSeiFlag                = EB_FALSE;
+    configPtr->unregisteredUserDataSeiFlag              = EB_FALSE;
+    configPtr->recoveryPointSeiFlag                     = EB_FALSE;
+    configPtr->enableTemporalId                         = 1;
+    configPtr->switchThreadsToRtPriority                = EB_TRUE;
+    configPtr->fpsInVps                                 = EB_FALSE;
+    configPtr->maxCLL                                   = 0;
+    configPtr->maxFALL                                  = 0;
+    configPtr->useMasteringDisplayColorVolume           = EB_FALSE;
+    configPtr->displayPrimaryX[0]                       = 0;
+    configPtr->displayPrimaryX[1]                       = 0;
+    configPtr->displayPrimaryX[2]                       = 0;
+    configPtr->displayPrimaryY[0]                       = 0;
+    configPtr->displayPrimaryY[1]                       = 0;
+    configPtr->displayPrimaryY[2]                       = 0;
+    configPtr->whitePointX                              = 0;
+    configPtr->whitePointY                              = 0;
+    configPtr->maxDisplayMasteringLuminance             = 0;
+    configPtr->minDisplayMasteringLuminance             = 0;
+    configPtr->dolbyVisionProfile                       = 0;
+    configPtr->dolbyVisionRpuFile                       = NULL;
+    configPtr->useNaluFile                              = EB_FALSE;
+    configPtr->naluFile                                 = NULL;
+
+    // Platform Specific Flags
+    configPtr->asmType                                  = 1;
+    configPtr->targetSocket                             = -1;
+    configPtr->logicalProcessors                        = 0;
+
+    configPtr->inputPaddedWidth                         = 0;
+    configPtr->inputPaddedHeight                        = 0;
+    configPtr->sequenceBuffer                           = 0;
+    configPtr->disableDlfFlag                           = EB_FALSE;
 
     // Testing
-    configPtr->testUserData                                 = 0;
-	configPtr->eosFlag										= EB_FALSE;
+    configPtr->testUserData                             = 0;
+	configPtr->eosFlag                                  = EB_FALSE;
 
     // Computational Performance Parameters
-    configPtr->performanceContext.libStartTime[0] = 0;
-    configPtr->performanceContext.libStartTime[1] = 0;
+    configPtr->performanceContext.libStartTime[0]       = 0;
+    configPtr->performanceContext.libStartTime[1]       = 0;
 
-    configPtr->performanceContext.encodeStartTime[0] = 0;
-    configPtr->performanceContext.encodeStartTime[1] = 0;
+    configPtr->performanceContext.encodeStartTime[0]    = 0;
+    configPtr->performanceContext.encodeStartTime[1]    = 0;
+    
+    configPtr->performanceContext.totalExecutionTime    = 0;
+    configPtr->performanceContext.totalEncodeTime       = 0;
+    configPtr->performanceContext.frameCount            = 0;
+    configPtr->performanceContext.averageSpeed          = 0;
+    configPtr->performanceContext.startsTime            = 0;
+    configPtr->performanceContext.startuTime            = 0;
+    configPtr->performanceContext.maxLatency            = 0;
+    configPtr->performanceContext.totalLatency          = 0;
+    configPtr->performanceContext.byteCount             = 0;
 
-    configPtr->performanceContext.totalExecutionTime = 0;
-    configPtr->performanceContext.totalEncodeTime = 0;
-    configPtr->performanceContext.frameCount                = 0;
-    configPtr->performanceContext.averageSpeed              = 0;
-    configPtr->performanceContext.startsTime                = 0;
-    configPtr->performanceContext.startuTime                = 0;
-    configPtr->performanceContext.maxLatency                = 0;
-    configPtr->performanceContext.totalLatency              = 0;
-    configPtr->performanceContext.byteCount                 = 0;
-
-    // ASM Type
-    configPtr->asmType                                      = 1;
-
-    configPtr->stopEncoder                                  = EB_FALSE;
-    configPtr->logicalProcessors                            = 0;
-    configPtr->targetSocket                                 = -1;
-    configPtr->processedFrameCount                          = 0;
-    configPtr->processedByteCount                           = 0;
-
+    configPtr->stopEncoder                              = EB_FALSE;
+    configPtr->processedFrameCount                      = 0;
+    configPtr->processedByteCount                       = 0;
 
     return;
 }
@@ -1115,7 +1136,6 @@ EB_ERRORTYPE ReadCommandLine(
     /***************************************************************************************************/
     /****************  Find configuration files tokens and call respective functions  ******************/
     /***************************************************************************************************/
-
     // Find the Config File Path in the command line
     if (FindTokenMultipleInputs(argc, argv, CONFIG_FILE_TOKEN, config_strings) == 0) {
 

--- a/Source/App/EbAppConfig.c
+++ b/Source/App/EbAppConfig.c
@@ -226,10 +226,10 @@ static void SetEnableTemporalId                 (const char *value, EbConfig_t *
 static void SetProfile                          (const char *value, EbConfig_t *cfg) {cfg->profile                          = strtol(value,  NULL, 0);};
 static void SetTier                             (const char *value, EbConfig_t *cfg) {cfg->tier                             = strtol(value,  NULL, 0);};
 static void SetLevel                            (const char *value, EbConfig_t *cfg) {
-	if (strtoul( value, NULL,0) != 0 || EB_STRCMP(value, "0") == 0 )
-		cfg->level = (uint32_t)(10*strtod(value,  NULL));
-	else
-		cfg->level = 9999999;
+    if (strtoul( value, NULL,0) != 0 || EB_STRCMP(value, "0") == 0 )
+        cfg->level = (uint32_t)(10*strtod(value,  NULL));
+    else
+        cfg->level = 9999999;
 };
 static void SetInjector                         (const char *value, EbConfig_t *cfg) {cfg->injector                         = strtol(value,  NULL, 0);};
 static void SpeedControlFlag                    (const char *value, EbConfig_t *cfg) {cfg->speedControlFlag                 = strtol(value, NULL, 0); };
@@ -285,7 +285,7 @@ config_entry_t config_entry[] = {
 
     // Bit-depth
     { SINGLE_INPUT, ENCODER_BIT_DEPTH, "EncoderBitDepth", SetEncoderBitDepth },
-	{ SINGLE_INPUT, INPUT_COMPRESSED_TEN_BIT_FORMAT, "CompressedTenBitFormat", SetcompressedTenBitFormat },
+    { SINGLE_INPUT, INPUT_COMPRESSED_TEN_BIT_FORMAT, "CompressedTenBitFormat", SetcompressedTenBitFormat },
     { SINGLE_INPUT, ENCODER_COLOR_FORMAT, "EncoderColorFormat", SetEncoderColorFormat },
 
     // Source Definitions
@@ -311,9 +311,9 @@ config_entry_t config_entry[] = {
     { SINGLE_INPUT, SEPERATE_FILDS_TOKEN, "SeperateFields", SetSeperateFields },
 
     // Coding Structure
-	{ SINGLE_INPUT, HIERARCHICAL_LEVELS_TOKEN, "HierarchicalLevels", SetHierarchicalLevels },
+    { SINGLE_INPUT, HIERARCHICAL_LEVELS_TOKEN, "HierarchicalLevels", SetHierarchicalLevels },
     { SINGLE_INPUT, BASE_LAYER_SWITCH_MODE_TOKEN, "BaseLayerSwitchMode", SetBaseLayerSwitchMode },
-	{ SINGLE_INPUT, PRED_STRUCT_TOKEN, "PredStructure", SetCfgPredStructure },
+    { SINGLE_INPUT, PRED_STRUCT_TOKEN, "PredStructure", SetCfgPredStructure },
     { SINGLE_INPUT, INTRA_PERIOD_TOKEN, "IntraPeriod", SetCfgIntraPeriod },
     { SINGLE_INPUT, INTRA_REFRESH_TYPE_TOKEN, "IntraRefreshType", SetCfgIntraRefreshType },
 
@@ -349,7 +349,7 @@ config_entry_t config_entry[] = {
     { SINGLE_INPUT, TUNE_TOKEN, "Tune", SetCfgTune },
 
     // Adaptive QP Params
-	{ SINGLE_INPUT, BITRATE_REDUCTION_TOKEN, "BitRateReduction", SetBitRateReduction },
+    { SINGLE_INPUT, BITRATE_REDUCTION_TOKEN, "BitRateReduction", SetBitRateReduction },
     { SINGLE_INPUT, IMPROVE_SHARPNESS_TOKEN,"ImproveSharpness", SetImproveSharpness },
 
     // Optional Features
@@ -401,7 +401,7 @@ void EbConfigCtor(EbConfig_t *configPtr)
 #endif
 
     // Encoding Presets
-	configPtr->encMode								    = 9;
+    configPtr->encMode								    = 9;
     //configPtr->latencyMode                              = 0; // Deprecated
     configPtr->speedControlFlag                         = 0;
 
@@ -433,9 +433,9 @@ void EbConfigCtor(EbConfig_t *configPtr)
     configPtr->separateFields                           = EB_FALSE;
 
     // Coding Structure
-	configPtr->hierarchicalLevels					    = 3;
+    configPtr->hierarchicalLevels					    = 3;
     configPtr->baseLayerSwitchMode                      = 0;
-	configPtr->predStructure						    = 2;
+    configPtr->predStructure						    = 2;
     configPtr->intraPeriod                              = -2;
     configPtr->intraRefreshType                         = 1;
 
@@ -513,7 +513,7 @@ void EbConfigCtor(EbConfig_t *configPtr)
 
     // Testing
     configPtr->testUserData                             = 0;
-	configPtr->eosFlag                                  = EB_FALSE;
+    configPtr->eosFlag                                  = EB_FALSE;
 
     // Computational Performance Parameters
     configPtr->performanceContext.libStartTime[0]       = 0;
@@ -581,10 +581,10 @@ void EbConfigDtor(EbConfig_t *configPtr)
         configPtr->naluFile = (FILE *)NULL;
     }
 
-	if (configPtr->dolbyVisionRpuFile) {
-		fclose(configPtr->dolbyVisionRpuFile);
-		configPtr->dolbyVisionRpuFile = (FILE *)NULL;
-	}
+    if (configPtr->dolbyVisionRpuFile) {
+        fclose(configPtr->dolbyVisionRpuFile);
+        configPtr->dolbyVisionRpuFile = (FILE *)NULL;
+    }
 
     return;
 }
@@ -656,145 +656,145 @@ static void lineSplit(
 * Set Config Value
 **********************************/
 static void SetConfigValue(
-	EbConfig_t *config,
-	char       *name,
-	char       *value)
+    EbConfig_t *config,
+    char       *name,
+    char       *value)
 {
-	int32_t i=0;
+    int32_t i=0;
 
-	while(config_entry[i].name != NULL) {
-		if(EB_STRCMP(config_entry[i].name, name) == 0)  {
-			(*config_entry[i].scf)((const char *) value, config);
-		}
-		++i;
-	}
+    while(config_entry[i].name != NULL) {
+        if(EB_STRCMP(config_entry[i].name, name) == 0)  {
+            (*config_entry[i].scf)((const char *) value, config);
+        }
+        ++i;
+    }
 
-	return;
+    return;
 }
 
 /**********************************
 * Parse Config File
 **********************************/
 static void ParseConfigFile(
-	EbConfig_t *config,
-	char       *buffer,
-	int32_t         size)
+    EbConfig_t *config,
+    char       *buffer,
+    int32_t         size)
 {
-	uint32_t argc;
-	char *argv[CONFIG_FILE_MAX_ARG_COUNT];
-	uint32_t argLen[CONFIG_FILE_MAX_ARG_COUNT];
+    uint32_t argc;
+    char *argv[CONFIG_FILE_MAX_ARG_COUNT];
+    uint32_t argLen[CONFIG_FILE_MAX_ARG_COUNT];
 
-	char varName[CONFIG_FILE_MAX_VAR_LEN];
-	char varValue[CONFIG_FILE_MAX_ARG_COUNT][CONFIG_FILE_MAX_VAR_LEN];
+    char varName[CONFIG_FILE_MAX_VAR_LEN];
+    char varValue[CONFIG_FILE_MAX_ARG_COUNT][CONFIG_FILE_MAX_VAR_LEN];
 
-	uint32_t valueIndex;
+    uint32_t valueIndex;
 
-	uint32_t commentSectionFlag = 0;
-	uint32_t newLineFlag = 0;
+    uint32_t commentSectionFlag = 0;
+    uint32_t newLineFlag = 0;
 
-	// Keep looping until we process the entire file
-	while(size--) {
-		commentSectionFlag = ((*buffer == CONFIG_FILE_COMMENT_CHAR) || (commentSectionFlag != 0)) ? 1 : commentSectionFlag;
+    // Keep looping until we process the entire file
+    while(size--) {
+        commentSectionFlag = ((*buffer == CONFIG_FILE_COMMENT_CHAR) || (commentSectionFlag != 0)) ? 1 : commentSectionFlag;
 
-		// At the beginning of each line
-		if ((newLineFlag == 1) && (commentSectionFlag == 0)) {
-			// Do an argc/argv split for the line
-			lineSplit(&argc, argv, argLen, buffer);
+        // At the beginning of each line
+        if ((newLineFlag == 1) && (commentSectionFlag == 0)) {
+            // Do an argc/argv split for the line
+            lineSplit(&argc, argv, argLen, buffer);
 
-			if ((argc > 2) && (*argv[1] == CONFIG_FILE_VALUE_SPLIT)) {
-				// ***NOTE - We're assuming that the variable name is the first arg and
-				// the variable value is the third arg.
+            if ((argc > 2) && (*argv[1] == CONFIG_FILE_VALUE_SPLIT)) {
+                // ***NOTE - We're assuming that the variable name is the first arg and
+                // the variable value is the third arg.
 
-				// Cap the length of the variable name
-				argLen[0] = (argLen[0] > CONFIG_FILE_MAX_VAR_LEN - 1) ? CONFIG_FILE_MAX_VAR_LEN - 1 : argLen[0];
-				// Copy the variable name
-				EB_STRNCPY(varName, argv[0], argLen[0]);
-				// Null terminate the variable name
-				varName[argLen[0]] = CONFIG_FILE_NULL_CHAR;
+                // Cap the length of the variable name
+                argLen[0] = (argLen[0] > CONFIG_FILE_MAX_VAR_LEN - 1) ? CONFIG_FILE_MAX_VAR_LEN - 1 : argLen[0];
+                // Copy the variable name
+                EB_STRNCPY(varName, argv[0], argLen[0]);
+                // Null terminate the variable name
+                varName[argLen[0]] = CONFIG_FILE_NULL_CHAR;
 
-				for(valueIndex=0; (valueIndex < CONFIG_FILE_MAX_ARG_COUNT - 2) && (valueIndex < (argc - 2)); ++valueIndex) {
+                for(valueIndex=0; (valueIndex < CONFIG_FILE_MAX_ARG_COUNT - 2) && (valueIndex < (argc - 2)); ++valueIndex) {
 
-					// Cap the length of the variable
-					argLen[valueIndex+2] = (argLen[valueIndex+2] > CONFIG_FILE_MAX_VAR_LEN - 1) ? CONFIG_FILE_MAX_VAR_LEN - 1 : argLen[valueIndex+2];
-					// Copy the variable name
-					EB_STRNCPY(varValue[valueIndex], argv[valueIndex+2], argLen[valueIndex+2]);
-					// Null terminate the variable name
-					varValue[valueIndex][argLen[valueIndex+2]] = CONFIG_FILE_NULL_CHAR;
+                    // Cap the length of the variable
+                    argLen[valueIndex+2] = (argLen[valueIndex+2] > CONFIG_FILE_MAX_VAR_LEN - 1) ? CONFIG_FILE_MAX_VAR_LEN - 1 : argLen[valueIndex+2];
+                    // Copy the variable name
+                    EB_STRNCPY(varValue[valueIndex], argv[valueIndex+2], argLen[valueIndex+2]);
+                    // Null terminate the variable name
+                    varValue[valueIndex][argLen[valueIndex+2]] = CONFIG_FILE_NULL_CHAR;
 
-					SetConfigValue(config, varName, varValue[valueIndex]);
-				}
-			}
-		}
+                    SetConfigValue(config, varName, varValue[valueIndex]);
+                }
+            }
+        }
 
-		commentSectionFlag = (*buffer == CONFIG_FILE_NEWLINE_CHAR) ? 0 : commentSectionFlag;
-		newLineFlag = (*buffer == CONFIG_FILE_NEWLINE_CHAR) ? 1 : 0;
-		++buffer;
-	}
+        commentSectionFlag = (*buffer == CONFIG_FILE_NEWLINE_CHAR) ? 0 : commentSectionFlag;
+        newLineFlag = (*buffer == CONFIG_FILE_NEWLINE_CHAR) ? 1 : 0;
+        ++buffer;
+    }
 
-	return;
+    return;
 }
 
 /******************************************
 * Find Token
 ******************************************/
 static int32_t FindToken(
-	int32_t         argc,
-	char * const    argv[],
-	char const *    token,
-	char*           configStr)
+    int32_t         argc,
+    char * const    argv[],
+    char const *    token,
+    char*           configStr)
 {
-	int32_t return_error = -1;
+    int32_t return_error = -1;
 
-	while((argc > 0) && (return_error != 0)) {
-		return_error = EB_STRCMP(argv[--argc], token);
-		if (return_error == 0) {
-			EB_STRCPY(configStr, COMMAND_LINE_MAX_SIZE, argv[argc + 1]);
-		}
-	}
+    while((argc > 0) && (return_error != 0)) {
+        return_error = EB_STRCMP(argv[--argc], token);
+        if (return_error == 0) {
+            EB_STRCPY(configStr, COMMAND_LINE_MAX_SIZE, argv[argc + 1]);
+        }
+    }
 
-	return return_error;
+    return return_error;
 }
 
 /**********************************
 * Read Config File
 **********************************/
 static int32_t ReadConfigFile(
-	EbConfig_t  *config,
-	char		*configPath,
-	uint32_t     instanceIdx)
+    EbConfig_t  *config,
+    char		*configPath,
+    uint32_t     instanceIdx)
 {
-	int32_t return_error = 0;
+    int32_t return_error = 0;
 
-	// Open the config file
-	FOPEN(config->configFile, configPath, "rb");
+    // Open the config file
+    FOPEN(config->configFile, configPath, "rb");
 
-	if (config->configFile != (FILE*) NULL) {
-		int32_t configFileSize = findFileSize(config->configFile);
-		char *configFileBuffer = (char*) malloc(configFileSize);
+    if (config->configFile != (FILE*) NULL) {
+        int32_t configFileSize = findFileSize(config->configFile);
+        char *configFileBuffer = (char*) malloc(configFileSize);
 
-		if (configFileBuffer != (char *) NULL) {
-			int32_t resultSize = (int32_t) fread(configFileBuffer, 1, configFileSize, config->configFile);
+        if (configFileBuffer != (char *) NULL) {
+            int32_t resultSize = (int32_t) fread(configFileBuffer, 1, configFileSize, config->configFile);
 
-			if (resultSize == configFileSize) {
-				ParseConfigFile(config, configFileBuffer, configFileSize);
-			} else {
-				printf("Error channel %u: File Read Failed\n",instanceIdx+1);
-				return_error = -1;
-			}
-		} else {
-			printf("Error channel %u: Memory Allocation Failed\n",instanceIdx+1);
-			return_error = -1;
-		}
+            if (resultSize == configFileSize) {
+                ParseConfigFile(config, configFileBuffer, configFileSize);
+            } else {
+                printf("Error channel %u: File Read Failed\n",instanceIdx+1);
+                return_error = -1;
+            }
+        } else {
+            printf("Error channel %u: Memory Allocation Failed\n",instanceIdx+1);
+            return_error = -1;
+        }
 
-		free(configFileBuffer);
-		fclose(config->configFile);
-		config->configFile = (FILE*) NULL;
-	} else {
-		printf("Error channel %u: Couldn't open Config File: %s\n", instanceIdx+1,configPath);
-		return_error = -1;
-	}
+        free(configFileBuffer);
+        fclose(config->configFile);
+        config->configFile = (FILE*) NULL;
+    } else {
+        printf("Error channel %u: Couldn't open Config File: %s\n", instanceIdx+1,configPath);
+        return_error = -1;
+    }
 
-	return return_error;
+    return return_error;
 }
 
 /******************************************
@@ -802,18 +802,18 @@ static int32_t ReadConfigFile(
 ******************************************/
 static EB_ERRORTYPE VerifySettings(EbConfig_t *config, uint32_t channelNumber)
 {
-	EB_ERRORTYPE return_error = EB_ErrorNone;
+    EB_ERRORTYPE return_error = EB_ErrorNone;
 
-	// Check Input File
-	if(config->inputFile == (FILE*) NULL) {
-		fprintf(config->errorLogFile, "SVT [Error]: Instance %u: Invalid Input File\n",channelNumber+1);
-		return_error = EB_ErrorBadParameter;
-	}
+    // Check Input File
+    if(config->inputFile == (FILE*) NULL) {
+        fprintf(config->errorLogFile, "SVT [Error]: Instance %u: Invalid Input File\n",channelNumber+1);
+        return_error = EB_ErrorBadParameter;
+    }
 
     if (config->framesToBeEncoded <= -1) {
-		fprintf(config->errorLogFile, "SVT [Error]: Instance %u: FrameToBeEncoded must be greater than 0\n",channelNumber+1);
-		return_error = EB_ErrorBadParameter;
-	}
+        fprintf(config->errorLogFile, "SVT [Error]: Instance %u: FrameToBeEncoded must be greater than 0\n",channelNumber+1);
+        return_error = EB_ErrorBadParameter;
+    }
 
     if (config->framesToBeEncoded >= LLONG_MAX) {
         fprintf(config->errorLogFile, "SVT [Error]: Instance %u: FrameToBeEncoded must be less than 2^64 - 1\n", channelNumber + 1);
@@ -825,10 +825,10 @@ static EB_ERRORTYPE VerifySettings(EbConfig_t *config, uint32_t channelNumber)
         return_error = EB_ErrorBadParameter;
     }
 
-	if (config->bufferedInput > config->framesToBeEncoded) {
-		fprintf(config->errorLogFile, "SVT [Error]: Instance %u: Invalid BufferedInput. BufferedInput must be less or equal to the number of frames to be encoded\n",channelNumber+1);
-		return_error = EB_ErrorBadParameter;
-	}
+    if (config->bufferedInput > config->framesToBeEncoded) {
+        fprintf(config->errorLogFile, "SVT [Error]: Instance %u: Invalid BufferedInput. BufferedInput must be less or equal to the number of frames to be encoded\n",channelNumber+1);
+        return_error = EB_ErrorBadParameter;
+    }
 
     if (config->useQpFile == EB_TRUE && config->qpFile == NULL) {
         fprintf(config->errorLogFile, "SVT [Error]: Instance %u: Could not find QP file, UseQpFile is set to 1\n", channelNumber + 1);
@@ -934,44 +934,44 @@ int32_t FindTokenMultipleInputs(
     int32_t         argc,
     char* const     argv[],
     const char*     token,
-	char**          configStr)
+    char**          configStr)
 {
-	int32_t return_error = -1;
-	int32_t done = 0;
-	while((argc > 0) && (return_error != 0)) {
-		return_error = EB_STRCMP(argv[--argc], token);
-		if (return_error == 0) {
-			int32_t count;
-			for (count=0; count < MAX_CHANNEL_NUMBER  ; ++count){
-				if (done ==0){
-					if (argv[argc + count + 1] ){
-						if (strtoul(argv[argc + count + 1], NULL,0) != 0 || EB_STRCMP(argv[argc + count + 1], "0") == 0 ){
-							EB_STRCPY(configStr[count], COMMAND_LINE_MAX_SIZE, argv[argc + count + 1]);
-						}else if (argv[argc + count + 1][0] != '-'){
-							EB_STRCPY(configStr[count], COMMAND_LINE_MAX_SIZE, argv[argc + count + 1]);
-						}else {
-							EB_STRCPY(configStr[count], COMMAND_LINE_MAX_SIZE," ");
-							done = 1;
-						}
-					}else{
-						EB_STRCPY(configStr[count], COMMAND_LINE_MAX_SIZE, " ");
-						done =1;
-						//return return_error;
-					}
-				}else
-					EB_STRCPY(configStr[count], COMMAND_LINE_MAX_SIZE, " ");
-			}
-		}
-	}
+    int32_t return_error = -1;
+    int32_t done = 0;
+    while((argc > 0) && (return_error != 0)) {
+        return_error = EB_STRCMP(argv[--argc], token);
+        if (return_error == 0) {
+            int32_t count;
+            for (count=0; count < MAX_CHANNEL_NUMBER  ; ++count){
+                if (done ==0){
+                    if (argv[argc + count + 1] ){
+                        if (strtoul(argv[argc + count + 1], NULL,0) != 0 || EB_STRCMP(argv[argc + count + 1], "0") == 0 ){
+                            EB_STRCPY(configStr[count], COMMAND_LINE_MAX_SIZE, argv[argc + count + 1]);
+                        }else if (argv[argc + count + 1][0] != '-'){
+                            EB_STRCPY(configStr[count], COMMAND_LINE_MAX_SIZE, argv[argc + count + 1]);
+                        }else {
+                            EB_STRCPY(configStr[count], COMMAND_LINE_MAX_SIZE," ");
+                            done = 1;
+                        }
+                    }else{
+                        EB_STRCPY(configStr[count], COMMAND_LINE_MAX_SIZE, " ");
+                        done =1;
+                        //return return_error;
+                    }
+                }else
+                    EB_STRCPY(configStr[count], COMMAND_LINE_MAX_SIZE, " ");
+            }
+        }
+    }
 
-	return return_error;
+    return return_error;
 }
 
 uint32_t GetHelp(
     int32_t     argc,
     char *const argv[])
 {
-	char config_string[COMMAND_LINE_MAX_SIZE];
+    char config_string[COMMAND_LINE_MAX_SIZE];
     if (FindToken(argc, argv, HELP_TOKEN, config_string) == 0) {
         int32_t token_index = -1;
 
@@ -995,20 +995,20 @@ uint32_t GetNumberOfChannels(
     int32_t     argc,
     char *const argv[])
 {
-	char config_string[COMMAND_LINE_MAX_SIZE];
-	uint32_t channelNumber;
-	if (FindToken(argc, argv, CHANNEL_NUMBER_TOKEN, config_string) == 0) {
+    char config_string[COMMAND_LINE_MAX_SIZE];
+    uint32_t channelNumber;
+    if (FindToken(argc, argv, CHANNEL_NUMBER_TOKEN, config_string) == 0) {
 
-		// Set the input file
-		channelNumber = strtol(config_string,  NULL, 0);
-		if ((channelNumber > (uint32_t) MAX_CHANNEL_NUMBER) || channelNumber == 0){
-			printf("Error: The number of channels has to be within the range [1,%u]\n",(uint32_t) MAX_CHANNEL_NUMBER);
-			return 0;
-		}else{
-			return channelNumber;
-		}
-	}
-	return 1;
+        // Set the input file
+        channelNumber = strtol(config_string,  NULL, 0);
+        if ((channelNumber > (uint32_t) MAX_CHANNEL_NUMBER) || channelNumber == 0){
+            printf("Error: The number of channels has to be within the range [1,%u]\n",(uint32_t) MAX_CHANNEL_NUMBER);
+            return 0;
+        }else{
+            return channelNumber;
+        }
+    }
+    return 1;
 }
 
 void mark_token_as_read(
@@ -1106,11 +1106,11 @@ static EB_ERRORTYPE ParseMasteringDisplayColorVolumeSEI(
 * Read Command Line
 ******************************************/
 EB_ERRORTYPE ReadCommandLine(
-	int32_t        argc,
-	char *const    argv[],
-	EbConfig_t   **configs,
-	uint32_t       numChannels,
-	EB_ERRORTYPE  *return_errors)
+    int32_t        argc,
+    char *const    argv[],
+    EbConfig_t   **configs,
+    uint32_t       numChannels,
+    EB_ERRORTYPE  *return_errors)
 {
 
     EB_ERRORTYPE return_error = EB_ErrorBadParameter;
@@ -1126,7 +1126,7 @@ EB_ERRORTYPE ReadCommandLine(
     }
 
     // Copy tokens (except for CHANNEL_NUMBER_TOKEN ) into a temp token buffer hosting all tokens that are passed through the command line
-	size_t len = EB_STRLEN(CHANNEL_NUMBER_TOKEN, COMMAND_LINE_MAX_SIZE);
+    size_t len = EB_STRLEN(CHANNEL_NUMBER_TOKEN, COMMAND_LINE_MAX_SIZE);
     for (token_index = 0; token_index < argc; ++token_index) {
         if ((argv[token_index][0] == '-') && strncmp(argv[token_index], CHANNEL_NUMBER_TOKEN, len) && !is_negative_number(argv[token_index])) {
                 cmd_copy[cmd_token_cnt++] = argv[token_index];


### PR DESCRIPTION
Update the formating on the Sample config file for it to have a more uniform look. Added the EncoderColorFormat variable, it's option and definition needs to be checked. Reformatted the AppConfig file to match the structure of the sample config file to allow easy check if something is missing in the config file or a flag is missing in the documentation. Renamed the LogicalProcessorNumbers to LogicalProcessors in the documentation to match the actual variable name.