### PR TITLE
CMake: apply -fstack-protector-strong if not mingw

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,7 +79,6 @@ set(flags_to_test
     -Wextra
     -Wformat
     -Wformat-security
-    -fstack-protector-strong
     -fvisibility=hidden
     -fPIE
     -fPIC
@@ -96,6 +95,8 @@ else()
     #for Mingw64 support, see https://gcc.gnu.org/bugzilla/show_bug.cgi?id=65782
     if(MINGW)
         list(APPEND flags_to_test -fno-asynchronous-unwind-tables)
+    else()
+        list(APPEND flags_to_test -fstack-protector-strong)
     endif()
     if(NATIVE)
         list(APPEND flags_to_test -march=native)


### PR DESCRIPTION
Don't apply stack protector if mingw since not all mingw-w64 gcc's are compiled with stack-protector included