### PR TITLE
scan_type is unused but set

### DIFF
--- a/Source/App/EbAppInputy4m.c
+++ b/Source/App/EbAppInputy4m.c
@@ -35,7 +35,10 @@ int32_t read_y4m_header(EbConfig_t *cfg) {
     char *fresult, *tokstart, *tokend, format_str[YFM_HEADER_MAX];
     uint32_t bitdepth = 8, width = 0, height = 0, fr_n = 0,
         fr_d = 0, aspect_n, aspect_d;
-    char chroma[CHROMA_MAX] = "420", scan_type = 'p';
+    char chroma[CHROMA_MAX] = "420";
+#ifdef PRINT_HEADER
+    char scan_type = 'p';
+#endif
     EB_BOOL interlaced = EB_TRUE;
 
     /* pointer to the input file */
@@ -76,15 +79,21 @@ int32_t read_y4m_header(EbConfig_t *cfg) {
             switch (*tokstart++) {
             case 'p':
                 interlaced = EB_FALSE;
+#ifdef PRINT_HEADER
                 scan_type = 'p';
+#endif
                 break;
             case 't':
                 interlaced = EB_TRUE;
+#ifdef PRINT_HEADER
                 scan_type = 't';
+#endif
                 break;
             case 'b':
                 interlaced = EB_TRUE;
+#ifdef PRINT_HEADER
                 scan_type = 'b';
+#endif
                 break;
             case '?':
             default:


### PR DESCRIPTION
The scan_type variable is reported as being
"unused but set variable" when compiling in Linux.

Using the #ifdef PRINT_HEADER preprocessor to hide
it from the compiler

Signed-off-by: Mark Feldman <mark.feldman@intel.com>