### PR TITLE
Added encoder mode11 to tune 1(OQ)

### DIFF
--- a/Docs/svt-hevc_encoder_user_guide.md
+++ b/Docs/svt-hevc_encoder_user_guide.md
@@ -300,8 +300,8 @@ The encoder parameters present in the Sample.cfg file are listed in this table b
 | **MinQpAllowed** | -min-qp | [0 - 50] | 10 | Minimum QP value allowed for rate control use. Only used when RateControlMode is set to 1. Has to be < MaxQpAllowed |
 | **LookAheadDistance** | -lad | [0 - 250] | Depending on BRC mode | When RateControlMode is set to 1 it&#39;s best to set this parameter to be equal to the Intra period value (such is the default set by the encoder), When CQP is chosen, then a (2 \* minigopsize +1) look ahead is recommended. |
 | **SceneChangeDetection** | -scd | [0,1] | 1 | Enables or disables the scene change detection algorithm <br> 0 = OFF, 1 = ON |
-| **BitRateReduction** | -brr | [0,1] | 1 | Enables visual quality algorithms to reduce the output bitrate with minimal or no subjective visual quality impact. (no support for –tune 1 or -tune 2) <br>0 = OFF, 1 = ON |
-| **ImproveSharpness** | -sharp | [0,1] | 1 | This is a visual quality knob that allows the use of adaptive quantization within the picture and enables visual quality algorithms that improve the sharpness of the background. This feature is only available for 4k and 8k resolutions (no support for –tune 1 or -tune 2) <br> 0 = OFF, 1 = ON |
+| **BitRateReduction** | -brr | [0,1] | 1 | Enables visual quality algorithms to reduce the output bitrate with minimal or no subjective visual quality impact. <br>0 = OFF, 1 = ON |
+| **ImproveSharpness** | -sharp | [0,1] | 1 | This is a visual quality knob that allows the use of adaptive quantization within the picture and enables visual quality algorithms that improve the sharpness of the background. This feature is only available for 4k and 8k resolutions <br> 0 = OFF, 1 = ON |
 | **VideoUsabilityInfo** | -vid-info | [0,1] | 0 | Enables or disables sending a vui structure in the HEVC Elementary bitstream. 0 = OFF, 1 = ON |
 | **HighDynamicRangeInput** | -hdr | [0,1] | 0 | When set to 1, signals HDR10 input in the output HEVC elementary bitstream and forces VideoUsabilityInfo to 1. <br>0 = OFF, 1 = ON |
 | **AccessUnitDelimiter** | -ua-delm | [0,1] | 0 | SEI message, 0 = OFF, 1 = ON |

--- a/Source/Lib/Codec/EbDefinitions.h
+++ b/Source/Lib/Codec/EbDefinitions.h
@@ -406,7 +406,7 @@ static const EB_U32 me2Nx2NOffset[4]    = { 0, 1, 5, 21 };
 
 #define MAX_SUPPORTED_MODES_SUB1080P    10
 #define MAX_SUPPORTED_MODES_1080P       11
-#define MAX_SUPPORTED_MODES_4K_OQ       11
+#define MAX_SUPPORTED_MODES_4K_OQ       12
 #define MAX_SUPPORTED_MODES_4K_SQ       13
 
 #define SPEED_CONTROL_INIT_MOD ENC_MODE_5;
