### PR TITLE
Add vbv maxrate and bufsize to ffmpeg plugin

### DIFF
--- a/ffmpeg_plugin/0001-lavc-svt_hevc-add-libsvt-hevc-encoder-wrapper.patch
+++ b/ffmpeg_plugin/0001-lavc-svt_hevc-add-libsvt-hevc-encoder-wrapper.patch
@@ -1,7 +1,7 @@
-From a6f622288d6d26b7eddf02dbc4dea8f7d5788a93 Mon Sep 17 00:00:00 2001
+From bbae368ab44f7722777727b2cce48d11a3970323 Mon Sep 17 00:00:00 2001
 From: Jing Sun <jing.a.sun@intel.com>
 Date: Wed, 21 Nov 2018 11:33:04 +0800
-Subject: [PATCH 1/1] lavc/svt_hevc: add libsvt hevc encoder wrapper
+Subject: [PATCH] lavc/svt_hevc: add libsvt hevc encoder wrapper
 
 Signed-off-by: Zhengxu Huang <zhengxu.huang@intel.com>
 Signed-off-by: Hassene Tmar <hassene.tmar@intel.com>
@@ -11,15 +11,15 @@ Signed-off-by: Jing Sun <jing.a.sun@intel.com>
  configure                |   4 +
  libavcodec/Makefile      |   1 +
  libavcodec/allcodecs.c   |   1 +
- libavcodec/libsvt_hevc.c | 501 +++++++++++++++++++++++++++++++++++++++++++++++
- 4 files changed, 507 insertions(+)
+ libavcodec/libsvt_hevc.c | 502 +++++++++++++++++++++++++++++++++++++++
+ 4 files changed, 508 insertions(+)
  create mode 100644 libavcodec/libsvt_hevc.c
 
 diff --git a/configure b/configure
-index a9644e2..2f61c82 100755
+index 3fb8f3521d..e111e1ae59 100755
 --- a/configure
 +++ b/configure
-@@ -262,6 +262,7 @@ External library support:
+@@ -264,6 +264,7 @@ External library support:
    --enable-libspeex        enable Speex de/encoding via libspeex [no]
    --enable-libsrt          enable Haivision SRT protocol via libsrt [no]
    --enable-libssh          enable SFTP protocol via libssh [no]
@@ -27,7 +27,7 @@ index a9644e2..2f61c82 100755
    --enable-libtensorflow   enable TensorFlow as a DNN module backend
                             for DNN based filters like sr [no]
    --enable-libtesseract    enable Tesseract, needed for ocr filter [no]
-@@ -1743,6 +1744,7 @@ EXTERNAL_LIBRARY_LIST="
+@@ -1793,6 +1794,7 @@ EXTERNAL_LIBRARY_LIST="
      libspeex
      libsrt
      libssh
@@ -35,7 +35,7 @@ index a9644e2..2f61c82 100755
      libtensorflow
      libtesseract
      libtheora
-@@ -3125,6 +3127,7 @@ libshine_encoder_select="audio_frame_queue"
+@@ -3194,6 +3196,7 @@ libshine_encoder_select="audio_frame_queue"
  libspeex_decoder_deps="libspeex"
  libspeex_encoder_deps="libspeex"
  libspeex_encoder_select="audio_frame_queue"
@@ -43,7 +43,7 @@ index a9644e2..2f61c82 100755
  libtheora_encoder_deps="libtheora"
  libtwolame_encoder_deps="libtwolame"
  libvo_amrwbenc_encoder_deps="libvo_amrwbenc"
-@@ -6135,6 +6138,7 @@ enabled libsoxr           && require libsoxr soxr.h soxr_create -lsoxr
+@@ -6269,6 +6272,7 @@ enabled libsoxr           && require libsoxr soxr.h soxr_create -lsoxr
  enabled libssh            && require_pkg_config libssh libssh libssh/sftp.h sftp_init
  enabled libspeex          && require_pkg_config libspeex speex speex/speex.h speex_decoder_init
  enabled libsrt            && require_pkg_config libsrt "srt >= 1.3.0" srt/srt.h srt_socket
