### PR TITLE
Fix infinite loop when encoding with codeVpsSpsPps enabled

### DIFF
--- a/Source/Lib/Codec/EbEntropyCoding.c
+++ b/Source/Lib/Codec/EbEntropyCoding.c
@@ -4744,7 +4744,7 @@ static void WriteUvlc(
 	EB_U32 numberOfBits = 1;
 	EB_U32 tempBits = ++bits;
 
-	while (1 != tempBits)
+	while (tempBits > 1)
 	{
 		tempBits >>= 1;
 		numberOfBits += 2;


### PR DESCRIPTION
I have reported a bug that doesn't end encoding. (https://github.com/OpenVisualCloud/SVT-HEVC/issues/305)

This happens when using the EbH265EncStreamHeader API, after initializing the encoder with codeVpsSpsPps and before receiving the encoded packet.

In this case, some fields such as maxDpbSize, encoderBitDepth in SequenceControlSet that using by PacketizationKernel thread was not copied from main thread. So since the maxDbpSize value is 0 when creating VPS, WriteUvlc does infinite loop.