@@ -2049,7 +2049,7 @@ static const EB_U8 SearchAreaHeightOq[5][MAX_SUPPORTED_MODES] = {
 	{  64,   64,   64,   64,   16,   13,   13,    9,    9,    7,    7,    7,    7 },
 	{  64,   64,   64,   64,   16,    9,    9,    7,    7,    7,    7,    7,    7 },
 	{  64,   64,   64,   64,   16,   13,   13,    9,    9,    7,    7,    7,    7 },
-	{  64,   64,   64,   64,    9,    9,    9,    9,    7,    7,    7,    7,    7 }
+	{  64,   64,   64,   64,    9,    9,    9,    9,    7,    7,    7,    5,    5 }
 };
 /******************************************************************************
                             ME/HME settings SQ

--- a/Source/Lib/Codec/EbEncDecProcess.c
+++ b/Source/Lib/Codec/EbEncDecProcess.c
@@ -2789,7 +2789,6 @@ static EB_ERRORTYPE SignalDerivationEncDecKernelOq(
         else {
             contextPtr->mdContext->chromaLevel = 1;
         }
-
     }
     else {
         contextPtr->mdContext->chromaLevel = 1;
@@ -2895,7 +2894,7 @@ static EB_ERRORTYPE SignalDerivationEncDecKernelOq(
 	contextPtr->yBitsThsld = YBITS_THSHLD_1(0);
     
     // Set SAO Mode
-    contextPtr->saoMode = (pictureControlSetPtr->ParentPcsPtr->encMode <= ENC_MODE_10) ? 1 : 0;;
+    contextPtr->saoMode = (pictureControlSetPtr->ParentPcsPtr->encMode <= ENC_MODE_10) ? 1 : 0;
     
     // Set Exit Partitioning Flag 
     if (pictureControlSetPtr->encMode >= ENC_MODE_10) {

--- a/Source/Lib/Codec/EbEncDecProcess.c
+++ b/Source/Lib/Codec/EbEncDecProcess.c
@@ -2771,24 +2771,28 @@ static EB_ERRORTYPE SignalDerivationEncDecKernelOq(
 			contextPtr->mdContext->chromaLevel = 0;
 		}
 	}
-    else {
-		if (pictureControlSetPtr->sliceType == EB_I_PICTURE) {
-			contextPtr->mdContext->chromaLevel = 1;
-		}
-		else if (pictureControlSetPtr->temporalLayerIndex == 0) {
-			contextPtr->mdContext->chromaLevel = 0;
-		}
-        else if (pictureControlSetPtr->ParentPcsPtr->isUsedAsReferenceFlag) {
-			if (contextPtr->mdContext->intraMdOpenLoopFlag) {
-				contextPtr->mdContext->chromaLevel = 4;
-			}
-			else {
-				contextPtr->mdContext->chromaLevel = 0;
-			}
+    else if (pictureControlSetPtr->encMode <= ENC_MODE_10) {
+        if (pictureControlSetPtr->sliceType == EB_I_PICTURE) {
+            contextPtr->mdContext->chromaLevel = 1;
         }
-		else {
-			contextPtr->mdContext->chromaLevel = 1;
-		}
+        else if (pictureControlSetPtr->temporalLayerIndex == 0) {
+            contextPtr->mdContext->chromaLevel = 0;
+        }
+        else if (pictureControlSetPtr->ParentPcsPtr->isUsedAsReferenceFlag) {
+            if (contextPtr->mdContext->intraMdOpenLoopFlag) {
+                contextPtr->mdContext->chromaLevel = 4;
+            }
+            else {
+                contextPtr->mdContext->chromaLevel = 0;
+            }
+        }
+        else {
+            contextPtr->mdContext->chromaLevel = 1;
+        }
+
+    }
+    else {
+        contextPtr->mdContext->chromaLevel = 1;
     }
 
     // Set Coeff Cabac Update Flag
@@ -2891,7 +2895,7 @@ static EB_ERRORTYPE SignalDerivationEncDecKernelOq(
 	contextPtr->yBitsThsld = YBITS_THSHLD_1(0);
     
     // Set SAO Mode
-	contextPtr->saoMode = 1;
+    contextPtr->saoMode = (pictureControlSetPtr->ParentPcsPtr->encMode <= ENC_MODE_10) ? 1 : 0;;
     
     // Set Exit Partitioning Flag 
     if (pictureControlSetPtr->encMode >= ENC_MODE_10) {
@@ -2992,13 +2996,26 @@ static EB_ERRORTYPE SignalDerivationEncDecKernelOq(
 			}
 		}
 	}
-    else {
+    else if (pictureControlSetPtr->encMode <= ENC_MODE_10) {
         if (pictureControlSetPtr->temporalLayerIndex == 0) {
             contextPtr->mdContext->pfMdLevel = 0;
         }
         else {
             contextPtr->mdContext->pfMdLevel = 1;
-        }   
+        }
+    }
+    else
+    {
+
+        if (pictureControlSetPtr->sliceType == EB_I_PICTURE) {
+            contextPtr->mdContext->pfMdLevel = 1;
+        }
+        else if (pictureControlSetPtr->ParentPcsPtr->temporalLayerIndex == 0) {
+            contextPtr->mdContext->pfMdLevel = 2;
+        }
+        else {
+            contextPtr->mdContext->pfMdLevel = 3;
+        }
     }
 
     // Set INTRA4x4 Search Level

--- a/Source/Lib/Codec/EbEncHandle.c
+++ b/Source/Lib/Codec/EbEncHandle.c
@@ -2346,8 +2346,8 @@ static EB_ERRORTYPE VerifySettings(\
             SVT_LOG("SVT [Error]: Instance %u: encMode must be [0 - 12] for this resolution\n", channelNumber + 1);
             return_error = EB_ErrorBadParameter;
         }
-        else if (config->encMode > 10 && config->tune >= 1) {
-            SVT_LOG("SVT [Error]: Instance %u: encMode must be [0 - 10] for this resolution\n", channelNumber + 1);
+        else if (config->encMode > 11 && config->tune >= 1) {
+            SVT_LOG("SVT [Error]: Instance %u: encMode must be [0 - 11] for this resolution\n", channelNumber + 1);
             return_error = EB_ErrorBadParameter;
         }
     }

--- a/Source/Lib/Codec/EbEncHandle.c
+++ b/Source/Lib/Codec/EbEncHandle.c
@@ -2051,11 +2051,6 @@ void CopyApiFromApp(
     sequenceControlSetPtr->maxInputLumaWidth  = (EB_U16)((EB_H265_ENC_CONFIGURATION*)pComponentParameterStructure)->sourceWidth;
     sequenceControlSetPtr->maxInputLumaHeight = (EB_U16)((EB_H265_ENC_CONFIGURATION*)pComponentParameterStructure)->sourceHeight;
 
-    if (sequenceControlSetPtr->staticConfig.tune >= 1) {
-        sequenceControlSetPtr->staticConfig.bitRateReduction = 0;
-        sequenceControlSetPtr->staticConfig.improveSharpness = 0;
-    }
-
     sequenceControlSetPtr->intraPeriodLength = sequenceControlSetPtr->staticConfig.intraPeriodLength;
     sequenceControlSetPtr->intraRefreshType = sequenceControlSetPtr->staticConfig.intraRefreshType;
     sequenceControlSetPtr->maxTemporalLayers = sequenceControlSetPtr->staticConfig.hierarchicalLevels;
@@ -2522,16 +2517,6 @@ static EB_ERRORTYPE VerifySettings(\
 		return_error = EB_ErrorBadParameter;
 	}
 
-    if (config->tune > 0 && config->bitRateReduction == 1){
-        SVT_LOG("SVT [Error]: Instance %u: Bit Rate Reduction is not supported for OQ mode (Tune = 1 ) and VMAF mode (Tune = 2)\n", channelNumber + 1);
-        return_error = EB_ErrorBadParameter;
-    }
-
-    if (config->tune > 0 && config->improveSharpness == 1){
-        SVT_LOG("SVT [Error]: Instance %u: Improve sharpness is not supported for OQ mode (Tune = 1 ) and VMAF mode (Tune = 2)\n", channelNumber + 1);
-        return_error = EB_ErrorBadParameter;
-    }
-
     if (config->lookAheadDistance > 250 && config->lookAheadDistance != (EB_U32)~0) {
         SVT_LOG("SVT [Error]: Instance %u: The lookahead distance must be [0 - 250] \n", channelNumber + 1);
         return_error = EB_ErrorBadParameter;
@@ -2906,7 +2891,7 @@ static void PrintLibParams(
     else
         SVT_LOG("\nSVT [config]: BRC Mode / QP  / LookaheadDistance / SceneChange\t\t\t: CQP / %d / %d / %d ", config->qp, config->lookAheadDistance, config->sceneChangeDetection);
 
-    if (config->tune == 0)
+    if (config->tune <= 1)
         SVT_LOG("\nSVT [config]: BitRateReduction / ImproveSharpness\t\t\t\t: %d / %d ", config->bitRateReduction, config->improveSharpness);
     SVT_LOG("\n------------------------------------------- ");
     SVT_LOG("\n");

--- a/Source/Lib/Codec/EbModeDecision.c
+++ b/Source/Lib/Codec/EbModeDecision.c
@@ -1231,9 +1231,8 @@ void  ProductIntraCandidateInjection(
                 else {
                     if (((cuSize >= 16 && pictureControlSetPtr->ParentPcsPtr->cu16x16Mode == CU_16x16_MODE_0) &&
                         (sequenceControlSetPtr->staticConfig.tune != TUNE_OQ || (sequenceControlSetPtr->staticConfig.tune == TUNE_OQ && pictureControlSetPtr->encMode < ENC_MODE_11)))
-                         || (cuSize == 32)) {
-
-
+                         || (cuSize == 32)) 
+                    {
                         {
                             if (pictureControlSetPtr->ParentPcsPtr->limitOisToDcModeFlag)
                             {

--- a/Source/Lib/Codec/EbModeDecision.c
+++ b/Source/Lib/Codec/EbModeDecision.c
@@ -1229,7 +1229,10 @@ void  ProductIntraCandidateInjection(
                 // P/B Slice
                 //----------------------  
                 else {
-					if ((cuSize >= 16 && pictureControlSetPtr->ParentPcsPtr->cu16x16Mode == CU_16x16_MODE_0) || (cuSize == 32)) {
+                    if (((cuSize >= 16 && pictureControlSetPtr->ParentPcsPtr->cu16x16Mode == CU_16x16_MODE_0) &&
+                        (sequenceControlSetPtr->staticConfig.tune != TUNE_OQ || (sequenceControlSetPtr->staticConfig.tune == TUNE_OQ && pictureControlSetPtr->encMode < ENC_MODE_11)))
+                         || (cuSize == 32)) {
+
 
                         {
                             if (pictureControlSetPtr->ParentPcsPtr->limitOisToDcModeFlag)

--- a/Source/Lib/Codec/EbModeDecisionConfigurationProcess.c
+++ b/Source/Lib/Codec/EbModeDecisionConfigurationProcess.c
@@ -1493,26 +1493,45 @@ void SetTargetBudgetOq(
 				budget = pictureControlSetPtr->lcuTotalCount * U_109;
 		}
 	}
+    else if (contextPtr->adpLevel <= ENC_MODE_10) {
+        if (pictureControlSetPtr->ParentPcsPtr->temporalLayerIndex == 0)
+            budget = (contextPtr->adpDepthSensitivePictureClass == DEPTH_SENSITIVE_PIC_CLASS_2) ?
+            pictureControlSetPtr->ParentPcsPtr->lcuTotalCount * U_127 :
+            (contextPtr->adpDepthSensitivePictureClass == DEPTH_SENSITIVE_PIC_CLASS_1) ?
+            pictureControlSetPtr->ParentPcsPtr->lcuTotalCount * U_125 :
+            pictureControlSetPtr->ParentPcsPtr->lcuTotalCount * U_121;
+        else if (pictureControlSetPtr->ParentPcsPtr->isUsedAsReferenceFlag)
+            budget = (contextPtr->adpDepthSensitivePictureClass == DEPTH_SENSITIVE_PIC_CLASS_2) ?
+            pictureControlSetPtr->ParentPcsPtr->lcuTotalCount * OPEN_LOOP_COST :
+            (contextPtr->adpDepthSensitivePictureClass == DEPTH_SENSITIVE_PIC_CLASS_1) ?
+            pictureControlSetPtr->ParentPcsPtr->lcuTotalCount * 100 :
+            pictureControlSetPtr->ParentPcsPtr->lcuTotalCount * 100;
+        else
+            budget = (contextPtr->adpDepthSensitivePictureClass == DEPTH_SENSITIVE_PIC_CLASS_2) ?
+            pictureControlSetPtr->ParentPcsPtr->lcuTotalCount * 100 :
+            pictureControlSetPtr->ParentPcsPtr->lcuTotalCount * 100;
+    }
     else {
-		if (pictureControlSetPtr->ParentPcsPtr->temporalLayerIndex == 0)
-			budget = (contextPtr->adpDepthSensitivePictureClass == DEPTH_SENSITIVE_PIC_CLASS_2) ?
-			pictureControlSetPtr->ParentPcsPtr->lcuTotalCount * U_127 :
-			(contextPtr->adpDepthSensitivePictureClass == DEPTH_SENSITIVE_PIC_CLASS_1) ?
-			pictureControlSetPtr->ParentPcsPtr->lcuTotalCount * U_125 :
-			pictureControlSetPtr->ParentPcsPtr->lcuTotalCount * U_121;
-		else if (pictureControlSetPtr->ParentPcsPtr->isUsedAsReferenceFlag)
-			budget = (contextPtr->adpDepthSensitivePictureClass == DEPTH_SENSITIVE_PIC_CLASS_2) ?
-			pictureControlSetPtr->ParentPcsPtr->lcuTotalCount * OPEN_LOOP_COST :
-			(contextPtr->adpDepthSensitivePictureClass == DEPTH_SENSITIVE_PIC_CLASS_1) ?
-			pictureControlSetPtr->ParentPcsPtr->lcuTotalCount * 100 :
-			pictureControlSetPtr->ParentPcsPtr->lcuTotalCount * 100;
-		else
-			budget = (contextPtr->adpDepthSensitivePictureClass == DEPTH_SENSITIVE_PIC_CLASS_2) ?
-			pictureControlSetPtr->ParentPcsPtr->lcuTotalCount * 100 :
-			pictureControlSetPtr->ParentPcsPtr->lcuTotalCount * 100;
+        if (pictureControlSetPtr->ParentPcsPtr->temporalLayerIndex == 0)
+            budget = (contextPtr->adpDepthSensitivePictureClass == DEPTH_SENSITIVE_PIC_CLASS_2) ?
+            pictureControlSetPtr->ParentPcsPtr->lcuTotalCount * U_127 :
+            (contextPtr->adpDepthSensitivePictureClass == DEPTH_SENSITIVE_PIC_CLASS_1) ?
+            pictureControlSetPtr->ParentPcsPtr->lcuTotalCount * U_125 :
+            pictureControlSetPtr->ParentPcsPtr->lcuTotalCount * U_121;
+        else if (pictureControlSetPtr->ParentPcsPtr->isUsedAsReferenceFlag)
+            budget = (contextPtr->adpDepthSensitivePictureClass == DEPTH_SENSITIVE_PIC_CLASS_2) ?
+            pictureControlSetPtr->ParentPcsPtr->lcuTotalCount * OPEN_LOOP_COST :
+            (contextPtr->adpDepthSensitivePictureClass == DEPTH_SENSITIVE_PIC_CLASS_1) ?
+            pictureControlSetPtr->ParentPcsPtr->lcuTotalCount * U_104 :
+            pictureControlSetPtr->ParentPcsPtr->lcuTotalCount * U_103;
+        else
+            budget = (contextPtr->adpDepthSensitivePictureClass == DEPTH_SENSITIVE_PIC_CLASS_2) ?
+            pictureControlSetPtr->ParentPcsPtr->lcuTotalCount * U_104 :
+            pictureControlSetPtr->ParentPcsPtr->lcuTotalCount * U_103;
     }
 
-	contextPtr->budget = budget;
+
+    contextPtr->budget = budget;
 }
 
 /******************************************************

--- a/Source/Lib/Codec/EbPictureDecisionProcess.c
+++ b/Source/Lib/Codec/EbPictureDecisionProcess.c
@@ -372,7 +372,13 @@ EB_U8 PictureLevelSubPelSettingsOq(
     }
     else {
 		if (inputResolution >= INPUT_SIZE_4K_RANGE) {
-			subPelMode = (temporalLayerIndex == 0) ? 1 : 0;
+            if (encMode > ENC_MODE_10) {
+                subPelMode = 0;
+            }
+
+            else {
+                subPelMode = (temporalLayerIndex == 0) ? 1 : 0;
+            }
 		}
 		else {
 			subPelMode = isUsedAsReferenceFlag ? 1 : 0;
@@ -595,9 +601,20 @@ EB_ERRORTYPE SignalDerivationMultiProcessesOq(
 			pictureControlSetPtr->depthMode = PICT_FULL85_DEPTH_MODE;
 		}
 	}
-    else {
+    else if (pictureControlSetPtr->encMode <= ENC_MODE_10) {
         if (pictureControlSetPtr->sliceType == EB_I_PICTURE) {
             pictureControlSetPtr->depthMode = PICT_FULL84_DEPTH_MODE;
+        }
+        else {
+            pictureControlSetPtr->depthMode = PICT_LCU_SWITCH_DEPTH_MODE;
+        }
+    }
+
+    else {
+        if (pictureControlSetPtr->sliceType == EB_I_PICTURE) {
+
+            pictureControlSetPtr->depthMode = PICT_BDP_DEPTH_MODE;
+
         }
         else {
             pictureControlSetPtr->depthMode = PICT_LCU_SWITCH_DEPTH_MODE;

--- a/Source/Lib/Codec/EbPictureDecisionProcess.c
+++ b/Source/Lib/Codec/EbPictureDecisionProcess.c
@@ -375,7 +375,6 @@ EB_U8 PictureLevelSubPelSettingsOq(
             if (encMode > ENC_MODE_10) {
                 subPelMode = 0;
             }
-
             else {
                 subPelMode = (temporalLayerIndex == 0) ? 1 : 0;
             }
@@ -612,9 +611,7 @@ EB_ERRORTYPE SignalDerivationMultiProcessesOq(
 
     else {
         if (pictureControlSetPtr->sliceType == EB_I_PICTURE) {
-
             pictureControlSetPtr->depthMode = PICT_BDP_DEPTH_MODE;
-
         }
         else {
             pictureControlSetPtr->depthMode = PICT_LCU_SWITCH_DEPTH_MODE;


### PR DESCRIPTION
- Added M11 to OQ mode (tune1) by applying some M12 SQ (tune 0) features . Adopted features as follow : 

* M12 SQ ME search region .
* M12 SQ chroma level.
* M12 SQ Subpel Parameters .
* M12 SQ Partitioning 
* M12 SQ pf MD parameters.
* M12 SQ ADP level.
* Tune a new level for CU16x16 for better speed / BD-rate tradeoff.

=> M11 tune 1 : Speed = ~189 fps for 4K_60 on 8180 / BD-rate loss compared to M10 Tune1 : ~ 9 % 

- Added the ability to enable/disable BitRateReduction and Sharpness features for tune 1 