### PR TITLE
Y4m ctype

### DIFF
--- a/Source/App/EbAppInputy4m.c
+++ b/Source/App/EbAppInputy4m.c
@@ -10,7 +10,7 @@
 #define CHROMA_MAX 4
 
 #include "EbAppConfig.h"
-
+#include <ctype.h>
 
 /* copy a string until a specified character or a new line is found */
 char* copyUntilCharacterOrNewLine(char *src, char *dst, char chr) {


### PR DESCRIPTION
Adding #include <ctype.h> to eliminate compiler warning for isalnum function.
This function checks for alphanumeric characters and was added for a
validateAlphanumeric function to resolve a Klocwork reported issue with
checking input.