@@ -52,10 +52,10 @@ index a9644e2..2f61c82 100755
  enabled libtesseract      && require_pkg_config libtesseract tesseract tesseract/capi.h TessBaseAPICreate
  enabled libtheora         && require libtheora theora/theoraenc.h th_info_init -ltheoraenc -ltheoradec -logg
 diff --git a/libavcodec/Makefile b/libavcodec/Makefile
-index 3e41497..728503b 100644
+index 3cd73fbcc6..d39f568585 100644
 --- a/libavcodec/Makefile
 +++ b/libavcodec/Makefile
-@@ -981,6 +981,7 @@ OBJS-$(CONFIG_LIBOPUS_ENCODER)            += libopusenc.o libopus.o     \
+@@ -991,6 +991,7 @@ OBJS-$(CONFIG_LIBOPUS_ENCODER)            += libopusenc.o libopus.o     \
  OBJS-$(CONFIG_LIBSHINE_ENCODER)           += libshine.o
  OBJS-$(CONFIG_LIBSPEEX_DECODER)           += libspeexdec.o
  OBJS-$(CONFIG_LIBSPEEX_ENCODER)           += libspeexenc.o
@@ -64,10 +64,10 @@ index 3e41497..728503b 100644
  OBJS-$(CONFIG_LIBTWOLAME_ENCODER)         += libtwolame.o
  OBJS-$(CONFIG_LIBVO_AMRWBENC_ENCODER)     += libvo-amrwbenc.o
 diff --git a/libavcodec/allcodecs.c b/libavcodec/allcodecs.c
-index 1b8144a..5739d53 100644
+index d2f9a39ce5..d8788a7954 100644
 --- a/libavcodec/allcodecs.c
 +++ b/libavcodec/allcodecs.c
-@@ -697,6 +697,7 @@ extern AVCodec ff_librsvg_decoder;
+@@ -707,6 +707,7 @@ extern AVCodec ff_librsvg_decoder;
  extern AVCodec ff_libshine_encoder;
  extern AVCodec ff_libspeex_encoder;
  extern AVCodec ff_libspeex_decoder;
@@ -77,10 +77,10 @@ index 1b8144a..5739d53 100644
  extern AVCodec ff_libvo_amrwbenc_encoder;
 diff --git a/libavcodec/libsvt_hevc.c b/libavcodec/libsvt_hevc.c
 new file mode 100644
-index 0000000..d9ac04c
+index 0000000000..b6924b611f
 --- /dev/null
 +++ b/libavcodec/libsvt_hevc.c
-@@ -0,0 +1,499 @@
+@@ -0,0 +1,502 @@
 +/*
 +* Scalable Video Technology for HEVC encoder library plugin
 +*
@@ -245,6 +245,9 @@ index 0000000..d9ac04c
 +    }
 +
 +    param->targetBitRate = avctx->bit_rate;
++    param->vbvMaxrate = avctx->rc_max_rate;
++    param->vbvBufsize = avctx->rc_buffer_size;
++    param->vbvBufInit = 90;
 +
 +    if (avctx->gop_size > 0)
 +        param->intraPeriodLength = avctx->gop_size - 1;
@@ -581,5 +584,5 @@ index 0000000..d9ac04c
 +    .wrapper_name   = "libsvt_hevc",
 +};
 -- 
-1.8.3.1
+2.22.0
 


### PR DESCRIPTION
I've been testing this on my machine with ffmpeg and noticed that the vbv mode varied significantly in bitrate. This PR allows ffmpeg to set the maximum bitrate and buffer size to allow users to constrain the video stream if needed (for example, when livestreaming).

For some reason vbvBufInit is set to 0 by default in ffmpeg, making the beginning of the video stream very low quality. I'm setting it to 90 manually ([the advertised default](https://github.com/OpenVisualCloud/SVT-HEVC/blob/master/Source/API/EbApi.h#L524)), but I'm sure there is a better solution.