### PR TITLE
Fix bug #260

### DIFF
--- a/Source/Lib/Codec/EbEncHandle.c
+++ b/Source/Lib/Codec/EbEncHandle.c
@@ -3828,6 +3828,14 @@ EB_ERRORTYPE EbOutputBufferHeaderCtor(
 	EB_MALLOC(EB_BUFFERHEADERTYPE*, outBufPtr, sizeof(EB_BUFFERHEADERTYPE), EB_N_PTR);
 	*objectDblPtr = (EB_PTR)outBufPtr;
 
+    //Jing:TODO
+    //Simple work around here, for 8K case.
+    //Will improve here if memory is limited
+    //Can use fps/tbr/intra_period to compute a ideal maximum size
+    if (config->rateControlMode == 1 && config->targetBitRate >= 50000000) {
+        nStride = 10000000;
+    }
+
 	// Initialize Header
 	outBufPtr->nSize = sizeof(EB_BUFFERHEADERTYPE);
 


### PR DESCRIPTION
Caused by high bitrate, the encoded I frame is larger than 6MB, so
increase the size for now

Signed-off-by: Jing Li <jing.b.li@intel.com>