### PR TITLE
Fix Rate-Distortion Cost derivation error in RDOQ of chroma component

### DIFF
--- a/Source/Lib/Codec/EbTransforms.c
+++ b/Source/Lib/Codec/EbTransforms.c
@@ -2768,10 +2768,10 @@ void DecoupledQuantizeInvQuantizeLoops(
                                 rdoqError[iteration] = (((rdoqError[iteration] * ChromaWeightFactorRaNonRef[qp]) + CHROMA_WEIGHT_OFFSET) >> CHROMA_WEIGHT_SHIFT);
                             }
 
-                            rdoqCost[iteration] = ((rdoqError[iteration]) << COST_PRECISION) + (((lambda * rdoqBits[iteration]) + MD_OFFSET) >> MD_SHIFT);
+                            rdoqCost[iteration] = rdoqError[iteration] + (((lambda * rdoqBits[iteration]) + MD_OFFSET) >> MD_SHIFT);
                         }
                         else {
-                            rdoqCost[iteration] = ((rdoqError[iteration]) << COST_PRECISION) + (((lambda * rdoqBits[iteration]) + MD_OFFSET) >> MD_SHIFT);
+                            rdoqCost[iteration] = (rdoqError[iteration] << COST_PRECISION) + (((lambda * rdoqBits[iteration]) + MD_OFFSET) >> MD_SHIFT);
                         }
 
                         if (rdoqCost[iteration] < bestCost) {
@@ -2926,10 +2926,12 @@ void DecoupledQuantizeInvQuantizeLoops(
 							else {
 								sse[DIST_CALC_RESIDUAL] = (((sse[DIST_CALC_RESIDUAL] * ChromaWeightFactorRaNonRef[qp]) + CHROMA_WEIGHT_OFFSET) >> CHROMA_WEIGHT_SHIFT);
 							}
-						}
-						
 
-						pmCand->cost  = ((sse[DIST_CALC_RESIDUAL]) << COST_PRECISION) + (((lambda * coeffBits) + MD_OFFSET) >> MD_SHIFT);
+							pmCand->cost = sse[DIST_CALC_RESIDUAL] + (((lambda * coeffBits) + MD_OFFSET) >> MD_SHIFT);
+						} else {
+							pmCand->cost = (sse[DIST_CALC_RESIDUAL] << COST_PRECISION) + (((lambda * coeffBits) + MD_OFFSET) >> MD_SHIFT);
+						}
+
 
 						//determine best cost
 						if (pmCand->cost < bestCost){


### PR DESCRIPTION
In RDOQ, the chroma distortion has been scaled twice and the second part is not needed. With this issue fixed, the efficiency in luma component would increase.

Firstly, the chroma distortion was scaled by a weighting factor as follows,
```c++
rdoqError[iteration] = (((rdoqError[iteration] * ChromaWeightFactorRaBase[qp]) + CHROMA_WEIGHT_OFFSET) >> CHROMA_WEIGHT_SHIFT);
```
Secondly, the scaled distortions was scaled again like the `Luma` component as follows.
```c++
rdoqCost[iteration] = ((rdoqError[iteration]) << COST_PRECISION) + (((lambda * rdoqBits[iteration]) + MD_OFFSET) >> MD_SHIFT);
```
However, I think the second scaling process is not needed and should be removed.

For reference, we can found the RDCost derivation in `EbRateDistortionCost.c` as follows,
```c++
    // Compute Cost
    lumaSse = yDistortion[0];
    chromaSse = cbDistortion[0] + crDistortion[0];


    // *Note - As of Oct 2011, the JCT-VC uses the PSNR forumula
    //  PSNR = (LUMA_WEIGHT * PSNRy + PSNRu + PSNRv) / (2+LUMA_WEIGHT)
    lumaSse = LUMA_WEIGHT * (lumaSse << COST_PRECISION);

    // *Note - As in JCTVC-G1102, the JCT-VC uses the Mode Decision forumula where the chromaSse has been weighted
    //  CostMode = (lumaSse + wchroma * chromaSse) + lambdaSse * rateMode

    if (pictureControlSetPtr->ParentPcsPtr->predStructure == EB_PRED_RANDOM_ACCESS) {
        // Random Access
        if (pictureControlSetPtr->temporalLayerIndex == 0) {
        chromaSse = (((chromaSse * ChromaWeightFactorRaBase[qp]) + CHROMA_WEIGHT_OFFSET) >> CHROMA_WEIGHT_SHIFT);
        }
        else if (pictureControlSetPtr->ParentPcsPtr->isUsedAsReferenceFlag) {
        chromaSse = (((chromaSse * ChromaWeightFactorRaRefNonBase[qp]) + CHROMA_WEIGHT_OFFSET) >> CHROMA_WEIGHT_SHIFT);
        }
        else {
        chromaSse = (((chromaSse * ChromaWeightFactorRaNonRef[qp]) + CHROMA_WEIGHT_OFFSET) >> CHROMA_WEIGHT_SHIFT);
        }
    }
    else {
        // Low delay
        if (pictureControlSetPtr->temporalLayerIndex == 0) {
        chromaSse = (((chromaSse * ChromaWeightFactorLd[qp]) + CHROMA_WEIGHT_OFFSET) >> CHROMA_WEIGHT_SHIFT);
        }
        else {
        chromaSse = (((chromaSse * ChromaWeightFactorLdQpScaling[qp]) + CHROMA_WEIGHT_OFFSET) >> CHROMA_WEIGHT_SHIFT);
        }
    }

    distortion = lumaSse + chromaSse;

    // Assign full cost
    *candidateBufferPtr->fullCostPtr = distortion + (((lambda * coeffRate + lambda * lumaRate + lambdaChroma * chromaRate) + MD_OFFSET) >> MD_SHIFT);
```