### PR TITLE
SpatialFullDistortionKernel(SSE) fix

### DIFF
--- a/Source/Lib/ASM_AVX2/EbComputeSAD_AVX2.h
+++ b/Source/Lib/ASM_AVX2/EbComputeSAD_AVX2.h
@@ -28,8 +28,23 @@ EB_U32 Compute32xMSad_AVX2_INTRIN(
 	EB_U32  height,                         // input parameter, block height (M)
 	EB_U32  width);                         // input parameter, block width (N)    
 
+EB_U32 Compute40xMSad_AVX2_INTRIN(
+	EB_U8  *src,                            // input parameter, source samples Ptr
+	EB_U32  srcStride,                      // input parameter, source stride
+	EB_U8  *ref,                            // input parameter, reference samples Ptr
+	EB_U32  refStride,                      // input parameter, reference stride  
+	EB_U32  height,                         // input parameter, block height (M)
+	EB_U32  width);                         // input parameter, block width (N)    
 
 EB_U32 Compute48xMSad_AVX2_INTRIN(
+	EB_U8  *src,                            // input parameter, source samples Ptr
+	EB_U32  srcStride,                      // input parameter, source stride
+	EB_U8  *ref,                            // input parameter, reference samples Ptr
+	EB_U32  refStride,                      // input parameter, reference stride  
+	EB_U32  height,                         // input parameter, block height (M)
+	EB_U32  width);                         // input parameter, block width (N)    
+
+EB_U32 Compute56xMSad_AVX2_INTRIN(
 	EB_U8  *src,                            // input parameter, source samples Ptr
 	EB_U32  srcStride,                      // input parameter, source stride
 	EB_U8  *ref,                            // input parameter, reference samples Ptr

--- a/Source/Lib/ASM_AVX2/EbComputeSAD_Intrinsic_AVX2.c
+++ b/Source/Lib/ASM_AVX2/EbComputeSAD_Intrinsic_AVX2.c
@@ -1660,6 +1660,40 @@ EB_U32 Compute32xMSad_AVX2_INTRIN(
 /*******************************************************************************
 * Requirement: height % 2 = 0
 *******************************************************************************/
+EB_U32 Compute40xMSad_AVX2_INTRIN(
+        EB_U8  *src,        // input parameter, source samples Ptr
+        EB_U32  srcStride,  // input parameter, source stride
+        EB_U8  *ref,        // input parameter, reference samples Ptr
+        EB_U32  refStride,  // input parameter, reference stride
+        EB_U32  height,     // input parameter, block height (M)
+        EB_U32  width)     // input parameter, block width (N)
+{
+        __m128i xmm0, xmm1;
+        __m256i ymm0, ymm1;
+        EB_U32 y;
+        (void)width;
+
+        ymm0 = ymm1 = _mm256_setzero_si256();
+        xmm0 = xmm1 = _mm_setzero_si128();
+        for (y = 0; y < height; y += 2) {
+                ymm0 = _mm256_add_epi32(ymm0, _mm256_sad_epu8(_mm256_loadu_si256((__m256i*)src), _mm256_loadu_si256((__m256i*)ref)));
+                xmm0 = _mm_add_epi16(xmm0, _mm_sad_epu8(_mm_loadl_epi64((__m128i*)(src + 32)), _mm_loadl_epi64((__m128i*)(ref + 32))));
+                ymm1 = _mm256_add_epi32(ymm1, _mm256_sad_epu8(_mm256_loadu_si256((__m256i*)(src + srcStride)), _mm256_loadu_si256((__m256i*)(ref + refStride))));
+                xmm1 = _mm_add_epi16(xmm1, _mm_sad_epu8(_mm_loadl_epi64((__m128i*)(src + srcStride + 32)), _mm_loadl_epi64((__m128i*)(ref + refStride + 32))));
+
+                src += srcStride << 1;
+                ref += refStride << 1;
+        }
+        ymm0 = _mm256_add_epi32(ymm0, ymm1);
+        xmm0 = _mm_add_epi32(xmm0, xmm1);
+        xmm0 = _mm_add_epi32(xmm0, _mm_add_epi32(_mm256_extracti128_si256(ymm0, 0), _mm256_extracti128_si256(ymm0, 1)));
+        xmm0 = _mm_add_epi32(xmm0, _mm_srli_si128(xmm0, 8));
+        return _mm_extract_epi32(xmm0, 0);
+}
+
+/*******************************************************************************
+* Requirement: height % 2 = 0
+*******************************************************************************/
 EB_U32 Compute48xMSad_AVX2_INTRIN(
 	EB_U8  *src,        // input parameter, source samples Ptr
 	EB_U32  srcStride,  // input parameter, source stride
@@ -1688,6 +1722,42 @@ EB_U32 Compute48xMSad_AVX2_INTRIN(
 	xmm0 = _mm_add_epi32(xmm0, _mm_add_epi32(_mm256_extracti128_si256(ymm0, 0), _mm256_extracti128_si256(ymm0, 1)));
 	xmm0 = _mm_add_epi32(xmm0, _mm_srli_si128(xmm0, 8));
 	return _mm_extract_epi32(xmm0, 0);
+}
+
+/*******************************************************************************
+* Requirement: height % 2 = 0
+*******************************************************************************/
+EB_U32 Compute56xMSad_AVX2_INTRIN(
+        EB_U8  *src,        // input parameter, source samples Ptr
+        EB_U32  srcStride,  // input parameter, source stride
+        EB_U8  *ref,        // input parameter, reference samples Ptr
+        EB_U32  refStride,  // input parameter, reference stride
+        EB_U32  height,     // input parameter, block height (M)
+        EB_U32  width)     // input parameter, block width (N)
+{
+        __m128i xmm0, xmm1;
+        __m256i ymm0, ymm1, ymm2, ymm3;
+        EB_U32 y;
+        (void)width;
+
+        ymm0 = ymm1 = ymm2 = ymm3 = _mm256_setzero_si256();
+        for (y = 0; y < height; y += 2) {
+                ymm0 = _mm256_add_epi32(ymm0, _mm256_sad_epu8(_mm256_loadu_si256((__m256i*)src), _mm256_loadu_si256((__m256i*)ref)));
+                ymm1 = _mm256_add_epi32(ymm1, _mm256_sad_epu8(_mm256_loadu_si256((__m256i*)(src + 32)), _mm256_loadu_si256((__m256i*)(ref + 32))));
+                ymm2 = _mm256_add_epi32(ymm2, _mm256_sad_epu8(_mm256_loadu_si256((__m256i*)(src + srcStride)), _mm256_loadu_si256((__m256i*)(ref + refStride))));
+                ymm3 = _mm256_add_epi32(ymm3, _mm256_sad_epu8(_mm256_loadu_si256((__m256i*)(src + srcStride + 32)), _mm256_loadu_si256((__m256i*)(ref + refStride + 32))));
+
+                src += srcStride << 1;
+                ref += refStride << 1;
+        }
+        ymm0 = _mm256_add_epi32(ymm0, ymm2);
+        xmm0 = _mm_add_epi32(_mm256_extracti128_si256(ymm0, 0), _mm256_extracti128_si256(ymm0, 1));
+
+        xmm0 = _mm_add_epi32(xmm0, _mm_add_epi32(_mm256_extracti128_si256(ymm1, 0), _mm256_extracti128_si256(ymm3, 0)));
+        xmm1 = _mm_add_epi32(_mm256_extracti128_si256(ymm1, 1), _mm256_extracti128_si256(ymm3, 1)); 
+
+        xmm0 = _mm_add_epi32(_mm_add_epi32(xmm0, _mm_srli_si128(xmm0, 8)), xmm1);
+       return _mm_extract_epi32(xmm0, 0);
 }
 
 /*******************************************************************************

--- a/Source/Lib/ASM_AVX2/EbComputeSAD_Intrinsic_AVX2.c
+++ b/Source/Lib/ASM_AVX2/EbComputeSAD_Intrinsic_AVX2.c
@@ -67,7 +67,7 @@ void SadLoopKernel_AVX2_INTRIN(
           pRef = ref + j;
           ss3 = ss5 = _mm256_setzero_si256();
           for (k=0; k<height; k+=4) {
-			ss0 = _mm256_insertf128_si256(_mm256_castsi128_si256(_mm_loadu_si128((__m128i*)(pRef + 2 * refStride))), _mm_loadu_si128((__m128i*)pRef), 0x1);
+			ss0 = _mm256_insertf128_si256(_mm256_castsi128_si256(_mm_loadu_si128((__m128i*)(pRef))), _mm_loadu_si128((__m128i*)(pRef + 2 * refStride)), 0x1);
 			ss1 = _mm256_insertf128_si256(_mm256_castsi128_si256(_mm_loadu_si128((__m128i*)(pRef + refStride))), _mm_loadu_si128((__m128i*)(pRef + refStrideT)), 0x1);
 			ss2 = _mm256_insertf128_si256(_mm256_castsi128_si256(_mm_unpacklo_epi64(_mm_cvtsi32_si128(*(EB_U32 *)pSrc), _mm_cvtsi32_si128(*(EB_U32 *)(pSrc + srcStride)))), _mm_unpacklo_epi64(_mm_cvtsi32_si128(*(EB_U32 *)(pSrc + 2 * srcStride)), _mm_cvtsi32_si128(*(EB_U32 *)(pSrc + srcStrideT))), 0x1);
             ss3 = _mm256_adds_epu16(ss3, _mm256_mpsadbw_epu8(ss0, ss2, 0));

--- a/Source/Lib/ASM_AVX2/EbComputeSAD_SadLoopKernel_AVX512.c
+++ b/Source/Lib/ASM_AVX2/EbComputeSAD_SadLoopKernel_AVX512.c
@@ -91,7 +91,7 @@ void SadLoopKernel_AVX512_HmeL0_INTRIN(
 					pRef = ref + j;
 					ss3 = ss5 = _mm256_setzero_si256();
 					for (k = 0; k<height; k += 4) {
-						ss0 = _mm256_insertf128_si256(_mm256_castsi128_si256(_mm_loadu_si128((__m128i*)(pRef + 2 * refStride))), _mm_loadu_si128((__m128i*)pRef), 0x1);
+						ss0 = _mm256_insertf128_si256(_mm256_castsi128_si256(_mm_loadu_si128((__m128i*)(pRef))), _mm_loadu_si128((__m128i*)(pRef + 2 * refStride)), 0x1);
 						ss1 = _mm256_insertf128_si256(_mm256_castsi128_si256(_mm_loadu_si128((__m128i*)(pRef + refStride))), _mm_loadu_si128((__m128i*)(pRef + refStrideT)), 0x1);
 						ss2 = _mm256_insertf128_si256(_mm256_castsi128_si256(_mm_unpacklo_epi64(_mm_cvtsi32_si128(*(EB_U32 *)pSrc), _mm_cvtsi32_si128(*(EB_U32 *)(pSrc + srcStride)))), _mm_unpacklo_epi64(_mm_cvtsi32_si128(*(EB_U32 *)(pSrc + 2 * srcStride)), _mm_cvtsi32_si128(*(EB_U32 *)(pSrc + srcStrideT))), 0x1);
 						ss3 = _mm256_adds_epu16(ss3, _mm256_mpsadbw_epu8(ss0, ss2, 0));
@@ -1153,7 +1153,7 @@ void SadLoopKernel_AVX2_HmeL0_INTRIN(
                     pRef = ref + j;
                     ss3 = ss5 = _mm256_setzero_si256();
                     for (k = 0; k<height; k += 4) {
-                        ss0 = _mm256_insertf128_si256(_mm256_castsi128_si256(_mm_loadu_si128((__m128i*)(pRef + 2 * refStride))), _mm_loadu_si128((__m128i*)pRef), 0x1);
+                        ss0 = _mm256_insertf128_si256(_mm256_castsi128_si256(_mm_loadu_si128((__m128i*)(pRef))), _mm_loadu_si128((__m128i*)(pRef + 2 * refStride)), 0x1);
                         ss1 = _mm256_insertf128_si256(_mm256_castsi128_si256(_mm_loadu_si128((__m128i*)(pRef + refStride))), _mm_loadu_si128((__m128i*)(pRef + refStrideT)), 0x1);
                         ss2 = _mm256_insertf128_si256(_mm256_castsi128_si256(_mm_unpacklo_epi64(_mm_cvtsi32_si128(*(EB_U32 *)pSrc), _mm_cvtsi32_si128(*(EB_U32 *)(pSrc + srcStride)))), _mm_unpacklo_epi64(_mm_cvtsi32_si128(*(EB_U32 *)(pSrc + 2 * srcStride)), _mm_cvtsi32_si128(*(EB_U32 *)(pSrc + srcStrideT))), 0x1);
                         ss3 = _mm256_adds_epu16(ss3, _mm256_mpsadbw_epu8(ss0, ss2, 0));

--- a/Source/Lib/Codec/EbComputeSAD.h
+++ b/Source/Lib/Codec/EbComputeSAD.h
@@ -101,9 +101,9 @@ extern "C" {
             /*2 16xM */ FastLoop_NxMSadKernel,
             /*3 24xM */ FastLoop_NxMSadKernel,
             /*4 32xM */ FastLoop_NxMSadKernel,
-            /*5      */ FastLoop_NxMSadKernel,
+            /*5 40xM */ FastLoop_NxMSadKernel,
             /*6 48xM */ FastLoop_NxMSadKernel,
-            /*7      */ FastLoop_NxMSadKernel,
+            /*7 56xM */ FastLoop_NxMSadKernel,
             /*8 64xM */ FastLoop_NxMSadKernel
         },
         // AVX2
@@ -113,9 +113,9 @@ extern "C" {
             /*2 16xM */	Compute16xMSad_SSE2_INTRIN,//Compute16xMSad_AVX2_INTRIN is slower than the SSE2 version
             /*3 24xM */	Compute24xMSad_AVX2_INTRIN,
             /*4 32xM */	Compute32xMSad_AVX2_INTRIN,
-            /*5      */ (EB_SADKERNELNxM_TYPE)NxMSadKernelVoidFunc,
+            /*5 40xM */ Compute40xMSad_AVX2_INTRIN,
             /*6 48xM */	Compute48xMSad_AVX2_INTRIN,
-            /*7      */ (EB_SADKERNELNxM_TYPE)NxMSadKernelVoidFunc,
+            /*7 56xM */	Compute56xMSad_AVX2_INTRIN,
             /*8 64xM */ Compute64xMSad_AVX2_INTRIN,
         },
     };


### PR DESCRIPTION
Fix bug in function where subtraction of 8 bit unsigned integers was landing in an 8 bit signed space (not enough bits to store possible answers).  Proposed fix to use zero extend or unpack so that subtraction of 8 bit unsigned integers land in 16 bit space ( leaving enough bits to store possible answers).