### PR TITLE
Fix bug IntraPeriod = -1

### DIFF
--- a/Source/Lib/Codec/EbEncHandle.c
+++ b/Source/Lib/Codec/EbEncHandle.c
@@ -1683,7 +1683,8 @@ EB_U32 SetParentPcs(EB_H265_ENC_CONFIGURATION*   config)
     fps = fps > 120 ? 120 : fps;
     fps = fps < 24 ? 24 : fps;
 
-    if (((EB_U32)(config->intraPeriodLength) > (fps << 1)) && ((config->sourceWidth * config->sourceHeight) < INPUT_SIZE_4K_TH))
+    
+    if (config->intraPeriodLength >0 && ((EB_U32)(config->intraPeriodLength) > (fps << 1)) && ((config->sourceWidth * config->sourceHeight) < INPUT_SIZE_4K_TH))
         fps = config->intraPeriodLength;
 
     EB_U32     lowLatencyInput = (config->encMode < 6 || config->speedControlFlag == 1) ? fps :

--- a/Source/Lib/Codec/EbEncHandle.c
+++ b/Source/Lib/Codec/EbEncHandle.c
@@ -1682,9 +1682,8 @@ EB_U32 SetParentPcs(EB_H265_ENC_CONFIGURATION*   config)
 
     fps = fps > 120 ? 120 : fps;
     fps = fps < 24 ? 24 : fps;
-
     
-    if (config->intraPeriodLength >0 && ((EB_U32)(config->intraPeriodLength) > (fps << 1)) && ((config->sourceWidth * config->sourceHeight) < INPUT_SIZE_4K_TH))
+    if (config->intraPeriodLength > 0 && ((EB_U32)(config->intraPeriodLength) > (fps << 1)) && ((config->sourceWidth * config->sourceHeight) < INPUT_SIZE_4K_TH))
         fps = config->intraPeriodLength;
 
     EB_U32     lowLatencyInput = (config->encMode < 6 || config->speedControlFlag == 1) ? fps :

--- a/Source/Lib/Codec/EbEncHandle.c
+++ b/Source/Lib/Codec/EbEncHandle.c
@@ -1682,7 +1682,7 @@ EB_U32 SetParentPcs(EB_H265_ENC_CONFIGURATION*   config)
 
     fps = fps > 120 ? 120 : fps;
     fps = fps < 24 ? 24 : fps;
-    
+
     if (config->intraPeriodLength > 0 && ((EB_U32)(config->intraPeriodLength) > (fps << 1)) && ((config->sourceWidth * config->sourceHeight) < INPUT_SIZE_4K_TH))
         fps = config->intraPeriodLength;
 


### PR DESCRIPTION
Handle the case when IntraPeriodLength is equal
to -1 by avoiding a EB_U32 cast.

Encoder was crashing once the fps value was set
to -1

Signed-off-by: Mark Feldman <mark.feldman@intel.com>