### PR TITLE
Fix chroma prediction error in function `IntraPredictionOl()`.

### DIFF
--- a/Source/Lib/Codec/EbIntraPrediction.c
+++ b/Source/Lib/Codec/EbIntraPrediction.c
@@ -5510,7 +5510,7 @@ EB_ERRORTYPE IntraPredictionOl(
 		}
 
 		// The chromaMode is always DM
-		EB_U32 chromaMode = (EB_U32)funcIndex;
+		EB_U32 chromaMode = (EB_U32)openLoopIntraCandidateIndex;
 
         EB_U32 puChromaOriginIndex = (((puOriginY & (63)) * 32) + (puOriginX & (63)))>>1;
 		EB_U32 chromaPuSize = puWidth >> 1;


### PR DESCRIPTION
The variable `chromaMode` here is set to the entropy coding value as `EB_U32 chromaMode = (EB_U32)funcIndex`, however it would be utilized in later function call (line: 5625 in this file) for intra prediction.
So, here we should set `chromaMode` as the real prediction mode.