### PR TITLE
Fix wrong bitstream indication for conformance to MainRext

### DIFF
--- a/Source/Lib/Codec/EbEncHandle.c
+++ b/Source/Lib/Codec/EbEncHandle.c
@@ -2451,6 +2451,7 @@ void CopyApiFromApp(
         sequenceControlSetPtr->staticConfig.encoderColorFormat = EB_YUV420;
     }
     sequenceControlSetPtr->chromaFormatIdc = (EB_U32)(sequenceControlSetPtr->staticConfig.encoderColorFormat);
+    sequenceControlSetPtr->encoderBitDepth = (EB_U32)(sequenceControlSetPtr->staticConfig.encoderBitDepth);
     sequenceControlSetPtr->enableTmvpSps = sequenceControlSetPtr->staticConfig.unrestrictedMotionVector;
 
     // Copying to masteringDisplayColorVolume structure

--- a/Source/Lib/Codec/EbEntropyCoding.c
+++ b/Source/Lib/Codec/EbEntropyCoding.c
@@ -4968,70 +4968,37 @@ static void CodeProfileTier(
         // "general_max_12bit_constraint_flag"
         WriteFlagCavlc(
            bitstreamPtr,
-           1);
+           (scsPtr->encoderBitDepth <= EB_12BIT));
 
         // "general_max_10bit_constraint_flag"
-        if(scsPtr->encoderBitDepth <= EB_10BIT || scsPtr->staticConfig.constrainedIntra == EB_TRUE)
-        {
-            WriteFlagCavlc(
-               bitstreamPtr,
-               1);
-        } else
-        {
-            WriteFlagCavlc(
-               bitstreamPtr,
-               0);
-        }
+        WriteFlagCavlc(
+           bitstreamPtr,
+           (scsPtr->encoderBitDepth <= EB_10BIT));
 
         // "general_max_8bit_constraint_flag"
-        //if(scsPtr->encoderBitDepth == EB_8BIT)
-        if(scsPtr->encoderBitDepth == EB_8BIT && (scsPtr->chromaFormatIdc == EB_YUV444 || scsPtr->staticConfig.constrainedIntra == EB_TRUE))
-        {
-            WriteFlagCavlc(
-               bitstreamPtr,
-               1);
-        } else
-        {
-            WriteFlagCavlc(
-               bitstreamPtr,
-               0);
-        }
+        WriteFlagCavlc(
+           bitstreamPtr,
+           (scsPtr->encoderBitDepth <= EB_8BIT && scsPtr->chromaFormatIdc != EB_YUV422));
 
         // "general_max_422chroma_constraint_flag"
-        if(scsPtr->chromaFormatIdc == EB_YUV422 || (scsPtr->chromaFormatIdc == EB_YUV420 && scsPtr->staticConfig.constrainedIntra == EB_TRUE))
-        {
-            WriteFlagCavlc(
-               bitstreamPtr,
-               1);
-        } else
-        {
-            WriteFlagCavlc(
-               bitstreamPtr,
-               0);
-        }
+        WriteFlagCavlc(
+           bitstreamPtr,
+           (scsPtr->chromaFormatIdc <= EB_YUV422));
 
         // "general_max_420chroma_constraint_flag"
-        if(scsPtr->chromaFormatIdc == EB_YUV420)
-        {
-            WriteFlagCavlc(
-               bitstreamPtr,
-               1);
-        } else
-        {
-            WriteFlagCavlc(
-               bitstreamPtr,
-               0);
-        }
+        WriteFlagCavlc(
+           bitstreamPtr,
+           (scsPtr->chromaFormatIdc <= EB_YUV420));
 
         // "general_max_monochrome_constraint_flag"
         WriteFlagCavlc(
            bitstreamPtr,
-           0);
+           (scsPtr->chromaFormatIdc <= EB_YUV400));
 
         // "general_intra_constraint_flag"
         WriteFlagCavlc(
            bitstreamPtr,
-           (scsPtr->staticConfig.constrainedIntra == EB_TRUE));
+           (scsPtr->intraPeriodLength == 0));
 
         // "general_one_picture_only_constraint_flag"
         WriteFlagCavlc(

--- a/Source/Lib/Codec/EbEntropyCoding.c
+++ b/Source/Lib/Codec/EbEntropyCoding.c
@@ -4978,7 +4978,7 @@ static void CodeProfileTier(
         // "general_max_8bit_constraint_flag"
         WriteFlagCavlc(
            bitstreamPtr,
-           (scsPtr->encoderBitDepth <= EB_8BIT && scsPtr->chromaFormatIdc != EB_YUV422));
+           (scsPtr->encoderBitDepth <= EB_8BIT));
 
         // "general_max_422chroma_constraint_flag"
         WriteFlagCavlc(


### PR DESCRIPTION
The encoderBitDepth field required to generate the H265 range extension profile indicator,
but it was not copied from the API. So for all bit depth encodings were indicated as 8bits in the 
range extension profile.

And the bitstream conforming to the format range extentions profiles should obey
the constraints defined by ITU-T H.265. But current code does not conform to 
the constraints in some cases. Such as, the previous generate a incorrect main-422-10 profile with 
the general_max_8bit_constraint_flag set to 1 when encoding YUV422/8bit with ConstrainedIntra mode.

The latest ITU-T H.265 revision referenced is (02/2018).
