### PR TITLE
Optimize Copy of SequenceControlSet and initial value assignment

### DIFF
--- a/Source/Lib/Codec/EbResourceCoordinationProcess.c
+++ b/Source/Lib/Codec/EbResourceCoordinationProcess.c
@@ -516,38 +516,32 @@ void* ResourceCoordinationKernel(void *inputPtr)
         //   prepare a new sequenceControlSetPtr containing the new changes and update the state
         //   of the previous Active SequenceControlSet
         EbBlockOnMutex(contextPtr->sequenceControlSetInstanceArray[instanceIndex]->configMutex);
-        if(contextPtr->sequenceControlSetInstanceArray[instanceIndex]->encodeContextPtr->initialPicture) {
-            
+        if (contextPtr->sequenceControlSetInstanceArray[instanceIndex]->encodeContextPtr->initialPicture) {
+
             // Update picture width, picture height, cropping right offset, cropping bottom offset, and conformance windows
-            if(contextPtr->sequenceControlSetInstanceArray[instanceIndex]->encodeContextPtr->initialPicture) 
-            
-            {
-                contextPtr->sequenceControlSetInstanceArray[instanceIndex]->sequenceControlSetPtr->lumaWidth = contextPtr->sequenceControlSetInstanceArray[instanceIndex]->sequenceControlSetPtr->maxInputLumaWidth;
-                contextPtr->sequenceControlSetInstanceArray[instanceIndex]->sequenceControlSetPtr->lumaHeight = contextPtr->sequenceControlSetInstanceArray[instanceIndex]->sequenceControlSetPtr->maxInputLumaHeight;
-                contextPtr->sequenceControlSetInstanceArray[instanceIndex]->sequenceControlSetPtr->chromaWidth = (contextPtr->sequenceControlSetInstanceArray[instanceIndex]->sequenceControlSetPtr->maxInputLumaWidth >> subWidthCMinus1);
-                contextPtr->sequenceControlSetInstanceArray[instanceIndex]->sequenceControlSetPtr->chromaHeight = (contextPtr->sequenceControlSetInstanceArray[instanceIndex]->sequenceControlSetPtr->maxInputLumaHeight >> subHeightCMinus1);
+            if (contextPtr->sequenceControlSetInstanceArray[instanceIndex]->encodeContextPtr->initialPicture) {
+                sequenceControlSetPtr->lumaWidth    = sequenceControlSetPtr->maxInputLumaWidth;
+                sequenceControlSetPtr->lumaHeight   = sequenceControlSetPtr->maxInputLumaHeight;
+                sequenceControlSetPtr->chromaWidth  = sequenceControlSetPtr->maxInputLumaWidth >> subWidthCMinus1;
+                sequenceControlSetPtr->chromaHeight = sequenceControlSetPtr->maxInputLumaHeight >> subHeightCMinus1;
 
-                
-                contextPtr->sequenceControlSetInstanceArray[instanceIndex]->sequenceControlSetPtr->padRight = contextPtr->sequenceControlSetInstanceArray[instanceIndex]->sequenceControlSetPtr->maxInputPadRight;
-                contextPtr->sequenceControlSetInstanceArray[instanceIndex]->sequenceControlSetPtr->croppingRightOffset = contextPtr->sequenceControlSetInstanceArray[instanceIndex]->sequenceControlSetPtr->padRight;
-                contextPtr->sequenceControlSetInstanceArray[instanceIndex]->sequenceControlSetPtr->padBottom = contextPtr->sequenceControlSetInstanceArray[instanceIndex]->sequenceControlSetPtr->maxInputPadBottom;
-                contextPtr->sequenceControlSetInstanceArray[instanceIndex]->sequenceControlSetPtr->croppingBottomOffset = contextPtr->sequenceControlSetInstanceArray[instanceIndex]->sequenceControlSetPtr->padBottom;
+                sequenceControlSetPtr->padRight             = sequenceControlSetPtr->maxInputPadRight;
+                sequenceControlSetPtr->croppingRightOffset  = sequenceControlSetPtr->padRight;
+                sequenceControlSetPtr->padBottom            = sequenceControlSetPtr->maxInputPadBottom;
+                sequenceControlSetPtr->croppingBottomOffset = sequenceControlSetPtr->padBottom;
 
-                if(contextPtr->sequenceControlSetInstanceArray[instanceIndex]->sequenceControlSetPtr->padRight != 0 || contextPtr->sequenceControlSetInstanceArray[instanceIndex]->sequenceControlSetPtr->padBottom != 0) {
-                    contextPtr->sequenceControlSetInstanceArray[instanceIndex]->sequenceControlSetPtr->conformanceWindowFlag = 1;
-                }
-                else {
-                    contextPtr->sequenceControlSetInstanceArray[instanceIndex]->sequenceControlSetPtr->conformanceWindowFlag = 0;
-                }
-                
-				inputSize = contextPtr->sequenceControlSetInstanceArray[instanceIndex]->sequenceControlSetPtr->lumaWidth * contextPtr->sequenceControlSetInstanceArray[instanceIndex]->sequenceControlSetPtr->lumaHeight;
+                if (sequenceControlSetPtr->padRight != 0 || sequenceControlSetPtr->padBottom != 0)
+                    sequenceControlSetPtr->conformanceWindowFlag = 1;
+                else
+                    sequenceControlSetPtr->conformanceWindowFlag = 0;
+
+                inputSize = sequenceControlSetPtr->lumaWidth * sequenceControlSetPtr->lumaHeight;
             }
 
             // HDR BT2020
             if (sequenceControlSetPtr->staticConfig.videoUsabilityInfo)
             {
-                
-                AppVideoUsabilityInfo_t    *vuiPtr = contextPtr->sequenceControlSetInstanceArray[instanceIndex]->sequenceControlSetPtr->videoUsabilityInfoPtr;
+                AppVideoUsabilityInfo_t *vuiPtr = sequenceControlSetPtr->videoUsabilityInfoPtr;
 
                 if (sequenceControlSetPtr->staticConfig.highDynamicRangeInput && is16BitInput){
                     vuiPtr->aspectRatioInfoPresentFlag = EB_TRUE;
@@ -586,7 +580,7 @@ void* ResourceCoordinationKernel(void *inputPtr)
             // Copy the contents of the active SequenceControlSet into the new empty SequenceControlSet
             CopySequenceControlSet(
                 (SequenceControlSet_t*) contextPtr->sequenceControlSetActiveArray[instanceIndex]->objectPtr,
-                contextPtr->sequenceControlSetInstanceArray[instanceIndex]->sequenceControlSetPtr);
+                sequenceControlSetPtr);
 
         }
         EbReleaseMutex(contextPtr->sequenceControlSetInstanceArray[instanceIndex]->configMutex);

--- a/Source/Lib/Codec/EbSei.c
+++ b/Source/Lib/Codec/EbSei.c
@@ -12,62 +12,11 @@ void EbVideoUsabilityInfoCopy(
     AppVideoUsabilityInfo_t *dstVuiPtr,
     AppVideoUsabilityInfo_t *srcVuiPtr)
 {
+    size_t sizeCopy = (size_t)((EB_U64)(&dstVuiPtr->hrdParametersPtr) -
+                               (EB_U64)(&dstVuiPtr->aspectRatioInfoPresentFlag));
 
-    dstVuiPtr->aspectRatioInfoPresentFlag = srcVuiPtr->aspectRatioInfoPresentFlag;
-    dstVuiPtr->aspectRatioIdc = srcVuiPtr->aspectRatioIdc;
-    dstVuiPtr->sarWidth = srcVuiPtr->sarWidth;
-    dstVuiPtr->sarHeight = srcVuiPtr->sarHeight;
-
-    dstVuiPtr->overscanInfoPresentFlag = srcVuiPtr->overscanInfoPresentFlag;
-    dstVuiPtr->overscanApproriateFlag = srcVuiPtr->overscanApproriateFlag;
-    dstVuiPtr->videoSignalTypePresentFlag = srcVuiPtr->videoSignalTypePresentFlag;
-
-    dstVuiPtr->videoFormat = srcVuiPtr->videoFormat;
-    dstVuiPtr->videoFullRangeFlag = srcVuiPtr->videoFullRangeFlag;
-
-    dstVuiPtr->colorDescriptionPresentFlag =  srcVuiPtr->colorDescriptionPresentFlag;
-    dstVuiPtr->colorPrimaries = srcVuiPtr->colorPrimaries;
-    dstVuiPtr->transferCharacteristics = srcVuiPtr->transferCharacteristics;
-    dstVuiPtr->matrixCoeffs = srcVuiPtr->matrixCoeffs;
-
-    dstVuiPtr->chromaLocInfoPresentFlag = srcVuiPtr->chromaLocInfoPresentFlag;
-    dstVuiPtr->chromaSampleLocTypeTopField = srcVuiPtr->chromaSampleLocTypeTopField;
-    dstVuiPtr->chromaSampleLocTypeBottomField = srcVuiPtr->chromaSampleLocTypeBottomField;
-
-    dstVuiPtr->neutralChromaIndicationFlag = srcVuiPtr->neutralChromaIndicationFlag;
-    dstVuiPtr->fieldSeqFlag = srcVuiPtr->fieldSeqFlag;
-    dstVuiPtr->frameFieldInfoPresentFlag = srcVuiPtr->frameFieldInfoPresentFlag;
-
-    dstVuiPtr->defaultDisplayWindowFlag = srcVuiPtr->defaultDisplayWindowFlag;
-    dstVuiPtr->defaultDisplayWinLeftOffset = srcVuiPtr->defaultDisplayWinLeftOffset;
-    dstVuiPtr->defaultDisplayWinRightOffset = srcVuiPtr->defaultDisplayWinRightOffset;
-    dstVuiPtr->defaultDisplayWinTopOffset =  srcVuiPtr->defaultDisplayWinTopOffset;
-    dstVuiPtr->defaultDisplayWinBottomOffset = srcVuiPtr->defaultDisplayWinBottomOffset;
-
-    dstVuiPtr->vuiTimingInfoPresentFlag = srcVuiPtr->vuiTimingInfoPresentFlag;
-    dstVuiPtr->vuiNumUnitsInTick = srcVuiPtr->vuiNumUnitsInTick;
-    dstVuiPtr->vuiTimeScale = srcVuiPtr->vuiTimeScale;
-
-    dstVuiPtr->vuiPocPropotionalTimingFlag = srcVuiPtr->vuiPocPropotionalTimingFlag;
-    dstVuiPtr->vuiNumTicksPocDiffOneMinus1 = srcVuiPtr->vuiNumTicksPocDiffOneMinus1;
-
-    dstVuiPtr->vuiHrdParametersPresentFlag = srcVuiPtr->vuiHrdParametersPresentFlag;
-
-    dstVuiPtr->bitstreamRestrictionFlag = srcVuiPtr->bitstreamRestrictionFlag;
-
-    dstVuiPtr->motionVectorsOverPicBoundariesFlag = srcVuiPtr->motionVectorsOverPicBoundariesFlag;
-    dstVuiPtr->restrictedRefPicListsFlag = srcVuiPtr->restrictedRefPicListsFlag;
-
-    dstVuiPtr->minSpatialSegmentationIdc = srcVuiPtr->minSpatialSegmentationIdc;
-    dstVuiPtr->maxBytesPerPicDenom = srcVuiPtr->maxBytesPerPicDenom;
-    dstVuiPtr->maxBitsPerMinCuDenom = srcVuiPtr->maxBitsPerMinCuDenom;
-    dstVuiPtr->log2MaxMvLengthHorizontal = srcVuiPtr->log2MaxMvLengthHorizontal;
-    dstVuiPtr->log2MaxMvLengthVertical = srcVuiPtr->log2MaxMvLengthVertical;
-
-    EB_MEMCPY(
-        dstVuiPtr->hrdParametersPtr,
-        srcVuiPtr->hrdParametersPtr,
-        sizeof(AppHrdParameters_t));
+    EB_MEMCPY(dstVuiPtr, srcVuiPtr, sizeCopy);
+    EB_MEMCPY(dstVuiPtr->hrdParametersPtr, srcVuiPtr->hrdParametersPtr, sizeof(AppHrdParameters_t));
 
     return;
 }

--- a/Source/Lib/Codec/EbSequenceControlSet.c
+++ b/Source/Lib/Codec/EbSequenceControlSet.c
@@ -182,132 +182,21 @@ EB_ERRORTYPE CopySequenceControlSet(
     SequenceControlSet_t *dst,
     SequenceControlSet_t *src)
 {
-    EB_U32  writeCount = 0;
-    EB_U32  segmentIndex = 0;
-    
-    dst->staticConfig               = src->staticConfig;                            writeCount += sizeof(EB_H265_ENC_CONFIGURATION);           
-    dst->encodeContextPtr           = src->encodeContextPtr;                        writeCount += sizeof(EncodeContext_t*);            
-    dst->spsId                      = src->spsId;                                   writeCount += sizeof(EB_U32);
-    dst->vpsId                      = src->vpsId;                                   writeCount += sizeof(EB_U32);
-    dst->profileSpace               = src->profileSpace;                            writeCount += sizeof(EB_U32);
-    dst->profileIdc                 = src->profileIdc;                              writeCount += sizeof(EB_U32);                     
-    dst->levelIdc                   = src->levelIdc;                                writeCount += sizeof(EB_U32);                     
-    dst->tierIdc                    = src->tierIdc;                                 writeCount += sizeof(EB_U32);                     
-    dst->chromaFormatIdc            = src->chromaFormatIdc;                         writeCount += sizeof(EB_U32);                     
-    dst->maxTemporalLayers          = src->maxTemporalLayers;                       writeCount += sizeof(EB_U32);                     
-    dst->bitsForPictureOrderCount   = src->bitsForPictureOrderCount;                writeCount += sizeof(EB_U32);                     
-    dst->maxInputLumaWidth          = src->maxInputLumaWidth;                       writeCount += sizeof(EB_U32);                     
-    dst->maxInputLumaHeight         = src->maxInputLumaHeight;                      writeCount += sizeof(EB_U32);  
-    dst->maxInputPadRight           = src->maxInputPadRight;                        writeCount += sizeof(EB_U32);
-    dst->maxInputPadBottom          = src->maxInputPadBottom;                       writeCount += sizeof(EB_U32);
-    dst->lumaWidth                  = src->lumaWidth;                               writeCount += sizeof(EB_U32);                     
-    dst->lumaHeight                 = src->lumaHeight;                              writeCount += sizeof(EB_U32); 
-    dst->chromaWidth                = src->chromaWidth;                             writeCount += sizeof(EB_U32);                     
-    dst->chromaHeight               = src->chromaHeight;                            writeCount += sizeof(EB_U32);                     
-    dst->padRight                   = src->padRight;                                writeCount += sizeof(EB_U32);
-    dst->padBottom                  = src->padBottom;                               writeCount += sizeof(EB_U32);
-	dst->croppingLeftOffset         = src->croppingLeftOffset;                      writeCount += sizeof(EB_S32);     
-    dst->croppingRightOffset        = src->croppingRightOffset;                     writeCount += sizeof(EB_S32);     
-    dst->croppingTopOffset          = src->croppingTopOffset;                       writeCount += sizeof(EB_S32);
-    dst->croppingBottomOffset       = src->croppingBottomOffset;                    writeCount += sizeof(EB_S32);
-    dst->conformanceWindowFlag      = src->conformanceWindowFlag;                   writeCount += sizeof(EB_U32);  
-    dst->frameRate                  = src->frameRate;                               writeCount += sizeof(EB_U32);                     
-    dst->inputBitdepth              = src->inputBitdepth;                           writeCount += sizeof(EB_BITDEPTH);                
-    dst->outputBitdepth             = src->outputBitdepth;                          writeCount += sizeof(EB_BITDEPTH);        
-	dst->predStructPtr              = src->predStructPtr;                           writeCount += sizeof(PredictionStructure_t*);
-    dst->intraPeriodLength          = src->intraPeriodLength;                       writeCount += sizeof(EB_S32);                     
-    dst->intraRefreshType           = src->intraRefreshType;                        writeCount += sizeof(EB_U32);  
-    dst->maxRefCount                = src->maxRefCount;                             writeCount += sizeof(EB_U32);
-    dst->lcuSize                    = src->lcuSize;                                 writeCount += sizeof(EB_U32);                     
-    dst->maxLcuDepth                = src->maxLcuDepth;                             writeCount += sizeof(EB_U32);
-                                                               
-    dst->interlacedVideo            = src->interlacedVideo ;                        writeCount += sizeof(EB_BOOL);
-                                                                              
-    dst->generalProgressiveSourceFlag   = src->generalProgressiveSourceFlag;        writeCount += sizeof(EB_U32);
-    dst->generalInterlacedSourceFlag    = src->generalInterlacedSourceFlag;         writeCount += sizeof(EB_U32);
-    dst->generalFrameOnlyConstraintFlag = src->generalFrameOnlyConstraintFlag;      writeCount += sizeof(EB_U32);
-    dst->targetBitrate              = src->targetBitrate;                           writeCount += sizeof(EB_U32);                     
-    dst->availableBandwidth         = src->availableBandwidth;                      writeCount += sizeof(EB_U32);                     
-    dst->qp                         = src->qp;                                      writeCount += sizeof(EB_U32);   
-    dst->enableQpScalingFlag        = src->enableQpScalingFlag;                     writeCount += sizeof(EB_BOOL);                  
-    dst->enableTmvpSps              = src->enableTmvpSps;                           writeCount += sizeof(EB_U32);   
-    dst->mvMergeTotalCount          = src->mvMergeTotalCount;                       writeCount += sizeof(EB_U32);            
-    dst->leftPadding                = src->leftPadding;                             writeCount += sizeof(EB_U16);
-    dst->rightPadding               = src->rightPadding;                            writeCount += sizeof(EB_U16);
-    dst->topPadding                 = src->topPadding;                              writeCount += sizeof(EB_U16);
-    dst->botPadding                 = src->botPadding;                              writeCount += sizeof(EB_U16);         
-    dst->enableDenoiseFlag          = src->enableDenoiseFlag;                       writeCount += sizeof(EB_BOOL);
-    dst->maxEncMode                 = src->maxEncMode;                              writeCount += sizeof(EB_U8);
+    AppVideoUsabilityInfo_t *videoUsabilityInfoPtr = dst->videoUsabilityInfoPtr;
+    size_t sizeCopy = (size_t)((EB_U64)(&dst->pictureControlSetPoolInitCount) -
+                               (EB_U64)(&dst->staticConfig));
 
-    // Segments
-    for (segmentIndex = 0; segmentIndex < MAX_TEMPORAL_LAYERS; ++segmentIndex) {
-        dst->meSegmentColumnCountArray[segmentIndex] = src->meSegmentColumnCountArray[segmentIndex]; writeCount += sizeof(EB_U32);
-        dst->meSegmentRowCountArray[segmentIndex] = src->meSegmentRowCountArray[segmentIndex]; writeCount += sizeof(EB_U32);
-        dst->encDecSegmentColCountArray[segmentIndex] = src->encDecSegmentColCountArray[segmentIndex]; writeCount += sizeof(EB_U32);
-        dst->encDecSegmentRowCountArray[segmentIndex] = src->encDecSegmentRowCountArray[segmentIndex]; writeCount += sizeof(EB_U32);
-    }
+    EB_MEMCPY(&dst->staticConfig, &src->staticConfig, sizeCopy);
 
-    EB_MEMCPY(
-        &dst->bufferingPeriod,
-        &src->bufferingPeriod,
-        sizeof(AppBufferingPeriodSei_t));
-
-    writeCount += sizeof(AppBufferingPeriodSei_t);
-
-    EB_MEMCPY(
-        &dst->activeParameterSet,
-        &src->activeParameterSet,
-        sizeof(AppActiveparameterSetSei_t));
-
-    writeCount += sizeof(AppActiveparameterSetSei_t);
-
-    EB_MEMCPY(
-        &dst->recoveryPoint,
-        &src->recoveryPoint,
-        sizeof(AppRecoveryPoint_t));
-
-    writeCount += sizeof(AppRecoveryPoint_t);
-
-    EB_MEMCPY(
-        &dst->contentLightLevel,
-        &src->contentLightLevel,
-        sizeof(AppContentLightLevelSei_t));
-
-    writeCount += sizeof(AppContentLightLevelSei_t);
-
-    EB_MEMCPY(
-        &dst->masteringDisplayColorVolume,
-        &src->masteringDisplayColorVolume,
-        sizeof(AppMasteringDisplayColorVolumeSei_t));
-
-    writeCount += sizeof(AppMasteringDisplayColorVolumeSei_t);
-
-    EB_MEMCPY(
-        &dst->picTimingSei,
-        &src->picTimingSei,
-        sizeof(AppPictureTimingSei_t));
-
-    writeCount += sizeof(AppPictureTimingSei_t);
-
-    EB_MEMCPY(
-        &dst->regUserDataSeiPtr,
-        &src->regUserDataSeiPtr,
-        sizeof(RegistedUserData_t));
-
-    writeCount += sizeof(RegistedUserData_t);
-
-    EB_MEMCPY(
-        &dst->unRegUserDataSeiPtr,
-        &src->unRegUserDataSeiPtr,
-        sizeof(UnregistedUserData_t));
-
-    writeCount += sizeof(UnregistedUserData_t);
-
+    dst->videoUsabilityInfoPtr = videoUsabilityInfoPtr;
     EbVideoUsabilityInfoCopy(
         dst->videoUsabilityInfoPtr,
         src->videoUsabilityInfoPtr);
-    
-    writeCount += sizeof(AppVideoUsabilityInfo_t*); 
+
+    dst->enableDenoiseFlag = src->enableDenoiseFlag;
+    dst->maxEncMode        = src->maxEncMode;
+
+    EB_MEMCPY(&dst->activeParameterSet, &src->activeParameterSet, sizeof(AppActiveparameterSetSei_t));
 
     return EB_ErrorNone;
 }

--- a/Source/Lib/Codec/EbSequenceControlSet.h
+++ b/Source/Lib/Codec/EbSequenceControlSet.h
@@ -22,7 +22,7 @@ extern "C" {
  * Sequence Control Set
  ************************************/
 typedef struct SequenceControlSet_s
-{        
+{
     EB_H265_ENC_CONFIGURATION   staticConfig;
 
     // Encoding Context
@@ -36,18 +36,18 @@ typedef struct SequenceControlSet_s
     EB_U32                      levelIdc;
     EB_U32                      tierIdc;
     EB_U32                      chromaFormatIdc;
-    EB_U32                      maxTemporalLayers;                  
+    EB_U32                      maxTemporalLayers;
     EB_U32                      bitsForPictureOrderCount;
-    
+
     // Picture deminsions
-	EB_U16                      maxInputLumaWidth;
-	EB_U16                      maxInputLumaHeight;
-	//EB_U16                      maxInputChromaWidth;
-	//EB_U16                      maxInputChromaHeight; 
-	EB_U16                      maxInputPadRight;
-	EB_U16                      maxInputPadBottom;
+    EB_U16                      maxInputLumaWidth;
+    EB_U16                      maxInputLumaHeight;
+    //EB_U16                    maxInputChromaWidth;
+    //EB_U16                    maxInputChromaHeight; 
+    EB_U16                      maxInputPadRight;
+    EB_U16                      maxInputPadBottom;
     EB_U16                      lumaWidth;
-	EB_U16                      lumaHeight;
+    EB_U16                      lumaHeight;
     EB_U32                      chromaWidth;
     EB_U32                      chromaHeight;
     EB_U32                      padRight;
@@ -57,11 +57,10 @@ typedef struct SequenceControlSet_s
     EB_U16                      rightPadding;
     EB_U16                      botPadding;
 
-
     EB_U32                      frameRate;  
     EB_U32                      encoderBitDepth;
 
-	// Cropping Definitions    
+    // Cropping Definitions
     EB_S32                      croppingLeftOffset;
     EB_S32                      croppingRightOffset;
     EB_S32                      croppingTopOffset;
@@ -141,11 +140,11 @@ typedef struct SequenceControlSet_s
     EB_U32                      maxDpbSize;
     
     // Picture Analysis
-	EB_U32						pictureAnalysisNumberOfRegionsPerWidth;
-	EB_U32						pictureAnalysisNumberOfRegionsPerHeight;
+    EB_U32                      pictureAnalysisNumberOfRegionsPerWidth;
+    EB_U32                      pictureAnalysisNumberOfRegionsPerHeight;
 
-	// A picure is marked as active if the number of active regions is higher than pictureActivityRegionTh
-	EB_U32						pictureActivityRegionTh;
+    // A picture is marked as active if the number of active regions is higher than pictureActivityRegionTh
+    EB_U32                      pictureActivityRegionTh;
 
     // Segments
     EB_U32                     meSegmentColumnCountArray[MAX_TEMPORAL_LAYERS];
@@ -154,41 +153,41 @@ typedef struct SequenceControlSet_s
     EB_U32                     encDecSegmentRowCountArray[MAX_TEMPORAL_LAYERS];
 
     // Buffers
-	EB_U32						pictureControlSetPoolInitCount;      
-	EB_U32						pictureControlSetPoolInitCountChild; 
-	EB_U32						paReferencePictureBufferInitCount;
-	EB_U32						referencePictureBufferInitCount;
+    EB_U32                      pictureControlSetPoolInitCount;      
+    EB_U32                      pictureControlSetPoolInitCountChild; 
+    EB_U32                      paReferencePictureBufferInitCount;
+    EB_U32                      referencePictureBufferInitCount;
     EB_U32                      reconBufferFifoInitCount;
-	EB_U32						inputOutputBufferFifoInitCount;
-	EB_U32						resourceCoordinationFifoInitCount;     
-	EB_U32						pictureAnalysisFifoInitCount;
-	EB_U32						pictureDecisionFifoInitCount;
-	EB_U32						motionEstimationFifoInitCount;
-	EB_U32						initialRateControlFifoInitCount;
-	EB_U32						pictureDemuxFifoInitCount;             
-	EB_U32						rateControlTasksFifoInitCount;           
-	EB_U32						rateControlFifoInitCount;                
-	EB_U32						modeDecisionConfigurationFifoInitCount;
-	//EB_U32						modeDecisionFifoInitCount;            
-	EB_U32						encDecFifoInitCount;
-	EB_U32						entropyCodingFifoInitCount;
-	EB_U32						pictureAnalysisProcessInitCount;     
-	EB_U32						motionEstimationProcessInitCount; 
-	EB_U32						sourceBasedOperationsProcessInitCount;
-	EB_U32						modeDecisionConfigurationProcessInitCount; 
-    EB_U32						encDecProcessInitCount;
-    EB_U32						entropyCodingProcessInitCount;
+    EB_U32                      inputOutputBufferFifoInitCount;
+    EB_U32                      resourceCoordinationFifoInitCount;     
+    EB_U32                      pictureAnalysisFifoInitCount;
+    EB_U32                      pictureDecisionFifoInitCount;
+    EB_U32                      motionEstimationFifoInitCount;
+    EB_U32                      initialRateControlFifoInitCount;
+    EB_U32                      pictureDemuxFifoInitCount;             
+    EB_U32                      rateControlTasksFifoInitCount;           
+    EB_U32                      rateControlFifoInitCount;                
+    EB_U32                      modeDecisionConfigurationFifoInitCount;
+    //EB_U32                    modeDecisionFifoInitCount;            
+    EB_U32                      encDecFifoInitCount;
+    EB_U32                      entropyCodingFifoInitCount;
+    EB_U32                      pictureAnalysisProcessInitCount;     
+    EB_U32                      motionEstimationProcessInitCount; 
+    EB_U32                      sourceBasedOperationsProcessInitCount;
+    EB_U32                      modeDecisionConfigurationProcessInitCount; 
+    EB_U32                      encDecProcessInitCount;
+    EB_U32                      entropyCodingProcessInitCount;
 
-    EB_U32						totalProcessInitCount;
+    EB_U32                      totalProcessInitCount;
 
-	LcuParams_t                *lcuParamsArray;
-    EB_U8 						pictureWidthInLcu;
-	EB_U8 						pictureHeightInLcu;
-	EB_U16						lcuTotalCount;
-	EB_INPUT_RESOLUTION			inputResolution;
-	EB_SCD_MODE  				scdMode;
+    LcuParams_t                *lcuParamsArray;
+    EB_U8                       pictureWidthInLcu;
+    EB_U8                       pictureHeightInLcu;
+    EB_U16                      lcuTotalCount;
+    EB_INPUT_RESOLUTION         inputResolution;
+    EB_SCD_MODE                 scdMode;
 
-    EB_BOOL				        enableDenoiseFlag;
+    EB_BOOL                     enableDenoiseFlag;
 
     EB_U8                       transCoeffShapeArray[2][8][4];    // [componantTypeIndex][resolutionIndex][levelIndex][tuSizeIndex]
 
@@ -220,7 +219,7 @@ extern EB_ERRORTYPE EbSequenceControlSetCtor(
     EB_PTR                           objectInitDataPtr);
     
 
-    
+
 extern EB_ERRORTYPE CopySequenceControlSet(
     SequenceControlSet_t            *dst,
     SequenceControlSet_t            *src);
@@ -231,13 +230,13 @@ extern EB_ERRORTYPE EbSequenceControlSetInstanceCtor(
 
 
 extern EB_ERRORTYPE LcuParamsCtor(
-	SequenceControlSet_t *sequenceControlSetPtr);
+    SequenceControlSet_t *sequenceControlSetPtr);
 
 extern EB_ERRORTYPE LcuParamsInit(
-	SequenceControlSet_t *sequenceControlSetPtr);
+    SequenceControlSet_t *sequenceControlSetPtr);
 extern EB_ERRORTYPE DeriveInputResolution(
-	SequenceControlSet_t *sequenceControlSetPtr,
-	EB_U32				  inputSize);
+    SequenceControlSet_t *sequenceControlSetPtr,
+    EB_U32                inputSize);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
1) In function `CopySequenceControlSet()`, paramters were assigned one by one. This would introde bugs if some parameters were not set. I followed the assignements here and copied the beging part started with `staticConfig` and ended with `pictureControlSetPoolInitCount`.
Actually, parameters like `enableStrongIntraSmoothing`, `reduceCodingLoopCandidates`, `maxDpbSize` and other parametres were missing in the former version.

2) In the 2nd commit, `encoderBitDepth` parameter was assigned with the video size and the long expression `contextPtr->sequenceControlSetInstanceArray[instanceIndex]->sequenceControlSetPtr` was replaced by the local variable `sequenceControlSetPtr` .