### PR TITLE
Fix B-frame without positive reference frames as P-frame.

### DIFF
--- a/Source/Lib/Codec/EbPictureDecisionProcess.c
+++ b/Source/Lib/Codec/EbPictureDecisionProcess.c
@@ -1560,8 +1560,12 @@ void* PictureDecisionKernel(void *inputPtr)
                                 EbObjectIncLiveCount(
                                     paReferenceEntryPtr->pPcsPtr->pPcsWrapperPtr,
                                     1);
-                        
+
                                 --paReferenceEntryPtr->dependentCount;
+                            } else {
+                                pictureControlSetPtr->sliceType = EB_P_PICTURE;
+                                ((EbPaReferenceObject_t *)pictureControlSetPtr->paReferencePictureWrapperPtr->objectPtr)->sliceType =
+                                    EB_P_PICTURE;
                             }
                         }
 

--- a/Source/Lib/Codec/EbPredictionStructure.c
+++ b/Source/Lib/Codec/EbPredictionStructure.c
@@ -1711,6 +1711,13 @@ static EB_ERRORTYPE PredictionStructureCtor(
                 }
             }
 
+            // Adjust List1 if there is no positive reference frames.
+            if (predictionStructurePtr->predStructEntryPtrArray[entryIndex]->positiveRefPicsTotalCount == 0 &&
+                predictionStructurePtr->predStructEntryPtrArray[entryIndex]->refList1.referenceListCount > 0) {
+                predictionStructurePtr->predStructEntryPtrArray[entryIndex]->refList1.referenceList = 0;
+                predictionStructurePtr->predStructEntryPtrArray[entryIndex]->refList1.referenceListCount = 0;
+            }
+
             // Adjust Reference Counts if list is empty
             predictionStructurePtr->predStructEntryPtrArray[entryIndex]->refPicsList0TotalCountMinus1  =
                 (predictionStructurePtr->predStructEntryPtrArray[entryIndex]->refPicsList0TotalCountMinus1 == ~0) ?


### PR DESCRIPTION
The `B frame` in the key position only have negative reference frames in the ramdom access prediction structure. For example the frames whose pictureNumber is 8 (`POC 8`) could only reference frame `POC 0`.
Using `B_SLICE` for this picture would bring in more header bits in the bit-stream and may bring in more computation.

So I suggest to fix their type as `P-frame`.