### PR TITLE
Remove limitation of less than 16 Sockets

### DIFF
--- a/Source/Lib/Codec/EbEncHandle.c
+++ b/Source/Lib/Codec/EbEncHandle.c
@@ -737,7 +737,7 @@ EB_ERRORTYPE InitThreadManagmentParams(){
     int maxSize = INITIAL_PROCESSOR_GROUP;
     if (processor_id_len < 0 || processor_id_len >= 128) return EB_ErrorInsufficientResources;
     if (physical_id_len < 0 || physical_id_len >= 128) return EB_ErrorInsufficientResources;
-	memset(lpGroup, 0, 16* sizeof(processorGroup));
+    memset(lpGroup, 0, INITIAL_PROCESSOR_GROUP * sizeof(processorGroup));
 
     FILE *fin = fopen("/proc/cpuinfo", "r");
     if (fin) {
@@ -759,9 +759,11 @@ EB_ERRORTYPE InitThreadManagmentParams(){
                 }
                 if (socket_id + 1 > numGroups)
                     numGroups = socket_id + 1;
-                if (socket_id > maxSize) {
-                    maxSize = maxSize*2;
-                    lpGroup = realloc(lpGroup,maxSize*sizeof(processorGroup));
+                if (socket_id >= maxSize) {
+                    maxSize = maxSize * 2;
+                    lpGroup = realloc(lpGroup,maxSize * sizeof(processorGroup));
+                    if (lpGroup == (processorGroup*) EB_NULL) 
+                        return EB_ErrorInsufficientResources; 
                 }
                 lpGroup[socket_id].group[lpGroup[socket_id].num++] = processor_id;
             }

--- a/Source/Lib/Codec/EbEncHandle.c
+++ b/Source/Lib/Codec/EbEncHandle.c
@@ -786,7 +786,6 @@ static EB_ERRORTYPE EbEncHandleCtor(
 {
     EB_U32  instanceIndex;
     EB_ERRORTYPE return_error = EB_ErrorNone;
-
     // Allocate Memory
     EbEncHandle_t *encHandlePtr = (EbEncHandle_t*) malloc(sizeof(EbEncHandle_t));
     *encHandleDblPtr = encHandlePtr;
@@ -796,12 +795,6 @@ static EB_ERRORTYPE EbEncHandleCtor(
     encHandlePtr->memoryMap             = (EbMemoryMapEntry*) malloc(sizeof(EbMemoryMapEntry) * MAX_NUM_PTR);
     encHandlePtr->memoryMapIndex        = 0;
 	encHandlePtr->totalLibMemory		= sizeof(EbEncHandle_t) + sizeof(EbMemoryMapEntry) * MAX_NUM_PTR;
-
-    #if  defined(__linux__)
-        lpGroup = (processorGroup*)malloc(sizeof(processorGroup)*INITIAL_PROCESSOR_GROUP);
-        if (lpGroup == (processorGroup*) EB_NULL)
-            return EB_ErrorInsufficientResources;
-    #endif
 
     // Save Memory Map Pointers
     totalLibMemory                      = &encHandlePtr->totalLibMemory;
@@ -1952,7 +1945,6 @@ EB_API EB_ERRORTYPE EbDeinitEncoder(EB_COMPONENTTYPE *h265EncComponent)
             //(void)(encHandlePtr);
         }
     }
-
     return return_error;
 }
 
@@ -1972,6 +1964,12 @@ EB_API EB_ERRORTYPE EbInitHandle(
 
 {
     EB_ERRORTYPE           return_error = EB_ErrorNone;
+
+    #if  defined(__linux__)
+        lpGroup = (processorGroup*) malloc(sizeof(processorGroup) * INITIAL_PROCESSOR_GROUP);
+        if (lpGroup == (processorGroup*) EB_NULL)
+            return EB_ErrorInsufficientResources;
+    #endif
 
     *pHandle = (EB_COMPONENTTYPE*) malloc(sizeof(EB_COMPONENTTYPE));
     if (*pHandle != (EB_HANDLETYPE) NULL) {

--- a/Source/Lib/Codec/EbEncHandle.c
+++ b/Source/Lib/Codec/EbEncHandle.c
@@ -797,6 +797,8 @@ static EB_ERRORTYPE EbEncHandleCtor(
 
     #if  defined(__linux__)
         lpGroup = (processorGroup*)malloc(sizeof(processorGroup)*INITIAL_PROCESSOR_GROUP);
+        if (lpGroup == (processorGroup*) EB_NULL)
+            return EB_ErrorInsufficientResources;
     #endif
 
     // Save Memory Map Pointers
@@ -1924,7 +1926,6 @@ EB_API EB_ERRORTYPE EbDeinitEncoder(EB_COMPONENTTYPE *h265EncComponent)
 #ifdef _WIN32
             _aligned_free(memoryEntry->ptr);
 #else
-            free(lpGroup);
             free(memoryEntry->ptr);
 #endif
             break;
@@ -2032,6 +2033,10 @@ EB_API EB_ERRORTYPE EbDeinitHandle(
     else {
         return_error = EB_ErrorInvalidComponent;
     }
+
+    #if  defined(__linux__)
+        free(lpGroup);
+    #endif
 
     return return_error;
 }

--- a/Source/Lib/Codec/EbEncHandle.c
+++ b/Source/Lib/Codec/EbEncHandle.c
@@ -481,8 +481,8 @@ typedef struct logicalProcessorGroup {
     uint32_t num;
     uint32_t group[1024];
 }processorGroup;
-#define MAX_PROCESSOR_GROUP 16
-processorGroup                   lpGroup[MAX_PROCESSOR_GROUP];
+#define INITIAL_PROCESSOR_GROUP 16
+processorGroup                  *lpGroup;
 #endif
 
 /**************************************
@@ -734,9 +734,10 @@ EB_ERRORTYPE InitThreadManagmentParams(){
     const char* PHYSICALID = "physical id";
     int processor_id_len = strnlen_ss(PROCESSORID, 128);
     int physical_id_len = strnlen_ss(PHYSICALID, 128);
+	int maxSize = INITIAL_PROCESSOR_GROUP;
     if (processor_id_len < 0 || processor_id_len >= 128) return EB_ErrorInsufficientResources;
     if (physical_id_len < 0 || physical_id_len >= 128) return EB_ErrorInsufficientResources;
-    memset(lpGroup, 0, 16* sizeof(processorGroup));
+	memset(lpGroup, 0, 16* sizeof(processorGroup));
 
     FILE *fin = fopen("/proc/cpuinfo", "r");
     if (fin) {
@@ -752,12 +753,16 @@ EB_ERRORTYPE InitThreadManagmentParams(){
                 char* p = line + physical_id_len;
                 while(*p < '0' || *p > '9') p++;
                 socket_id = strtol(p, NULL, 0);
-                if (socket_id < 0 || socket_id > 15) {
+                if (socket_id < 0) {
                     fclose(fin);
                     return EB_ErrorInsufficientResources;
                 }
                 if (socket_id + 1 > numGroups)
                     numGroups = socket_id + 1;
+				if (socket_id > maxSize) {
+					maxSize = maxSize+16;
+					lpGroup = realloc(lpGroup,maxSize*sizeof(processorGroup));
+				}
                 lpGroup[socket_id].group[lpGroup[socket_id].num++] = processor_id;
             }
         }
@@ -779,6 +784,7 @@ static EB_ERRORTYPE EbEncHandleCtor(
 {
     EB_U32  instanceIndex;
     EB_ERRORTYPE return_error = EB_ErrorNone;
+
     // Allocate Memory
     EbEncHandle_t *encHandlePtr = (EbEncHandle_t*) malloc(sizeof(EbEncHandle_t));
     *encHandleDblPtr = encHandlePtr;
@@ -788,6 +794,8 @@ static EB_ERRORTYPE EbEncHandleCtor(
     encHandlePtr->memoryMap             = (EbMemoryMapEntry*) malloc(sizeof(EbMemoryMapEntry) * MAX_NUM_PTR);
     encHandlePtr->memoryMapIndex        = 0;
 	encHandlePtr->totalLibMemory		= sizeof(EbEncHandle_t) + sizeof(EbMemoryMapEntry) * MAX_NUM_PTR;
+
+    lpGroup = (processorGroup*)malloc(sizeof(processorGroup)*INITIAL_PROCESSOR_GROUP);
 
     // Save Memory Map Pointers
     totalLibMemory                      = &encHandlePtr->totalLibMemory;
@@ -1938,6 +1946,9 @@ EB_API EB_ERRORTYPE EbDeinitEncoder(EB_COMPONENTTYPE *h265EncComponent)
             //(void)(encHandlePtr);
         }
     }
+
+	free(lpGroup);
+
     return return_error;
 }
 

--- a/Source/Lib/Codec/EbEncHandle.c
+++ b/Source/Lib/Codec/EbEncHandle.c
@@ -760,7 +760,7 @@ EB_ERRORTYPE InitThreadManagmentParams(){
                 if (socket_id + 1 > numGroups)
                     numGroups = socket_id + 1;
                 if (socket_id > maxSize) {
-                    maxSize = maxSize+16;
+                    maxSize = maxSize*2;
                     lpGroup = realloc(lpGroup,maxSize*sizeof(processorGroup));
                 }
                 lpGroup[socket_id].group[lpGroup[socket_id].num++] = processor_id;

--- a/Source/Lib/Codec/EbEncHandle.c
+++ b/Source/Lib/Codec/EbEncHandle.c
@@ -734,7 +734,7 @@ EB_ERRORTYPE InitThreadManagmentParams(){
     const char* PHYSICALID = "physical id";
     int processor_id_len = strnlen_ss(PROCESSORID, 128);
     int physical_id_len = strnlen_ss(PHYSICALID, 128);
-	int maxSize = INITIAL_PROCESSOR_GROUP;
+    int maxSize = INITIAL_PROCESSOR_GROUP;
     if (processor_id_len < 0 || processor_id_len >= 128) return EB_ErrorInsufficientResources;
     if (physical_id_len < 0 || physical_id_len >= 128) return EB_ErrorInsufficientResources;
 	memset(lpGroup, 0, 16* sizeof(processorGroup));
@@ -759,10 +759,10 @@ EB_ERRORTYPE InitThreadManagmentParams(){
                 }
                 if (socket_id + 1 > numGroups)
                     numGroups = socket_id + 1;
-				if (socket_id > maxSize) {
-					maxSize = maxSize+16;
-					lpGroup = realloc(lpGroup,maxSize*sizeof(processorGroup));
-				}
+                if (socket_id > maxSize) {
+                    maxSize = maxSize+16;
+                    lpGroup = realloc(lpGroup,maxSize*sizeof(processorGroup));
+                }
                 lpGroup[socket_id].group[lpGroup[socket_id].num++] = processor_id;
             }
         }
@@ -1947,7 +1947,7 @@ EB_API EB_ERRORTYPE EbDeinitEncoder(EB_COMPONENTTYPE *h265EncComponent)
         }
     }
 
-	free(lpGroup);
+    free(lpGroup);
 
     return return_error;
 }

--- a/Source/Lib/Codec/EbEncHandle.c
+++ b/Source/Lib/Codec/EbEncHandle.c
@@ -795,7 +795,9 @@ static EB_ERRORTYPE EbEncHandleCtor(
     encHandlePtr->memoryMapIndex        = 0;
 	encHandlePtr->totalLibMemory		= sizeof(EbEncHandle_t) + sizeof(EbMemoryMapEntry) * MAX_NUM_PTR;
 
-    lpGroup = (processorGroup*)malloc(sizeof(processorGroup)*INITIAL_PROCESSOR_GROUP);
+    #if  defined(__linux__)
+        lpGroup = (processorGroup*)malloc(sizeof(processorGroup)*INITIAL_PROCESSOR_GROUP);
+    #endif
 
     // Save Memory Map Pointers
     totalLibMemory                      = &encHandlePtr->totalLibMemory;
@@ -1922,6 +1924,7 @@ EB_API EB_ERRORTYPE EbDeinitEncoder(EB_COMPONENTTYPE *h265EncComponent)
 #ifdef _WIN32
             _aligned_free(memoryEntry->ptr);
 #else
+            free(lpGroup);
             free(memoryEntry->ptr);
 #endif
             break;
@@ -1946,8 +1949,6 @@ EB_API EB_ERRORTYPE EbDeinitEncoder(EB_COMPONENTTYPE *h265EncComponent)
             //(void)(encHandlePtr);
         }
     }
-
-    free(lpGroup);
 
     return return_error;
 }

--- a/Source/Lib/Codec/EbEncHandle.c
+++ b/Source/Lib/Codec/EbEncHandle.c
@@ -482,7 +482,7 @@ typedef struct logicalProcessorGroup {
     uint32_t group[1024];
 }processorGroup;
 #define INITIAL_PROCESSOR_GROUP 16
-processorGroup                  *lpGroup;
+processorGroup                  *lpGroup = EB_NULL;
 #endif
 
 /**************************************


### PR DESCRIPTION
This is referencing #181 

There was a socket_id > 15 clause that would cause it to throw an error on any machine with 16 or more sockets. While this would never occur with physical hardware it is possible to occur with virtual machines. Virtual machines can configure their systems to do 1 socket per core or really anything. Here is the lscpu of my configuration that I used to validate. Unfortunately I can only test up to 64 sockets with my little 8 core, anymore than that and the VM does not boot. I tested this via ffmpeg and stopped it after it encoded a about 20 seconds or so and it looks like it is encoding just fine. I would like it if other people validated this with their machines with higher counts if possible, I do not know if it will work if you go passed 128 due to there being what looks like a similar limitation on the cpu side but that looks like it might be a due to just the or clause here
https://github.com/OpenVisualCloud/SVT-HEVC/blob/835ec04a4bc9430169657abce5e41cdc6a73f129/Source/Lib/Codec/EbEncHandle.c#L737-L738

```
luis@clearlinux~/Desktop/SVT-HEVC $ lscpu
Architecture:        x86_64
CPU op-mode(s):      32-bit, 64-bit
Byte Order:          Little Endian
Address sizes:       40 bits physical, 48 bits virtual
CPU(s):              64
On-line CPU(s) list: 0-63
Thread(s) per core:  1
Core(s) per socket:  1
Socket(s):           64
NUMA node(s):        1
Vendor ID:           AuthenticAMD
CPU family:          23
Model:               1
Model name:          AMD Ryzen 7 1700 Eight-Core Processor
Stepping:            1
CPU MHz:             2994.302
BogoMIPS:            5988.60
Virtualization:      AMD-V
L1d cache:           64K
L1i cache:           64K
L2 cache:            512K
L3 cache:            16384K
NUMA node0 CPU(s):   0-63
Flags:               fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush mmx fxsr sse sse2 syscall nx mmxext fxsr_opt pdpe1gb rdtscp lm rep_good nopl cpuid extd_apicid pni pclmulqdq ssse3 fma cx16 sse4_1 sse4_2 x2apic movbe popcnt tsc_deadline_timer aes xsave avx f16c rdrand hypervisor lahf_lm cmp_legacy svm cr8_legacy abm sse4a misalignsse 3dnowprefetch osvw perfctr_core ssbd ibpb vmmcall fsgsbase tsc_adjust bmi1 avx2 smep bmi2 rdseed adx smap clflushopt sha_ni xsaveopt xsavec xgetbv1 virt_ssbd arat npt nrip_save
```