### PR TITLE
y4m container support in SVT-HEVC

### DIFF
--- a/Docs/svt-hevc_encoder_user_guide.md
+++ b/Docs/svt-hevc_encoder_user_guide.md
@@ -197,7 +197,7 @@ This token sets the encoder to run in the visual quality optimized mode (when se
 
 >-i filename **[Required]**
 
-A YUV file (e.g. 8 bit 4:2:0 planar) containing the video sequence that will be encoded.  Files encoded in YUV4MPEG2 format are also supported (common extension is ".y4m"). The dimensions of each image are specified by –w and –h as indicated below.
+A YUV file (e.g. 8 bit 4:2:0 planar) containing the video sequence that will be encoded.  The dimensions of each image are specified by –w and –h as indicated below. Files encoded in YUV4MPEG2 format are also supported (common extension is ".y4m"). The header in YUV4MPEG2 files contains width, height, framerate, and bit-depth information which do not need to be additional specified as command line arguments.
 
 >-b filename **[Optional]**
 
@@ -239,6 +239,10 @@ For dual socket systems, this token specific which socket the encoder runs on.
 For example, the following command encodes 100 frames of the YUV video sequence into the bin bit stream file.  The picture is 1920 luma pixels wide and 1080 pixels high using the Sample.cfg configuration. The QP equals 30 and the md5 checksum is not included in the bit stream.
 
 > SvtHevcEncApp.exe -c Sample.cfg -i CrowdRun\_1920x1080.yuv -w 1920 -h 1080 -n 100 -q 30 -intra-period 31 -b CrowdRun\_1920x1080\_qp30.bin
+
+For another example, the following command encodes the complete YUV video sequence, which is stored in a y4m format, into the bin bit stream file. No width, height, or frame rate parameters need to be specified for y4m files.
+
+> SvtHevcEncApp.exe -i akiyo_cif.y4m -b akiyo_cif.bin
 
 It should be noted that not all the encoder parameters present in the Sample.cfg can be changed using the command line.
 

--- a/Docs/svt-hevc_encoder_user_guide.md
+++ b/Docs/svt-hevc_encoder_user_guide.md
@@ -197,7 +197,7 @@ This token sets the encoder to run in the visual quality optimized mode (when se
 
 >-i filename **[Required]**
 
-A YUV file (e.g. 8 bit 4:2:0 planar) containing the video sequence that will be encoded.  The dimensions of each image are specified by –w and –h as indicated below.
+A YUV file (e.g. 8 bit 4:2:0 planar) containing the video sequence that will be encoded.  Files encoded in YUV4MPEG2 format are also supported (common extension is ".y4m"). The dimensions of each image are specified by –w and –h as indicated below.
 
 >-b filename **[Optional]**
 

--- a/Source/App/CMakeLists.txt
+++ b/Source/App/CMakeLists.txt
@@ -46,4 +46,4 @@ if (MSVC OR MSYS OR MINGW OR WIN32)
                            SvtHevcEnc)
 endif()
 
-install(TARGETS SvtHevcEncApp RUNTIME DESTINATION bin)
+install(TARGETS SvtHevcEncApp RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/Source/App/CMakeLists.txt
+++ b/Source/App/CMakeLists.txt
@@ -25,6 +25,7 @@ add_executable (SvtHevcEncApp
     EbAppContext.h
     ../API/EbErrorCodes.h
     ../API/EbTime.h
+    EbAppInputy4m.c
 )
 
 #********** SET COMPILE FLAGS************

--- a/Source/App/CMakeLists.txt
+++ b/Source/App/CMakeLists.txt
@@ -46,4 +46,8 @@ if (MSVC OR MSYS OR MINGW OR WIN32)
                            SvtHevcEnc)
 endif()
 
+if(NOT CMAKE_INSTALL_BINDIR)
+    set(CMAKE_INSTALL_BINDIR bin)
+endif()
+
 install(TARGETS SvtHevcEncApp RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/Source/App/EbAppConfig.c
+++ b/Source/App/EbAppConfig.c
@@ -10,6 +10,7 @@
 
 #include "EbAppConfig.h"
 #include "EbApi.h"
+#include "EbAppInputy4m.h"
 
 #ifdef _WIN32
 #else
@@ -129,7 +130,7 @@ static void SetCfgInputFile                     (const char *value, EbConfig_t *
         FOPEN(cfg->inputFile, value, "rb");
         /* if input is a YUV4MPEG2 (y4m) file, read header and parse parameters */
         if (cfg->inputFile != NULL) {
-            if (check_if_y4m(cfg) == EB_TRUE)
+            if ((EB_BOOL)(check_if_y4m(cfg)) == EB_TRUE)
                 cfg->y4m_input = EB_TRUE;
             else
                 cfg->y4m_input = EB_FALSE;

--- a/Source/App/EbAppConfig.c
+++ b/Source/App/EbAppConfig.c
@@ -127,6 +127,16 @@ static void SetCfgInputFile                     (const char *value, EbConfig_t *
     }
     else {
         FOPEN(cfg->inputFile, value, "rb");
+        /* if input is a YUV4MPEG2 (y4m) file, read header and parse parameters */
+        if (cfg->inputFile != NULL) {
+            if (check_if_y4m(cfg) == EB_TRUE)
+                cfg->y4m_input = EB_TRUE;
+            else
+                cfg->y4m_input = EB_FALSE;
+        }
+        else {
+            cfg->y4m_input = EB_FALSE;
+        }
     }
 };
 static void SetCfgStreamFile                    (const char *value, EbConfig_t *cfg)
@@ -1121,9 +1131,13 @@ int32_t ComputeFramesToBeEncoded(
     uint64_t fileSize = 0;
     int32_t frameCount = 0;
     uint32_t frameSize;
+    uint64_t currLoc;
+
     if (config->inputFile) {
+        currLoc = ftello64(config->inputFile); // get current fp location
         fseeko64(config->inputFile, 0L, SEEK_END);
         fileSize = ftello64(config->inputFile);
+        fseeko64(config->inputFile, currLoc, SEEK_SET); // seek back to that location
     }
 
     frameSize = config->inputPaddedWidth * config->inputPaddedHeight; // Luma
@@ -1196,6 +1210,7 @@ EB_ERRORTYPE ReadCommandLine(
     uint32_t    index           = 0;
     int32_t             cmd_token_cnt   = 0;                        // total number of tokens
     int32_t             token_index     = -1;
+    int32_t ret_y4m;
 
     for (index = 0; index < MAX_CHANNEL_NUMBER; ++index){
         config_strings[index] = (char*)malloc(sizeof(char)*COMMAND_LINE_MAX_SIZE);
@@ -1260,6 +1275,20 @@ EB_ERRORTYPE ReadCommandLine(
     }
 
     /***************************************************************************************************/
+    /********************** Parse parameters from input file if in y4m format **************************/
+    /********************** overriding config file and command line inputs    **************************/
+    /***************************************************************************************************/
+    for (index = 0; index < numChannels; ++index) {
+        if ((configs[index])->y4m_input == EB_TRUE) {
+            ret_y4m = read_y4m_header(configs[index]);
+            if (ret_y4m == EB_ErrorBadParameter) {
+                printf("Error found when reading the y4m file parameters.\n");
+                return EB_ErrorBadParameter;
+            }
+        }
+    }
+
+    /***************************************************************************************************/
     /**************************************   Verify configuration parameters   ************************/
     /***************************************************************************************************/
     // Verify the config values
@@ -1274,7 +1303,6 @@ EB_ERRORTYPE ReadCommandLine(
                     configs[index]->inputPaddedWidth  = configs[index]->sourceWidth + LEFT_INPUT_PADDING + RIGHT_INPUT_PADDING;
                     configs[index]->inputPaddedHeight = configs[index]->sourceHeight + TOP_INPUT_PADDING + BOTTOM_INPUT_PADDING;
                 }
-
 
                 // Assuming no errors, set the frames to be encoded to the number of frames in the input yuv
                 if (return_errors[index] == EB_ErrorNone && configs[index]->framesToBeEncoded == 0)

--- a/Source/App/EbAppConfig.h
+++ b/Source/App/EbAppConfig.h
@@ -237,6 +237,10 @@ typedef struct EbConfig_s
 
     FILE                   *qpFile;
 
+    // y4m format support
+    EB_BOOL                 y4m_input;
+    unsigned char           y4m_buf[9];
+
     EB_BOOL                useQpFile;
 #if 1//TILES
     uint8_t                 tileColumnCount;

--- a/Source/App/EbAppInputy4m.c
+++ b/Source/App/EbAppInputy4m.c
@@ -9,6 +9,9 @@
 #define PRINT_HEADER 0
 #define CHROMA_MAX 4
 
+#include "EbAppConfig.h"
+
+
 /* copy a string until a specified character or a new line is found */
 char* copyUntilCharacterOrNewLine(char *src, char *dst, char chr) {
 	rsize_t count = 0;

--- a/Source/App/EbAppInputy4m.c
+++ b/Source/App/EbAppInputy4m.c
@@ -1,0 +1,307 @@
+/*
+* Copyright(c) 2019 Intel Corporation
+* SPDX - License - Identifier: BSD - 2 - Clause - Patent
+*/
+
+#include "EbAppInputy4m.h"
+#define YFM_HEADER_MAX 80
+#define YUV4MPEG2_IND_SIZE 9
+#define PRINT_HEADER 0
+#define CHROMA_MAX 4
+
+/* copy a string until a specified character or a new line is found */
+char* copyUntilCharacterOrNewLine(char *src, char *dst, char chr) {
+	rsize_t count = 0;
+	char * src_init = src;
+
+	while (*src != chr && *src != '\n') {
+		src++;
+		count++;
+	}
+
+	//EB_STRNCPY(dst, YFM_HEADER_MAX, src_init, count);
+	EB_STRNCPY(dst, src_init, count);
+
+	return src;
+}
+
+/* reads the y4m header and parses the input parameters */
+int32_t read_y4m_header(EbConfig_t *cfg) {
+	FILE *ptr_in;
+	char buffer[YFM_HEADER_MAX];
+	char *fresult, *tokstart, *tokend, format_str[YFM_HEADER_MAX];
+	uint32_t bitdepth = 8, width = 0, height = 0, fr_n = 0,
+		fr_d = 0, aspect_n, aspect_d;
+	char chroma[CHROMA_MAX] = "420", scan_type = 'p';
+	EB_BOOL interlaced = EB_TRUE;
+
+	/* pointer to the input file */
+	ptr_in = cfg->inputFile;
+
+	/* get first line after YUV4MPEG2 */
+	fresult = fgets(buffer, sizeof(buffer), ptr_in);
+	assert(fresult != NULL);
+
+	/* print header */
+	if (PRINT_HEADER) {
+		printf("y4m header:");
+		fputs(buffer, stdout);
+	}
+
+	/* read header parameters */
+	for (tokstart = &(buffer[0]); *tokstart != '\0'; tokstart++) {
+		if (*tokstart == 0x20)
+			continue;
+		switch (*tokstart++) {
+		case 'W': /* width, required. */
+			width = (uint32_t)strtol(tokstart, &tokend, 10);
+			if (PRINT_HEADER)
+				printf("width = %d\n", width);
+			tokstart = tokend;
+			break;
+		case 'H': /* height, required. */
+			height = (uint32_t)strtol(tokstart, &tokend, 10);
+			if (PRINT_HEADER)
+				printf("height = %d\n", height);
+			tokstart = tokend;
+			break;
+		case 'I': /* scan type, not required, default: 'p' */
+			switch (*tokstart++) {
+			case 'p':
+				interlaced = EB_FALSE;
+				scan_type = 'p';
+				break;
+			case 't':
+				interlaced = EB_TRUE;
+				scan_type = 't';
+				break;
+			case 'b':
+				interlaced = EB_TRUE;
+				scan_type = 'b';
+				break;
+			case '?':
+			default:
+				fprintf(cfg->errorLogFile, "interlace type not supported\n");
+				return EB_ErrorBadParameter;
+			}
+			if (PRINT_HEADER)
+				printf("scan_type = %c\n", scan_type);
+			break;
+		case 'C': /* color space, not required: default "420" */
+			tokstart = copyUntilCharacterOrNewLine(tokstart, format_str, 0x20);
+			if (EB_STRCMP("420mpeg2", format_str) == 0) {
+				EB_STRCPY(chroma, CHROMA_MAX, "420");
+				// chroma left
+				bitdepth = 8;
+			}
+			else if (EB_STRCMP("420paldv", format_str) == 0) {
+				EB_STRCPY(chroma, CHROMA_MAX, "420");
+				// chroma top-left
+				bitdepth = 8;
+			}
+			else if (EB_STRCMP("420jpeg", format_str) == 0) {
+				EB_STRCPY(chroma, CHROMA_MAX, "420");
+				// chroma center
+				bitdepth = 8;
+			}
+			else if (EB_STRCMP("420p16", format_str) == 0) {
+				EB_STRCPY(chroma, CHROMA_MAX, "420");
+				bitdepth = 16;
+			}
+			else if (EB_STRCMP("422p16", format_str) == 0) {
+				EB_STRCPY(chroma, CHROMA_MAX, "422");
+				bitdepth = 16;
+			}
+			else if (EB_STRCMP("444p16", format_str) == 0) {
+				EB_STRCPY(chroma, CHROMA_MAX, "444");
+				bitdepth = 16;
+			}
+			else if (EB_STRCMP("420p14", format_str) == 0) {
+				EB_STRCPY(chroma, CHROMA_MAX, "420");
+				bitdepth = 14;
+			}
+			else if (EB_STRCMP("422p14", format_str) == 0) {
+				EB_STRCPY(chroma, CHROMA_MAX, "422");
+				bitdepth = 14;
+			}
+			else if (EB_STRCMP("444p14", format_str) == 0) {
+				EB_STRCPY(chroma, CHROMA_MAX, "444");
+				bitdepth = 14;
+			}
+			else if (EB_STRCMP("420p12", format_str) == 0) {
+				EB_STRCPY(chroma, CHROMA_MAX, "420");
+				bitdepth = 12;
+			}
+			else if (EB_STRCMP("422p12", format_str) == 0) {
+				EB_STRCPY(chroma, CHROMA_MAX, "422");
+				bitdepth = 12;
+			}
+			else if (EB_STRCMP("444p12", format_str) == 0) {
+				EB_STRCPY(chroma, CHROMA_MAX, "444");
+				bitdepth = 12;
+			}
+			else if (EB_STRCMP("420p10", format_str) == 0) {
+				EB_STRCPY(chroma, CHROMA_MAX, "420");
+				bitdepth = 10;
+			}
+			else if (EB_STRCMP("422p10", format_str) == 0) {
+				EB_STRCPY(chroma, CHROMA_MAX, "422");
+				bitdepth = 10;
+			}
+			else if (EB_STRCMP("444p10", format_str) == 0) {
+				EB_STRCPY(chroma, CHROMA_MAX, "444");
+				bitdepth = 10;
+			}
+			else if (EB_STRCMP("420p9", format_str) == 0) {
+				EB_STRCPY(chroma, CHROMA_MAX, "420");
+				bitdepth = 9;
+			}
+			else if (EB_STRCMP("422p9", format_str) == 0) {
+				EB_STRCPY(chroma, CHROMA_MAX, "422");
+				bitdepth = 9;
+			}
+			else if (EB_STRCMP("444p9", format_str) == 0) {
+				EB_STRCPY(chroma, CHROMA_MAX, "444");
+				bitdepth = 9;
+			}
+			else if (EB_STRCMP("420", format_str) == 0) {
+				EB_STRCPY(chroma, CHROMA_MAX, "420");
+				bitdepth = 8;
+			}
+			else if (EB_STRCMP("411", format_str) == 0) {
+				EB_STRCPY(chroma, CHROMA_MAX, "411");
+				bitdepth = 8;
+			}
+			else if (EB_STRCMP("422", format_str) == 0) {
+				EB_STRCPY(chroma, CHROMA_MAX, "422");
+				bitdepth = 8;
+			}
+			else if (EB_STRCMP("444", format_str) == 0) {
+				EB_STRCPY(chroma, CHROMA_MAX, "444");
+				bitdepth = 8;
+			}
+			else if (EB_STRCMP("mono16", format_str) == 0) {
+				EB_STRCPY(chroma, CHROMA_MAX, "400");
+				bitdepth = 16;
+			}
+			else if (EB_STRCMP("mono12", format_str) == 0) {
+				EB_STRCPY(chroma, CHROMA_MAX, "400");
+				bitdepth = 12;
+			}
+			else if (EB_STRCMP("mono10", format_str) == 0) {
+				EB_STRCPY(chroma, CHROMA_MAX, "400");
+				bitdepth = 10;
+			}
+			else if (EB_STRCMP("mono9", format_str) == 0) {
+				EB_STRCPY(chroma, CHROMA_MAX, "400");
+				bitdepth = 9;
+			}
+			else if (EB_STRCMP("mono", format_str) == 0) {
+				EB_STRCPY(chroma, CHROMA_MAX, "400");
+				bitdepth = 8;
+			}
+			else {
+				fprintf(cfg->errorLogFile, "chroma format not supported\n");
+				return EB_ErrorBadParameter;
+			}
+			if (PRINT_HEADER)
+				printf("chroma = %s, bitdepth = %d\n", chroma, bitdepth);
+			break;
+		case 'F': /* frame rate, required */
+			tokstart = copyUntilCharacterOrNewLine(tokstart, format_str, ':');
+			fr_n = (uint32_t)strtol(format_str, (char **)NULL, 10);
+			tokstart++;
+			tokstart = copyUntilCharacterOrNewLine(tokstart, format_str, 0x20);
+			fr_d = (uint32_t)strtol(format_str, (char **)NULL, 10);
+			if (PRINT_HEADER) {
+				printf("framerate_n = %d\n", fr_n);
+				printf("framerate_d = %d\n", fr_d);
+			}
+			break;
+		case 'A': /* aspect ratio, not required */
+			tokstart = copyUntilCharacterOrNewLine(tokstart, format_str, ':');
+			aspect_n = (uint32_t)strtol(format_str, (char **)NULL, 10);
+			tokstart++;
+			tokstart = copyUntilCharacterOrNewLine(tokstart, format_str, 0x20);
+			aspect_d = (uint32_t)strtol(format_str, (char **)NULL, 10);
+			if (PRINT_HEADER) {
+				printf("aspect_n = %d\n", aspect_n);
+				printf("aspect_d = %d\n", aspect_d);
+			}
+			break;
+		default:
+			break;
+		}
+	}
+
+	/*check if required parameters were read*/
+	if (width == 0) {
+		fprintf(cfg->errorLogFile, "width not found in y4m header\n");
+		return EB_ErrorBadParameter;
+	}
+	if (height == 0) {
+		fprintf(cfg->errorLogFile, "height not found in y4m header\n");
+		return EB_ErrorBadParameter;
+	}
+	if (fr_n == 0 || fr_d == 0) {
+		fprintf(cfg->errorLogFile, "frame rate not found in y4m header\n");
+		return EB_ErrorBadParameter;
+	}
+
+	/* Assign parameters to cfg */
+	cfg->sourceWidth = width;
+	cfg->sourceHeight = height;
+	cfg->frameRateNumerator = fr_n;
+	cfg->frameRateDenominator = fr_d;
+	cfg->frameRate = fr_n / fr_d;
+	cfg->encoderBitDepth = bitdepth;
+	cfg->interlacedVideo = interlaced;
+	/* TODO: when implemented, need to set input bit depth
+		(instead of the encoder bit depth) and chroma format */
+
+	return EB_ErrorNone;
+}
+
+/* read next line which contains the "FRAME" delimiter */
+int32_t read_y4m_frame_delimiter(EbConfig_t *cfg) {
+	unsigned char bufferY4Mheader[10];
+	char *fresult;
+
+	fresult = fgets((char *)bufferY4Mheader, sizeof(bufferY4Mheader), cfg->inputFile);
+
+	if (fresult == NULL) {
+		assert(feof(cfg->inputFile));
+		return EB_ErrorNone;
+	}
+
+	if (EB_STRCMP((const char*)bufferY4Mheader, "FRAME\n") != 0) {
+		fprintf(cfg->errorLogFile, "Failed to read proper y4m frame delimeter. Read broken.\n");
+		return EB_ErrorBadParameter;
+	}
+
+	return EB_ErrorNone;
+}
+
+/* check if the input file is in YUV4MPEG2 (y4m) format */
+EB_BOOL check_if_y4m(EbConfig_t *cfg) {
+	char buffer[YUV4MPEG2_IND_SIZE + 1];
+	size_t headerReadLength;
+
+	/* Parse the header for the "YUV4MPEG2" string */
+	headerReadLength = fread(buffer, YUV4MPEG2_IND_SIZE, 1, cfg->inputFile);
+	assert(headerReadLength == 1);
+	buffer[YUV4MPEG2_IND_SIZE] = 0;
+
+	if (EB_STRCMP(buffer, "YUV4MPEG2") == 0) {
+		return EB_TRUE; /* YUV4MPEG2 file */
+	}
+	else {
+		if (cfg->inputFile != stdin) {
+			fseek(cfg->inputFile, 0, SEEK_SET);
+		}
+		else {
+			memcpy(cfg->y4m_buf, buffer, YUV4MPEG2_IND_SIZE); /* TODO copy 9 bytes read to cfg->y4m_buf*/
+		}
+		return EB_FALSE; /* Not a YUV4MPEG2 file */
+	}
+}

--- a/Source/App/EbAppInputy4m.h
+++ b/Source/App/EbAppInputy4m.h
@@ -1,0 +1,17 @@
+/*
+* Copyright(c) 2019 Intel Corporation
+* SPDX - License - Identifier: BSD - 2 - Clause - Patent
+*/
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <assert.h>
+
+#include "EbAppConfig.h"
+
+int32_t read_y4m_header(EbConfig_t *cfg);
+
+int32_t read_y4m_frame_delimiter(EbConfig_t *cfg);
+
+EB_BOOL check_if_y4m(EbConfig_t *cfg);

--- a/Source/App/EbAppProcessCmd.c
+++ b/Source/App/EbAppProcessCmd.c
@@ -14,6 +14,7 @@
 #include "EbAppContext.h"
 #include "EbAppConfig.h"
 #include "EbErrorCodes.h"
+#include "EbAppInputy4m.h"
 
 #include "EbTime.h"
 /***************************************

--- a/Source/App/EbAppProcessCmd.c
+++ b/Source/App/EbAppProcessCmd.c
@@ -24,6 +24,7 @@
 #define FUTURE_WINDOW_WIDTH                 4
 #define SIZE_OF_ONE_FRAME_IN_BYTES(width, height, csp, is16bit) \
     ( (((width)*(height)) + 2*(((width)*(height))>>(3-csp)) )<<is16bit)
+#define YUV4MPEG2_IND_SIZE 9
 extern volatile int32_t keepRunning;
 
 /***************************************
@@ -763,6 +764,7 @@ static void ReadInputFrames(
     const uint32_t  inputPaddedWidth = config->inputPaddedWidth;
     const uint32_t  inputPaddedHeight = config->inputPaddedHeight;
     FILE   *inputFile = config->inputFile;
+	uint8_t  *ebInputPtr;
     EB_H265_ENC_INPUT* inputPtr = (EB_H265_ENC_INPUT*)headerPtr->pBuffer;
     const EB_COLOR_FORMAT colorFormat = (EB_COLOR_FORMAT)config->encoderColorFormat;
     const uint8_t subWidthCMinus1 = (colorFormat == EB_YUV444 ? 1 : 2) - 1;
@@ -813,12 +815,26 @@ static void ReadInputFrames(
                     fseek(inputFile, -(long)(readSize << 1), SEEK_CUR);
                 }
             } else {
+
+                /* if input is a y4m file, read next line which contains "FRAME" */
+                if (config->y4m_input == EB_TRUE)
+                    read_y4m_frame_delimiter(config);
                 const uint32_t lumaReadSize = inputPaddedWidth * inputPaddedHeight << is16bit;
+                ebInputPtr = inputPtr->luma;
+                if (config->y4m_input == EB_FALSE && config->processedFrameCount == 0 && config->inputFile == stdin) {
+                    /* if not a y4m file and input is read from stdin, 9 bytes were already read when checking
+                       or the YUV4MPEG2 string in the stream, so copy those bytes over */
+                    memcpy(ebInputPtr, config->y4m_buf, YUV4MPEG2_IND_SIZE);
+                    headerPtr->nFilledLen += YUV4MPEG2_IND_SIZE;
+                    ebInputPtr += YUV4MPEG2_IND_SIZE;
+                    headerPtr->nFilledLen += (uint32_t)fread(ebInputPtr, 1, lumaReadSize - YUV4MPEG2_IND_SIZE, inputFile);
+                }
+                else {
+                    headerPtr->nFilledLen += (uint32_t)fread(inputPtr->luma, 1, lumaReadSize, inputFile);
+                }
                 const uint32_t chromaReadSize = lumaReadSize >> (3 - colorFormat);
-                headerPtr->nFilledLen += (uint32_t)fread(inputPtr->luma, 1, lumaReadSize, inputFile);
                 headerPtr->nFilledLen += (uint32_t)fread(inputPtr->cb, 1, chromaReadSize, inputFile);
                 headerPtr->nFilledLen += (uint32_t)fread(inputPtr->cr, 1, chromaReadSize, inputFile);
-
 
                 if (readSize != headerPtr->nFilledLen) {
 

--- a/ffmpeg_plugin/0001-lavc-svt_hevc-add-libsvt-hevc-encoder-wrapper.patch
+++ b/ffmpeg_plugin/0001-lavc-svt_hevc-add-libsvt-hevc-encoder-wrapper.patch
@@ -1,4 +1,4 @@
-From 75edd6ac46515acb71a5a87dca23633fbbc842c5 Mon Sep 17 00:00:00 2001
+From a6f622288d6d26b7eddf02dbc4dea8f7d5788a93 Mon Sep 17 00:00:00 2001
 From: Jing Sun <jing.a.sun@intel.com>
 Date: Wed, 21 Nov 2018 11:33:04 +0800
 Subject: [PATCH 1/1] lavc/svt_hevc: add libsvt hevc encoder wrapper
@@ -11,15 +11,15 @@ Signed-off-by: Jing Sun <jing.a.sun@intel.com>
  configure                |   4 +
  libavcodec/Makefile      |   1 +
  libavcodec/allcodecs.c   |   1 +
- libavcodec/libsvt_hevc.c | 541 +++++++++++++++++++++++++++++++++++++++++++++++
- 4 files changed, 547 insertions(+)
+ libavcodec/libsvt_hevc.c | 501 +++++++++++++++++++++++++++++++++++++++++++++++
+ 4 files changed, 507 insertions(+)
  create mode 100644 libavcodec/libsvt_hevc.c
 
 diff --git a/configure b/configure
-index d644a5b..2bc93a6 100755
+index a9644e2..2f61c82 100755
 --- a/configure
 +++ b/configure
-@@ -264,6 +264,7 @@ External library support:
+@@ -262,6 +262,7 @@ External library support:
    --enable-libspeex        enable Speex de/encoding via libspeex [no]
    --enable-libsrt          enable Haivision SRT protocol via libsrt [no]
    --enable-libssh          enable SFTP protocol via libssh [no]
@@ -27,7 +27,7 @@ index d644a5b..2bc93a6 100755
    --enable-libtensorflow   enable TensorFlow as a DNN module backend
                             for DNN based filters like sr [no]
    --enable-libtesseract    enable Tesseract, needed for ocr filter [no]
-@@ -1782,6 +1783,7 @@ EXTERNAL_LIBRARY_LIST="
+@@ -1743,6 +1744,7 @@ EXTERNAL_LIBRARY_LIST="
      libspeex
      libsrt
      libssh
@@ -35,7 +35,7 @@ index d644a5b..2bc93a6 100755
      libtensorflow
      libtesseract
      libtheora
-@@ -3174,6 +3176,7 @@ libshine_encoder_select="audio_frame_queue"
+@@ -3125,6 +3127,7 @@ libshine_encoder_select="audio_frame_queue"
  libspeex_decoder_deps="libspeex"
  libspeex_encoder_deps="libspeex"
  libspeex_encoder_select="audio_frame_queue"
@@ -43,7 +43,7 @@ index d644a5b..2bc93a6 100755
  libtheora_encoder_deps="libtheora"
  libtwolame_encoder_deps="libtwolame"
  libvo_amrwbenc_encoder_deps="libvo_amrwbenc"
-@@ -6203,6 +6206,7 @@ enabled libsoxr           && require libsoxr soxr.h soxr_create -lsoxr
+@@ -6135,6 +6138,7 @@ enabled libsoxr           && require libsoxr soxr.h soxr_create -lsoxr
  enabled libssh            && require_pkg_config libssh libssh libssh/sftp.h sftp_init
  enabled libspeex          && require_pkg_config libspeex speex speex/speex.h speex_decoder_init
  enabled libsrt            && require_pkg_config libsrt "srt >= 1.3.0" srt/srt.h srt_socket
@@ -52,10 +52,10 @@ index d644a5b..2bc93a6 100755
  enabled libtesseract      && require_pkg_config libtesseract tesseract tesseract/capi.h TessBaseAPICreate
  enabled libtheora         && require libtheora theora/theoraenc.h th_info_init -ltheoraenc -ltheoradec -logg
 diff --git a/libavcodec/Makefile b/libavcodec/Makefile
-index f37135f..8e031d3 100644
+index 3e41497..728503b 100644
 --- a/libavcodec/Makefile
 +++ b/libavcodec/Makefile
-@@ -991,6 +991,7 @@ OBJS-$(CONFIG_LIBOPUS_ENCODER)            += libopusenc.o libopus.o     \
+@@ -981,6 +981,7 @@ OBJS-$(CONFIG_LIBOPUS_ENCODER)            += libopusenc.o libopus.o     \
  OBJS-$(CONFIG_LIBSHINE_ENCODER)           += libshine.o
  OBJS-$(CONFIG_LIBSPEEX_DECODER)           += libspeexdec.o
  OBJS-$(CONFIG_LIBSPEEX_ENCODER)           += libspeexenc.o
@@ -64,10 +64,10 @@ index f37135f..8e031d3 100644
  OBJS-$(CONFIG_LIBTWOLAME_ENCODER)         += libtwolame.o
  OBJS-$(CONFIG_LIBVO_AMRWBENC_ENCODER)     += libvo-amrwbenc.o
 diff --git a/libavcodec/allcodecs.c b/libavcodec/allcodecs.c
-index 6178d31..e27a7b6 100644
+index 1b8144a..5739d53 100644
 --- a/libavcodec/allcodecs.c
 +++ b/libavcodec/allcodecs.c
-@@ -706,6 +706,7 @@ extern AVCodec ff_librsvg_decoder;
+@@ -697,6 +697,7 @@ extern AVCodec ff_librsvg_decoder;
  extern AVCodec ff_libshine_encoder;
  extern AVCodec ff_libspeex_encoder;
  extern AVCodec ff_libspeex_decoder;
@@ -77,14 +77,14 @@ index 6178d31..e27a7b6 100644
  extern AVCodec ff_libvo_amrwbenc_encoder;
 diff --git a/libavcodec/libsvt_hevc.c b/libavcodec/libsvt_hevc.c
 new file mode 100644
-index 0000000..9b5d146
+index 0000000..d9ac04c
 --- /dev/null
 +++ b/libavcodec/libsvt_hevc.c
-@@ -0,0 +1,541 @@
+@@ -0,0 +1,501 @@
 +/*
 +* Scalable Video Technology for HEVC encoder library plugin
 +*
-+* Copyright (c) 2018 Intel Corporation
++* Copyright (c) 2019 Intel Corporation
 +*
 +* This file is part of FFmpeg.
 +*
@@ -116,8 +116,8 @@ index 0000000..9b5d146
 +
 +typedef enum eos_status {
 +    EOS_NOT_REACHED = 0,
-+    EOS_REACHED,
-+    EOS_TOTRIGGER
++    EOS_SENT,
++    EOS_RECEIVED
 +}EOS_STATUS;
 +
 +typedef struct SvtContext {
@@ -129,42 +129,32 @@ index 0000000..9b5d146
 +    EOS_STATUS eos_flag;
 +
 +    // User options.
-+    int vui_info;
++    int profile;
 +    int hierarchical_level;
-+    int la_depth;
 +    int enc_mode;
++    int tier;
++    int level;
 +    int rc_mode;
 +    int scd;
 +    int tune;
-+    int qp;
-+    int hdr;
-+    int asm_type;
-+
-+    int forced_idr;
-+
-+    int aud;
-+
-+    int profile;
-+    int tier;
-+    int level;
-+
 +    int base_layer_switch_mode;
++    int qp;
++    int aud;
++    int asm_type;
++    int forced_idr;
++    int la_depth;
 +} SvtContext;
 +
 +static int error_mapping(EB_ERRORTYPE svt_ret)
 +{
-+    int err;
-+
 +    switch (svt_ret) {
 +    case EB_ErrorInsufficientResources:
-+        err = AVERROR(ENOMEM);
-+        break;
++        return AVERROR(ENOMEM);
 +
 +    case EB_ErrorUndefined:
 +    case EB_ErrorInvalidComponent:
 +    case EB_ErrorBadParameter:
-+        err = AVERROR(EINVAL);
-+        break;
++        return AVERROR(EINVAL);
 +
 +    case EB_ErrorDestroyThreadFailed:
 +    case EB_ErrorSemaphoreUnresponsive:
@@ -172,21 +162,17 @@ index 0000000..9b5d146
 +    case EB_ErrorCreateMutexFailed:
 +    case EB_ErrorMutexUnresponsive:
 +    case EB_ErrorDestroyMutexFailed:
-+        err = AVERROR_EXTERNAL;
-+            break;
++        return AVERROR_EXTERNAL;
 +
 +    case EB_NoErrorEmptyQueue:
-+        err = AVERROR(EAGAIN);
++        return AVERROR(EAGAIN);
 +
 +    case EB_ErrorNone:
-+        err = 0;
-+        break;
++        return 0;
 +
 +    default:
-+        err = AVERROR_UNKNOWN;
++        return AVERROR_UNKNOWN;
 +    }
-+
-+    return err;
 +}
 +
 +static void free_buffer(SvtContext *svt_enc)
@@ -196,43 +182,40 @@ index 0000000..9b5d146
 +    av_freep(&in_data);
 +}
 +
-+static int alloc_buffer(EB_H265_ENC_CONFIGURATION *config, SvtContext *svt_enc)
++static EB_ERRORTYPE alloc_buffer(SvtContext *svt_enc)
 +{
-+    EB_H265_ENC_INPUT *in_data;
++    EB_BUFFERHEADERTYPE *in_buf = &svt_enc->in_buf;
++    EB_H265_ENC_INPUT *in_data = NULL;
 +
-+    // allocate buffer for in and out
-+    in_data  = av_mallocz(sizeof(*in_data));
-+    if (!in_data)
-+        goto failed;
-+    svt_enc->in_buf.pBuffer  = (unsigned char *)in_data;
++    memset(in_buf, 0, sizeof(*in_buf));
++    in_buf->nSize = sizeof(*in_buf);
++    in_buf->sliceType = EB_INVALID_PICTURE;
 +
-+    svt_enc->in_buf.nSize        = sizeof(svt_enc->in_buf);
-+    svt_enc->in_buf.pAppPrivate  = NULL;
-+
-+    return 0;
-+
-+failed:
-+    free_buffer(svt_enc);
-+    return AVERROR(ENOMEM);
++    in_data = (EB_H265_ENC_INPUT *)av_mallocz(sizeof(*in_data));
++    if (in_data) {
++        in_buf->pBuffer = (uint8_t *)in_data;
++        return EB_ErrorNone;
++    } else {
++        return EB_ErrorInsufficientResources;
++    }
 +}
 +
 +static int config_enc_params(EB_H265_ENC_CONFIGURATION *param,
 +                             AVCodecContext *avctx)
 +{
 +    SvtContext *svt_enc = avctx->priv_data;
-+    int ret;
 +
-+    param->sourceWidth     = avctx->width;
-+    param->sourceHeight    = avctx->height;
-+    param->encoderBitDepth = 8;
++    param->sourceWidth = avctx->width;
++    param->sourceHeight = avctx->height;
 +
 +    if ((avctx->pix_fmt == AV_PIX_FMT_YUV420P10) ||
 +        (avctx->pix_fmt == AV_PIX_FMT_YUV422P10) ||
 +        (avctx->pix_fmt == AV_PIX_FMT_YUV444P10)) {
-+        av_log(avctx, AV_LOG_DEBUG, "Encoder 10 bits depth input\n");
-+
-+        param->compressedTenBitFormat = 0;
-+        param->encoderBitDepth        = 10;
++        av_log(avctx, AV_LOG_DEBUG, "Set 10 bits depth input\n");
++        param->encoderBitDepth = 10;
++    } else {
++        av_log(avctx, AV_LOG_DEBUG, "Set 8 bits depth input\n");
++        param->encoderBitDepth = 8;
 +    }
 +
 +    if ((avctx->pix_fmt == AV_PIX_FMT_YUV420P) ||
@@ -244,139 +227,129 @@ index 0000000..9b5d146
 +    else
 +        param->encoderColorFormat = EB_YUV444;
 +
++    param->profile = svt_enc->profile;
 +
-+    // Update param from options
-+    param->hierarchicalLevels     = svt_enc->hierarchical_level - 1;
-+    param->encMode                = svt_enc->enc_mode;
-+    param->profile                = svt_enc->profile;
-+    param->tier                   = svt_enc->tier;
-+    param->level                  = svt_enc->level;
-+    param->rateControlMode        = svt_enc->rc_mode;
-+    param->sceneChangeDetection   = svt_enc->scd;
-+    param->tune                   = svt_enc->tune;
-+    param->baseLayerSwitchMode    = svt_enc->base_layer_switch_mode;
-+    param->qp                     = svt_enc->qp;
-+    param->accessUnitDelimiter    = svt_enc->aud;
-+    param->asmType                = svt_enc->asm_type;
-+
-+    if (param->profile == FF_PROFILE_HEVC_MAIN_STILL_PICTURE) {
-+        av_log(avctx, AV_LOG_ERROR, "Main Still Picture Profile not supported!\n");
++    if (FF_PROFILE_HEVC_MAIN_STILL_PICTURE == param->profile) {
++        av_log(avctx, AV_LOG_ERROR, "Main Still Picture Profile not supported\n");
 +        return EB_ErrorBadParameter;
 +    }
 +
 +    if ((param->encoderColorFormat >= EB_YUV422) &&
 +        (param->profile != FF_PROFILE_HEVC_REXT)) {
-+        av_log(avctx, AV_LOG_WARNING, "Rext Profile forced for 422 or 444!\n");
++        av_log(avctx, AV_LOG_WARNING, "Rext Profile forced for 422 or 444\n");
 +        param->profile = FF_PROFILE_HEVC_REXT;
 +    }
 +
-+    if ((param->profile == FF_PROFILE_HEVC_MAIN) &&
++    if ((FF_PROFILE_HEVC_MAIN == param->profile) &&
 +        (param->encoderBitDepth > 8)) {
-+        av_log(avctx, AV_LOG_WARNING, "Main10 Profile forced for 10 bits!\n");
++        av_log(avctx, AV_LOG_WARNING, "Main10 Profile forced for 10 bits\n");
 +        param->profile = FF_PROFILE_HEVC_MAIN_10;
 +    }
 +
-+    param->targetBitRate          = avctx->bit_rate;
-+    if (avctx->gop_size > 0)
-+        param->intraPeriodLength  = avctx->gop_size - 1;
++    param->targetBitRate = avctx->bit_rate;
 +
-+    if (avctx->framerate.num > 0 && avctx->framerate.den > 0) {
-+        param->frameRateNumerator     = avctx->framerate.num;
-+        param->frameRateDenominator   = avctx->framerate.den * avctx->ticks_per_frame;
++    if (avctx->gop_size > 0)
++        param->intraPeriodLength = avctx->gop_size - 1;
++
++    if ((avctx->framerate.num > 0) && (avctx->framerate.den > 0)) {
++        param->frameRateNumerator = avctx->framerate.num;
++        param->frameRateDenominator =
++            avctx->framerate.den * avctx->ticks_per_frame;
 +    } else {
-+        param->frameRateNumerator     = avctx->time_base.den;
-+        param->frameRateDenominator   = avctx->time_base.num * avctx->ticks_per_frame;
++        param->frameRateNumerator = avctx->time_base.den;
++        param->frameRateDenominator =
++            avctx->time_base.num * avctx->ticks_per_frame;
 +    }
 +
 +    if (param->rateControlMode) {
-+        param->maxQpAllowed       = avctx->qmax;
-+        param->minQpAllowed       = avctx->qmin;
++        param->maxQpAllowed = avctx->qmax;
++        param->minQpAllowed = avctx->qmin;
 +    }
 +
-+    param->intraRefreshType       =
-+        !!(avctx->flags & AV_CODEC_FLAG_CLOSED_GOP) + 1;
++    param->hierarchicalLevels = svt_enc->hierarchical_level;
++    param->encMode = svt_enc->enc_mode;
++    param->tier = svt_enc->tier;
++    param->level = svt_enc->level;
++    param->rateControlMode = svt_enc->rc_mode;
++    param->sceneChangeDetection = svt_enc->scd;
++    param->tune = svt_enc->tune;
++    param->baseLayerSwitchMode = svt_enc->base_layer_switch_mode;
++    param->qp = svt_enc->qp;
++    param->accessUnitDelimiter = svt_enc->aud;
++    param->asmType = svt_enc->asm_type;
 +
-+    // is it repeat headers for MP4 or Annex-b
-+    if (avctx->flags & AV_CODEC_FLAG_GLOBAL_HEADER)
-+        param->codeVpsSpsPps          = 0;
-+    else
-+        param->codeVpsSpsPps          = 1;
-+
-+    param->codeEosNal             = 1;
-+
-+    if (svt_enc->hdr) {
-+        svt_enc->vui_info = 1;
-+        param->highDynamicRangeInput = svt_enc->hdr;
-+    }
-+
-+    if (svt_enc->vui_info)
-+        param->videoUsabilityInfo = svt_enc->vui_info;
++    param->intraRefreshType =  svt_enc->forced_idr + 1;
 +
 +    if (svt_enc->la_depth != -1)
-+        param->lookAheadDistance  = svt_enc->la_depth;
++        param->lookAheadDistance = svt_enc->la_depth;
 +
-+    ret = alloc_buffer(param, svt_enc);
++    if (avctx->flags & AV_CODEC_FLAG_GLOBAL_HEADER)
++        param->codeVpsSpsPps = 0;
++    else
++        param->codeVpsSpsPps = 1;
 +
-+    return ret;
++    param->codeEosNal = 1;
++
++    return EB_ErrorNone;
 +}
 +
 +static void read_in_data(EB_H265_ENC_CONFIGURATION *config,
 +                         const AVFrame *frame,
 +                         EB_BUFFERHEADERTYPE *header_ptr)
 +{
-+    uint8_t is16bit = config->encoderBitDepth > 8;
-+    uint64_t luma_size =
-+        (uint64_t)config->sourceWidth * config->sourceHeight<< is16bit;
++    uint8_t is16bit;
++    uint64_t frame_size;
 +    EB_H265_ENC_INPUT *in_data = (EB_H265_ENC_INPUT *)header_ptr->pBuffer;
 +
-+    // support yuv420p and yuv420p010
-+    in_data->luma = frame->data[0];
-+    in_data->cb   = frame->data[1];
-+    in_data->cr   = frame->data[2];
++    is16bit = config->encoderBitDepth > 8;
++    frame_size = (uint64_t)(config->sourceWidth * config->sourceHeight) << is16bit;
 +
-+    // stride info
-+    in_data->yStride  = frame->linesize[0] >> is16bit;
++    in_data->luma = frame->data[0];
++    in_data->cb = frame->data[1];
++    in_data->cr = frame->data[2];
++
++    in_data->yStride = frame->linesize[0] >> is16bit;
 +    in_data->cbStride = frame->linesize[1] >> is16bit;
 +    in_data->crStride = frame->linesize[2] >> is16bit;
 +
 +    if (config->encoderColorFormat == EB_YUV420)
-+        luma_size *= 3/2u;
++        frame_size *= 3/2u;
 +    else if (config->encoderColorFormat == EB_YUV422)
-+        luma_size *= 2u;
++        frame_size *= 2u;
 +    else
-+        luma_size *= 3u;
++        frame_size *= 3u;
 +
-+    header_ptr->nFilledLen += luma_size;
++    header_ptr->nFilledLen += frame_size;
 +}
 +
 +static av_cold int eb_enc_init(AVCodecContext *avctx)
 +{
-+    SvtContext   *svt_enc = avctx->priv_data;
++    SvtContext *svt_enc = avctx->priv_data;
 +    EB_ERRORTYPE svt_ret;
 +
 +    svt_enc->eos_flag = EOS_NOT_REACHED;
 +
 +    svt_ret = EbInitHandle(&svt_enc->svt_handle, svt_enc, &svt_enc->enc_params);
 +    if (svt_ret != EB_ErrorNone) {
-+        av_log(avctx, AV_LOG_ERROR, "Error init encoder handle\n");
-+        goto failed;
++        av_log(avctx, AV_LOG_ERROR, "Failed to init handle\n");
++        return error_mapping(svt_ret);
 +    }
 +
 +    svt_ret = config_enc_params(&svt_enc->enc_params, avctx);
 +    if (svt_ret != EB_ErrorNone) {
-+        av_log(avctx, AV_LOG_ERROR, "Error configure encoder parameters\n");
++        av_log(avctx, AV_LOG_ERROR, "Failed to config parameters\n");
 +        goto failed_init_handle;
 +    }
 +
 +    svt_ret = EbH265EncSetParameter(svt_enc->svt_handle, &svt_enc->enc_params);
 +    if (svt_ret != EB_ErrorNone) {
-+        av_log(avctx, AV_LOG_ERROR, "Error setting encoder parameters\n");
++        av_log(avctx, AV_LOG_ERROR, "Failed to set parameters\n");
 +        goto failed_init_handle;
 +    }
 +
 +    svt_ret = EbInitEncoder(svt_enc->svt_handle);
 +    if (svt_ret != EB_ErrorNone) {
-+        av_log(avctx, AV_LOG_ERROR, "Error init encoder\n");
++        av_log(avctx, AV_LOG_ERROR, "Failed to init encoder\n");
 +        goto failed_init_handle;
 +    }
 +
@@ -385,105 +358,96 @@ index 0000000..9b5d146
 +
 +        svt_ret = EbH265EncStreamHeader(svt_enc->svt_handle, &header_ptr);
 +        if (svt_ret != EB_ErrorNone) {
-+            av_log(avctx, AV_LOG_ERROR, "Error when build stream header.\n");
-+            goto failed_init_enc;
++            av_log(avctx, AV_LOG_ERROR, "Failed to build stream header\n");
++            goto failed_init_encoder;
 +        }
 +
 +        avctx->extradata_size = header_ptr->nFilledLen;
-+        avctx->extradata = av_mallocz(avctx->extradata_size + AV_INPUT_BUFFER_PADDING_SIZE);
++        avctx->extradata = av_malloc(avctx->extradata_size + AV_INPUT_BUFFER_PADDING_SIZE);
 +        if (!avctx->extradata) {
-+            av_log(avctx, AV_LOG_ERROR,
-+                   "Cannot allocate HEVC header of size %d.\n", avctx->extradata_size);
++            av_log(avctx, AV_LOG_ERROR, "Failed to allocate extradata\n");
 +            svt_ret = EB_ErrorInsufficientResources;
-+            goto failed_init_enc;
++            goto failed_init_encoder;
 +        }
 +        memcpy(avctx->extradata, header_ptr->pBuffer, avctx->extradata_size);
++        memset((void *)(avctx->extradata+avctx->extradata_size), 0, AV_INPUT_BUFFER_PADDING_SIZE);
 +    }
 +
++    svt_ret = alloc_buffer(svt_enc);
++    if (svt_ret != EB_ErrorNone) {
++        av_log(avctx, AV_LOG_ERROR, "Failed to alloc data buffer\n");
++        goto failed_init_encoder;
++    }
 +    return 0;
 +
-+failed_init_enc:
++failed_init_encoder:
 +    EbDeinitEncoder(svt_enc->svt_handle);
 +failed_init_handle:
 +    EbDeinitHandle(svt_enc->svt_handle);
-+failed:
-+    free_buffer(svt_enc);
 +    svt_enc->svt_handle = NULL;
 +    svt_enc = NULL;
 +    return error_mapping(svt_ret);
 +}
 +
-+static int eb_send_frame(AVCodecContext *avctx, const AVFrame *frame)
++static int eb_encode_frame(AVCodecContext *avctx, AVPacket *pkt,
++                           const AVFrame *frame, int *got_packet)
 +{
-+    SvtContext           *svt_enc = avctx->priv_data;
-+    EB_BUFFERHEADERTYPE  *header_ptr = &svt_enc->in_buf;
++    SvtContext *svt_enc = avctx->priv_data;
++    EB_BUFFERHEADERTYPE *header_ptr = &svt_enc->in_buf;
++    EB_ERRORTYPE svt_ret;
++    int av_ret;
 +
-+    if (!frame) {
-+        EB_BUFFERHEADERTYPE header_ptr_last;
-+        header_ptr_last.nAllocLen   = 0;
-+        header_ptr_last.nFilledLen  = 0;
-+        header_ptr_last.nTickCount  = 0;
-+        header_ptr_last.pAppPrivate = NULL;
-+        header_ptr_last.pBuffer     = NULL;
-+        header_ptr_last.nFlags      = EB_BUFFERFLAG_EOS;
-+
-+        EbH265EncSendPicture(svt_enc->svt_handle, &header_ptr_last);
-+        svt_enc->eos_flag = EOS_REACHED;
-+        av_log(avctx, AV_LOG_DEBUG, "Finish sending frames!!!\n");
++    if (EOS_RECEIVED == svt_enc->eos_flag) {
++        *got_packet = 0;
 +        return 0;
 +    }
 +
-+    read_in_data(&svt_enc->enc_params, frame, header_ptr);
++    if (!frame) {
++        if (!svt_enc->eos_flag) {
++            svt_enc->eos_flag = EOS_SENT;
 +
-+    header_ptr->nFlags       = 0;
-+    header_ptr->pAppPrivate  = NULL;
-+    header_ptr->pts          = frame->pts;
-+    switch (frame->pict_type) {
-+    case AV_PICTURE_TYPE_I:
-+        header_ptr->sliceType = svt_enc->forced_idr > 0 ? EB_IDR_PICTURE : EB_I_PICTURE;
-+        break;
-+    case AV_PICTURE_TYPE_P:
-+        header_ptr->sliceType = EB_P_PICTURE;
-+        break;
-+    case AV_PICTURE_TYPE_B:
-+        header_ptr->sliceType = EB_B_PICTURE;
-+        break;
-+    default:
-+        header_ptr->sliceType = EB_INVALID_PICTURE;
-+        break;
-+    }
-+    EbH265EncSendPicture(svt_enc->svt_handle, header_ptr);
++            header_ptr->nAllocLen = 0;
++            header_ptr->nFilledLen = 0;
++            header_ptr->nTickCount = 0;
++            header_ptr->pBuffer = NULL;
++            header_ptr->nFlags = EB_BUFFERFLAG_EOS;
 +
-+    return 0;
-+}
++            EbH265EncSendPicture(svt_enc->svt_handle, header_ptr);
 +
-+static int eb_receive_packet(AVCodecContext *avctx, AVPacket *pkt)
-+{
-+    SvtContext  *svt_enc = avctx->priv_data;
-+    EB_BUFFERHEADERTYPE   *header_ptr = NULL;
-+    EB_ERRORTYPE          svt_ret;
-+    int ret = 0;
++            av_log(avctx, AV_LOG_DEBUG, "Sent EOS\n");
++        }
++    } else {
++        read_in_data(&svt_enc->enc_params, frame, header_ptr);
++        header_ptr->pts = frame->pts;
 +
-+    if (EOS_TOTRIGGER == svt_enc->eos_flag) {
-+        pkt = NULL;
-+        return AVERROR_EOF;
++        EbH265EncSendPicture(svt_enc->svt_handle, header_ptr);
++
++        av_log(avctx, AV_LOG_DEBUG, "Sent PTS %"PRId64"\n", header_ptr->pts);
 +    }
 +
++    header_ptr = NULL;
 +    svt_ret = EbH265GetPacket(svt_enc->svt_handle, &header_ptr, svt_enc->eos_flag);
-+    if (svt_ret == EB_NoErrorEmptyQueue)
-+        return AVERROR(EAGAIN);
 +
-+    if ((ret = ff_alloc_packet2(avctx, pkt, header_ptr->nFilledLen, 0)) < 0) {
-+        av_log(avctx, AV_LOG_ERROR, "Failed to allocate output packet.\n");
++    if (svt_ret == EB_NoErrorEmptyQueue) {
++        *got_packet = 0;
++        av_log(avctx, AV_LOG_DEBUG, "Received none\n");
++        return 0;
++    }
++
++    av_log(avctx, AV_LOG_DEBUG, "Received PTS %"PRId64" packet\n", header_ptr->pts);
++
++    av_ret = ff_alloc_packet2(avctx, pkt, header_ptr->nFilledLen, 0);
++    if (av_ret) {
++        av_log(avctx, AV_LOG_ERROR, "Failed to allocate a packet\n");
 +        EbH265ReleaseOutBuffer(&header_ptr);
-+        return ret;
++        return av_ret;
 +    }
 +
 +    memcpy(pkt->data, header_ptr->pBuffer, header_ptr->nFilledLen);
-+
 +    pkt->size = header_ptr->nFilledLen;
 +    pkt->pts  = header_ptr->pts;
 +    pkt->dts  = header_ptr->dts;
++
 +    if ((header_ptr->sliceType == EB_IDR_PICTURE) ||
 +        (header_ptr->sliceType == EB_I_PICTURE))
 +        pkt->flags |= AV_PKT_FLAG_KEY;
@@ -492,8 +456,10 @@ index 0000000..9b5d146
 +
 +    EbH265ReleaseOutBuffer(&header_ptr);
 +
++    *got_packet = 1;
++
 +    if (EB_BUFFERFLAG_EOS == header_ptr->nFlags)
-+        svt_enc->eos_flag = EOS_TOTRIGGER;
++       svt_enc->eos_flag = EOS_RECEIVED;
 +
 +    return 0;
 +}
@@ -503,13 +469,14 @@ index 0000000..9b5d146
 +    SvtContext *svt_enc = avctx->priv_data;
 +
 +    if (svt_enc) {
++        free_buffer(svt_enc);
++
 +        if (svt_enc->svt_handle) {
 +            EbDeinitEncoder(svt_enc->svt_handle);
 +            EbDeinitHandle(svt_enc->svt_handle);
 +            svt_enc->svt_handle = NULL;
 +        }
 +
-+        free_buffer(svt_enc);
 +        svt_enc = NULL;
 +    }
 +
@@ -519,46 +486,52 @@ index 0000000..9b5d146
 +#define OFFSET(x) offsetof(SvtContext, x)
 +#define VE AV_OPT_FLAG_VIDEO_PARAM | AV_OPT_FLAG_ENCODING_PARAM
 +static const AVOption options[] = {
-+    { "vui", "Enable vui info", OFFSET(vui_info),
++    { "asm_type", "Assembly instruction set type [0: C Only, 1: Auto]", OFFSET(asm_type),
 +      AV_OPT_TYPE_BOOL, { .i64 = 1 }, 0, 1, VE },
 +
-+    { "aud", "Include AUD", OFFSET(aud),
++    { "aud", "Include Access Unit Delimiter", OFFSET(aud),
 +      AV_OPT_TYPE_BOOL, { .i64 = 0 }, 0, 1, VE },
 +
++    { "bl_mode", "Random Access Prediction Structure type setting", OFFSET(base_layer_switch_mode),
++      AV_OPT_TYPE_BOOL, { .i64 = 0 }, 0, 1, VE },
++
++    { "forced-idr", "If forcing keyframes, force them as IDR frames.", OFFSET(forced_idr),
++      AV_OPT_TYPE_BOOL,   { .i64 = 0 }, 0, 1, VE },
++
 +    { "hielevel", "Hierarchical prediction levels setting", OFFSET(hierarchical_level),
-+      AV_OPT_TYPE_INT, { .i64 = 4 }, 1, 4, VE , "hielevel"},
-+        { "flat",   NULL, 0, AV_OPT_TYPE_CONST, { .i64 = 1 },  INT_MIN, INT_MAX, VE, "hielevel" },
-+        { "2level", NULL, 0, AV_OPT_TYPE_CONST, { .i64 = 2 },  INT_MIN, INT_MAX, VE, "hielevel" },
-+        { "3level", NULL, 0, AV_OPT_TYPE_CONST, { .i64 = 3 },  INT_MIN, INT_MAX, VE, "hielevel" },
-+        { "4level", NULL, 0, AV_OPT_TYPE_CONST, { .i64 = 4 },  INT_MIN, INT_MAX, VE, "hielevel" },
++      AV_OPT_TYPE_INT, { .i64 = 3 }, 0, 3, VE , "hielevel"},
++        { "flat",   NULL, 0, AV_OPT_TYPE_CONST, { .i64 = 0 },  INT_MIN, INT_MAX, VE, "hielevel" },
++        { "1 level", NULL, 0, AV_OPT_TYPE_CONST, { .i64 = 1 },  INT_MIN, INT_MAX, VE, "hielevel" },
++        { "2 level", NULL, 0, AV_OPT_TYPE_CONST, { .i64 = 2 },  INT_MIN, INT_MAX, VE, "hielevel" },
++        { "3 level", NULL, 0, AV_OPT_TYPE_CONST, { .i64 = 3 },  INT_MIN, INT_MAX, VE, "hielevel" },
 +
 +    { "la_depth", "Look ahead distance [0, 256]", OFFSET(la_depth),
 +      AV_OPT_TYPE_INT, { .i64 = -1 }, -1, 256, VE },
 +
-+    { "preset", "Encoding preset [0, 12] (e,g, for subjective quality tuning mode and >=4k resolution), [0, 10] (for >= 1080p resolution), [0, 9] (for all resolution and modes)",
++    { "level", "Set level (level_idc)", OFFSET(level),
++      AV_OPT_TYPE_INT, { .i64 = 0 }, 0, 0xff, VE, "level" },
++
++    { "preset", "Encoding preset [0, 12]",
 +      OFFSET(enc_mode), AV_OPT_TYPE_INT, { .i64 = 9 }, 0, 12, VE },
 +
 +    { "profile", "Profile setting, Main Still Picture Profile not supported", OFFSET(profile),
 +      AV_OPT_TYPE_INT, { .i64 = FF_PROFILE_HEVC_MAIN }, FF_PROFILE_HEVC_MAIN, FF_PROFILE_HEVC_REXT, VE, "profile"},
 +
-+    { "tier", "Set tier (general_tier_flag)", OFFSET(tier),
-+      AV_OPT_TYPE_INT, { .i64 = 0 }, 0, 1, VE, "tier" },
-+        { "main", NULL, 0, AV_OPT_TYPE_CONST, { .i64 = 0 }, 0, 0, VE, "tier" },
-+        { "high", NULL, 0, AV_OPT_TYPE_CONST, { .i64 = 1 }, 0, 0, VE, "tier" },
-+
-+    { "level", "Set level (level_idc)", OFFSET(level),
-+      AV_OPT_TYPE_INT, { .i64 = 0 }, 0, 0xff, VE, "level" },
++    { "qp", "QP value for intra frames", OFFSET(qp),
++      AV_OPT_TYPE_INT, { .i64 = 32 }, 0, 51, VE },
 +
 +    { "rc", "Bit rate control mode", OFFSET(rc_mode),
 +      AV_OPT_TYPE_INT, { .i64 = 0 }, 0, 1, VE , "rc"},
 +        { "cqp", NULL, 0, AV_OPT_TYPE_CONST, { .i64 = 0 },  INT_MIN, INT_MAX, VE, "rc" },
 +        { "vbr", NULL, 0, AV_OPT_TYPE_CONST, { .i64 = 1 },  INT_MIN, INT_MAX, VE, "rc" },
 +
-+    { "qp", "QP value for intra frames", OFFSET(qp),
-+      AV_OPT_TYPE_INT, { .i64 = 32 }, 0, 51, VE },
-+
 +    { "sc_detection", "Scene change detection", OFFSET(scd),
 +      AV_OPT_TYPE_BOOL, { .i64 = 1 }, 0, 1, VE },
++
++    { "tier", "Set tier (general_tier_flag)", OFFSET(tier),
++      AV_OPT_TYPE_INT, { .i64 = 0 }, 0, 1, VE, "tier" },
++        { "main", NULL, 0, AV_OPT_TYPE_CONST, { .i64 = 0 }, 0, 0, VE, "tier" },
++        { "high", NULL, 0, AV_OPT_TYPE_CONST, { .i64 = 1 }, 0, 0, VE, "tier" },
 +
 +    { "tune", "Quality tuning mode", OFFSET(tune), AV_OPT_TYPE_INT, { .i64 = 1 }, 0, 2, VE, "tune" },
 +        { "sq", "Visually optimized mode", 0,
@@ -568,19 +541,7 @@ index 0000000..9b5d146
 +        { "vmaf", "VMAF optimized mode", 0,
 +          AV_OPT_TYPE_CONST, { .i64 = 2 },  INT_MIN, INT_MAX, VE, "tune" },
 +
-+    { "bl_mode", "Random Access Prediction Structure type setting", OFFSET(base_layer_switch_mode),
-+      AV_OPT_TYPE_BOOL, { .i64 = 0 }, 0, 1, VE },
-+
-+    { "forced-idr", "If forcing keyframes, force them as IDR frames.", OFFSET(forced_idr),
-+      AV_OPT_TYPE_BOOL,   { .i64 = 0 }, -1, 1, VE },
-+
-+    { "hdr", "High dynamic range input", OFFSET(hdr),
-+      AV_OPT_TYPE_BOOL,   { .i64 = 0 }, 0, 1, VE },
-+
-+    { "asm_type", "Assembly instruction set type [0: C Only, 1: Auto]", OFFSET(asm_type),
-+      AV_OPT_TYPE_BOOL,   { .i64 = 1 }, 0, 1, VE },
-+
-+    { NULL },
++    {NULL},
 +};
 +
 +static const AVClass class = {
@@ -606,8 +567,7 @@ index 0000000..9b5d146
 +    .type           = AVMEDIA_TYPE_VIDEO,
 +    .id             = AV_CODEC_ID_HEVC,
 +    .init           = eb_enc_init,
-+    .send_frame     = eb_send_frame,
-+    .receive_packet = eb_receive_packet,
++    .encode2        = eb_encode_frame,
 +    .close          = eb_enc_close,
 +    .capabilities   = AV_CODEC_CAP_DELAY | AV_CODEC_CAP_AUTO_THREADS,
 +    .pix_fmts       = (const enum AVPixelFormat[]){ AV_PIX_FMT_YUV420P,


### PR DESCRIPTION
Migrated changes to support y4m container from SVT-AV1 to SVT-HEVC.  Tested with  
akiyo_cif.y4m from xiph.