### PR TITLE
Fix typo for YUV422P10 since it was missing from the list.

### DIFF
--- a/ffmpeg_plugin/0001-lavc-svt_hevc-add-libsvt-hevc-encoder-wrapper.patch
+++ b/ffmpeg_plugin/0001-lavc-svt_hevc-add-libsvt-hevc-encoder-wrapper.patch
@@ -573,7 +573,7 @@ index 0000000..d9ac04c
 +    .pix_fmts       = (const enum AVPixelFormat[]){ AV_PIX_FMT_YUV420P,
 +                                                    AV_PIX_FMT_YUV420P10,
 +                                                    AV_PIX_FMT_YUV422P,
-+                                                    AV_PIX_FMT_YUV420P10,
++                                                    AV_PIX_FMT_YUV422P10,
 +                                                    AV_PIX_FMT_YUV444P,
 +                                                    AV_PIX_FMT_YUV444P10,
 +                                                    AV_PIX_FMT_NONE },


### PR DESCRIPTION
Closes: #285 

Change typo for YUV422P10.