### PR TITLE
Changing default value for fpsInVps to TRUE

### DIFF
--- a/Config/Sample.cfg
+++ b/Config/Sample.cfg
@@ -101,7 +101,7 @@ UnregisteredUserData            : 0                     # SEI message (0= OFF, 1
 RecoveryPoint                   : 0                     # SEI message (0= OFF, 1=ON )
 TemporalId                      : 1                     # 0: OFF, 1: Insert temporal ID in NAL units 
 SwitchThreadsToRtPriority       : 1                     # 0: OFF, 1: Switch threads to real time priority (works on Linux only)
-FPSInVPS                        : 0                     # 0: OFF, 1: Enable VPS timing info 
+FPSInVPS                        : 1                     # 0: OFF, 1: Enable VPS timing info 
 UnrestrictedMotionVector        : 0                     # 0: OFF, 1: Have unrestricted motion vectors
 MaxCLL                          : 0                     # SEI message (0=OFF,  1=ON ) 
 MaxFALL                         : 0                     # SEI message (0=OFF,  1=ON )

--- a/Docs/svt-hevc_encoder_user_guide.md
+++ b/Docs/svt-hevc_encoder_user_guide.md
@@ -302,7 +302,7 @@ The encoder parameters present in the Sample.cfg file are listed in this table b
 | **LogicalProcessors** | -lp | [0, total number of logical processor] | 0 | The number of logical processor which encoder threads run on.Refer to Appendix A.2 |
 | **TargetSocket** | -ss | [-1,1] | -1 | For dual socket systems, this can specify which socket the encoder runs on.Refer to Appendix A.2 |
 | **SwitchThreadsToRtPriority** | -rt | [0,1] | 1 | Enables or disables threads to real time priority, 0 = OFF, 1 = ON (only works on Linux) |
-| **FPSInVPS** | -fpsinvps | [0,1] | 0 | Enables or disables the VPS timing info, 0 = OFF, 1 = ON |
+| **FPSInVPS** | -fpsinvps | [0,1] | 1 | Enables or disables the VPS timing info, 0 = OFF, 1 = ON |
 | **TileRowCount** | -tile_row_cnt | [1,16] | 1 | Tile count in the Row |
 | **TileColumnCount** | -tile_col_cnt | [1,16] | 1 | Tile count in the column |
 | **TileSliceMode** | -tile_slice_mode | [0,1] | 0 | Per slice per tile, only valid for multi-tile |

--- a/Source/App/EbAppConfig.c
+++ b/Source/App/EbAppConfig.c
@@ -474,7 +474,7 @@ void EbConfigCtor(EbConfig_t *configPtr)
     configPtr->minDisplayMasteringLuminance         = 0;
 
     configPtr->switchThreadsToRtPriority            = EB_TRUE;
-    configPtr->fpsInVps                             = EB_FALSE;
+    configPtr->fpsInVps                             = EB_TRUE;
     configPtr->unrestrictedMotionVector             = EB_TRUE;
 
     // Encoding Presets
@@ -559,7 +559,7 @@ void EbConfigCtor(EbConfig_t *configPtr)
     configPtr->recoveryPointSeiFlag                     = EB_FALSE;
     configPtr->enableTemporalId                         = 1;
     configPtr->switchThreadsToRtPriority                = EB_TRUE;
-    configPtr->fpsInVps                                 = EB_FALSE;
+    configPtr->fpsInVps                                 = EB_TRUE;
     configPtr->maxCLL                                   = 0;
     configPtr->maxFALL                                  = 0;
     configPtr->useMasteringDisplayColorVolume           = EB_FALSE;

--- a/Source/Lib/Codec/EbEncHandle.c
+++ b/Source/Lib/Codec/EbEncHandle.c
@@ -2804,7 +2804,7 @@ EB_ERRORTYPE EbH265EncInitParameter(
     configPtr->codeVpsSpsPps = 0;
     configPtr->codeEosNal    = 0;
     configPtr->switchThreadsToRtPriority = EB_TRUE;
-    configPtr->fpsInVps      = EB_FALSE;
+    configPtr->fpsInVps      = EB_TRUE;
     configPtr->unrestrictedMotionVector = EB_TRUE;
 
     configPtr->videoUsabilityInfo = 0;


### PR DESCRIPTION
This change was result of investigating https://github.com/OpenVisualCloud/SVT-HEVC/issues/218 where ffprobe did not report the correct frame rate.  The solution was to use the fpsInVps command line option.  However a better solution is to change the default so that the fps is always written to the Vps structure (unless the user decides to set fpsInVps to false with a parameter).