### PR TITLE
Gstreamer plugin: Enhance profile setting and fix some issues

### DIFF
--- a/gstreamer-plugin/git-patch/0001-svthevcenc-Add-svthevc-encoder-element.patch
+++ b/gstreamer-plugin/git-patch/0001-svthevcenc-Add-svthevc-encoder-element.patch
@@ -1,4 +1,4 @@
-From 2be99ff9ba5e2e0d09ef89e6091ae6f0cc913069 Mon Sep 17 00:00:00 2001
+From 51a65a6a772cba2d5b030b2094f849ad7523bf59 Mon Sep 17 00:00:00 2001
 From: Yeongjin Jeong <yeongjin.jeong@navercorp.com>
 Date: Sat, 23 Mar 2019 21:01:51 +0900
 Subject: [PATCH] svthevcenc: Add svthevc encoder element
@@ -8,14 +8,14 @@ Subject: [PATCH] svthevcenc: Add svthevc encoder element
  ext/Makefile.am                   |   12 +-
  ext/meson.build                   |    1 +
  ext/svthevcenc/Makefile.am        |   18 +
- ext/svthevcenc/gstsvthevcenc.c    | 1818 +++++++++++++++++++++++++++++
+ ext/svthevcenc/gstsvthevcenc.c    | 1824 +++++++++++++++++++++++++++++
  ext/svthevcenc/gstsvthevcenc.h    |  116 ++
  ext/svthevcenc/meson.build        |   18 +
  tests/check/Makefile.am           |    7 +
  tests/check/elements/.gitignore   |    1 +
  tests/check/elements/svthevcenc.c |  228 ++++
  tests/check/meson.build           |    1 +
- 11 files changed, 2226 insertions(+), 2 deletions(-)
+ 11 files changed, 2232 insertions(+), 2 deletions(-)
  create mode 100644 ext/svthevcenc/Makefile.am
  create mode 100644 ext/svthevcenc/gstsvthevcenc.c
  create mode 100644 ext/svthevcenc/gstsvthevcenc.h
@@ -127,10 +127,10 @@ index 000000000..6d7f55aa9
 +noinst_HEADERS = gstsvthevcenc.h
 diff --git a/ext/svthevcenc/gstsvthevcenc.c b/ext/svthevcenc/gstsvthevcenc.c
 new file mode 100644
-index 000000000..97ea9eb85
+index 000000000..0ab79a44e
 --- /dev/null
 +++ b/ext/svthevcenc/gstsvthevcenc.c
-@@ -0,0 +1,1818 @@
+@@ -0,0 +1,1824 @@
 +/* GStreamer H265 encoder plugin
 + * Copyright (C) 2019 Yeongjin Jeong <yeongjin.jeong@navercorp.com>
 + *
@@ -1524,6 +1524,12 @@ index 000000000..97ea9eb85
 +  GstVideoInfo *info = &encoder->input_state->info;
 +  FrameData *fdata;
 +  EB_ERRORTYPE svt_ret;
++
++  if (encoder->svt_eos_flag == EOS_REACHED) {
++    if (frame)
++      gst_video_codec_frame_unref (frame);
++    return GST_FLOW_OK;
++  }
 +
 +  if (encoder->svt_eos_flag == EOS_TOTRIGGER) {
 +    if (frame)

--- a/gstreamer-plugin/git-patch/0001-svthevcenc-Add-svthevc-encoder-element.patch
+++ b/gstreamer-plugin/git-patch/0001-svthevcenc-Add-svthevc-encoder-element.patch
@@ -1,8 +1,14 @@
-From 2c2ad0d7a3fd2540d6cf65a7c154f1ecd88194b6 Mon Sep 17 00:00:00 2001
+From 96ed5ca5ed0fa2125c69d0cf1b9e3ba2873e7210 Mon Sep 17 00:00:00 2001
 From: Yeongjin Jeong <yeongjin.jeong@navercorp.com>
 Date: Sat, 23 Mar 2019 21:01:51 +0900
-Subject: [PATCH] svthevcenc: Add svthevc encoder element
+Subject: [PATCH] svthevcenc: Add new SVT-HEVC encoder element
 
+The SVT-HEVC (Scalable Video Technology[0] for HEVC) Encoder is an
+open source video coding technology[1] that is highly optimized for
+Intel Xeon Scalable processors and Intel Xeon D processors.
+
+[0] https://01.org/svt
+[1] https://github.com/OpenVisualCloud/SVT-HEVC
 ---
  configure.ac                      |    8 +
  ext/Makefile.am                   |   12 +-

--- a/gstreamer-plugin/git-patch/0001-svthevcenc-Add-svthevc-encoder-element.patch
+++ b/gstreamer-plugin/git-patch/0001-svthevcenc-Add-svthevc-encoder-element.patch
@@ -1,4 +1,4 @@
-From 0b082bc3b45081cea26633c000aa8c7e65d0993c Mon Sep 17 00:00:00 2001
+From 5dd397a8945000e72dedb5b970b0e9c29f435a1d Mon Sep 17 00:00:00 2001
 From: Yeongjin Jeong <yeongjin.jeong@navercorp.com>
 Date: Sat, 23 Mar 2019 21:01:51 +0900
 Subject: [PATCH] svthevcenc: Add svthevc encoder element
@@ -8,14 +8,14 @@ Subject: [PATCH] svthevcenc: Add svthevc encoder element
  ext/Makefile.am                   |   12 +-
  ext/meson.build                   |    1 +
  ext/svthevcenc/Makefile.am        |   18 +
- ext/svthevcenc/gstsvthevcenc.c    | 1874 +++++++++++++++++++++++++++++
+ ext/svthevcenc/gstsvthevcenc.c    | 1868 +++++++++++++++++++++++++++++
  ext/svthevcenc/gstsvthevcenc.h    |  116 ++
  ext/svthevcenc/meson.build        |   18 +
  tests/check/Makefile.am           |    7 +
  tests/check/elements/.gitignore   |    1 +
  tests/check/elements/svthevcenc.c |  228 ++++
  tests/check/meson.build           |    1 +
- 11 files changed, 2282 insertions(+), 2 deletions(-)
+ 11 files changed, 2276 insertions(+), 2 deletions(-)
  create mode 100644 ext/svthevcenc/Makefile.am
  create mode 100644 ext/svthevcenc/gstsvthevcenc.c
  create mode 100644 ext/svthevcenc/gstsvthevcenc.h
@@ -127,10 +127,10 @@ index 000000000..6d7f55aa9
 +noinst_HEADERS = gstsvthevcenc.h
 diff --git a/ext/svthevcenc/gstsvthevcenc.c b/ext/svthevcenc/gstsvthevcenc.c
 new file mode 100644
-index 000000000..e61fbbe05
+index 000000000..7230e439b
 --- /dev/null
 +++ b/ext/svthevcenc/gstsvthevcenc.c
-@@ -0,0 +1,1874 @@
+@@ -0,0 +1,1868 @@
 +/* GStreamer H265 encoder plugin
 + * Copyright (C) 2019 Yeongjin Jeong <yeongjin.jeong@navercorp.com>
 + *
@@ -808,12 +808,6 @@ index 000000000..e61fbbe05
 +gst_svthevc_enc_finalize (GObject * object)
 +{
 +  GstSvtHevcEnc *encoder = GST_SVTHEVC_ENC (object);
-+
-+  if (encoder->input_state)
-+    gst_video_codec_state_unref (encoder->input_state);
-+  encoder->input_state = NULL;
-+
-+  gst_svthevc_enc_close_encoder (encoder);
 +
 +  if (encoder->in_buf) {
 +    EB_H265_ENC_INPUT *in_data = (EB_H265_ENC_INPUT *) encoder->in_buf->pBuffer;

--- a/gstreamer-plugin/git-patch/0001-svthevcenc-Add-svthevc-encoder-element.patch
+++ b/gstreamer-plugin/git-patch/0001-svthevcenc-Add-svthevc-encoder-element.patch
@@ -1,4 +1,4 @@
-From 0fb5a4e4d5f71b941eb5a79855dd834e8c05698f Mon Sep 17 00:00:00 2001
+From b5de27131f9a9ede34e194ca5994e8653674ac79 Mon Sep 17 00:00:00 2001
 From: Yeongjin Jeong <yeongjin.jeong@navercorp.com>
 Date: Sat, 23 Mar 2019 21:01:51 +0900
 Subject: [PATCH] svthevcenc: Add svthevc encoder element
@@ -8,14 +8,14 @@ Subject: [PATCH] svthevcenc: Add svthevc encoder element
  ext/Makefile.am                   |   12 +-
  ext/meson.build                   |    1 +
  ext/svthevcenc/Makefile.am        |   18 +
- ext/svthevcenc/gstsvthevcenc.c    | 1694 +++++++++++++++++++++++++++++++++++++
+ ext/svthevcenc/gstsvthevcenc.c    | 1695 +++++++++++++++++++++++++++++++++++++
  ext/svthevcenc/gstsvthevcenc.h    |  119 +++
  ext/svthevcenc/meson.build        |   18 +
  tests/check/Makefile.am           |    7 +
  tests/check/elements/.gitignore   |    1 +
  tests/check/elements/svthevcenc.c |  228 +++++
  tests/check/meson.build           |    1 +
- 11 files changed, 2105 insertions(+), 2 deletions(-)
+ 11 files changed, 2106 insertions(+), 2 deletions(-)
  create mode 100644 ext/svthevcenc/Makefile.am
  create mode 100644 ext/svthevcenc/gstsvthevcenc.c
  create mode 100644 ext/svthevcenc/gstsvthevcenc.h
@@ -23,10 +23,10 @@ Subject: [PATCH] svthevcenc: Add svthevc encoder element
  create mode 100644 tests/check/elements/svthevcenc.c
 
 diff --git a/configure.ac b/configure.ac
-index c770006..f8ff236 100644
+index dbd1541..3b25d04 100644
 --- a/configure.ac
 +++ b/configure.ac
-@@ -2111,6 +2111,12 @@ if test "x$HAVE_LTC" = "xyes"; then
+@@ -2107,6 +2107,12 @@ if test "x$HAVE_LTC" = "xyes"; then
    AC_DEFINE(HAVE_LTC, 1, [Use libltc])
  fi
  
@@ -39,7 +39,7 @@ index c770006..f8ff236 100644
  else
  
  dnl not building plugins with external dependencies,
-@@ -2192,6 +2198,7 @@ AM_CONDITIONAL(USE_X265, false)
+@@ -2188,6 +2194,7 @@ AM_CONDITIONAL(USE_X265, false)
  AM_CONDITIONAL(USE_DTLS, false)
  AM_CONDITIONAL(USE_TTML, false)
  AM_CONDITIONAL(USE_SCTP, false)
@@ -47,7 +47,7 @@ index c770006..f8ff236 100644
  
  fi dnl of EXT plugins
  
-@@ -2483,6 +2490,7 @@ ext/webrtc/Makefile
+@@ -2479,6 +2486,7 @@ ext/webrtc/Makefile
  ext/webrtcdsp/Makefile
  ext/wpe/Makefile
  ext/ttml/Makefile
@@ -127,10 +127,10 @@ index 0000000..6d7f55a
 +noinst_HEADERS = gstsvthevcenc.h
 diff --git a/ext/svthevcenc/gstsvthevcenc.c b/ext/svthevcenc/gstsvthevcenc.c
 new file mode 100644
-index 0000000..dbbe93b
+index 0000000..461fd62
 --- /dev/null
 +++ b/ext/svthevcenc/gstsvthevcenc.c
-@@ -0,0 +1,1694 @@
+@@ -0,0 +1,1695 @@
 +/* GStreamer H265 encoder plugin
 + * Copyright (C) 2019 Yeongjin Jeong <yeongjin.jeong@navercorp.com>
 + *
@@ -985,6 +985,7 @@ index 0000000..dbbe93b
 +    goto failed_init_handle;
 +  }
 +
++  encoder->push_header = TRUE;
 +  encoder->reconfig = FALSE;
 +
 +  /* good start, will be corrected if needed */
@@ -992,15 +993,15 @@ index 0000000..dbbe93b
 +
 +  GST_OBJECT_UNLOCK (encoder);
 +
-+  encoder->push_header = TRUE;
-+
 +  return TRUE;
 +
 +failed_init_handle:
 +  EbDeinitHandle (encoder->svt_handle);
 +failed:
 +  encoder->svt_handle = NULL;
-+  encoder = NULL;
++
++  GST_OBJECT_UNLOCK (encoder);
++
 +  return FALSE;
 +}
 +
@@ -1827,7 +1828,7 @@ index 0000000..dbbe93b
 +    plugin_init, VERSION, "GPL", GST_PACKAGE_NAME, GST_PACKAGE_ORIGIN)
 diff --git a/ext/svthevcenc/gstsvthevcenc.h b/ext/svthevcenc/gstsvthevcenc.h
 new file mode 100644
-index 0000000..283027f
+index 0000000..92087e2
 --- /dev/null
 +++ b/ext/svthevcenc/gstsvthevcenc.h
 @@ -0,0 +1,119 @@

--- a/gstreamer-plugin/git-patch/0001-svthevcenc-Add-svthevc-encoder-element.patch
+++ b/gstreamer-plugin/git-patch/0001-svthevcenc-Add-svthevc-encoder-element.patch
@@ -1,4 +1,4 @@
-From 517b3d95feead6bc775d01d860d504265bda62b2 Mon Sep 17 00:00:00 2001
+From 5c7b2b5e97328cffce30f0c4db905c2800f77429 Mon Sep 17 00:00:00 2001
 From: Yeongjin Jeong <yeongjin.jeong@navercorp.com>
 Date: Sat, 23 Mar 2019 21:01:51 +0900
 Subject: [PATCH] svthevcenc: Add svthevc encoder element
@@ -8,14 +8,14 @@ Subject: [PATCH] svthevcenc: Add svthevc encoder element
  ext/Makefile.am                   |   12 +-
  ext/meson.build                   |    1 +
  ext/svthevcenc/Makefile.am        |   18 +
- ext/svthevcenc/gstsvthevcenc.c    | 1803 +++++++++++++++++++++++++++++++++++++
- ext/svthevcenc/gstsvthevcenc.h    |  116 +++
+ ext/svthevcenc/gstsvthevcenc.c    | 1807 +++++++++++++++++++++++++++++
+ ext/svthevcenc/gstsvthevcenc.h    |  116 ++
  ext/svthevcenc/meson.build        |   18 +
  tests/check/Makefile.am           |    7 +
  tests/check/elements/.gitignore   |    1 +
- tests/check/elements/svthevcenc.c |  228 +++++
+ tests/check/elements/svthevcenc.c |  228 ++++
  tests/check/meson.build           |    1 +
- 11 files changed, 2211 insertions(+), 2 deletions(-)
+ 11 files changed, 2215 insertions(+), 2 deletions(-)
  create mode 100644 ext/svthevcenc/Makefile.am
  create mode 100644 ext/svthevcenc/gstsvthevcenc.c
  create mode 100644 ext/svthevcenc/gstsvthevcenc.h
@@ -23,10 +23,10 @@ Subject: [PATCH] svthevcenc: Add svthevc encoder element
  create mode 100644 tests/check/elements/svthevcenc.c
 
 diff --git a/configure.ac b/configure.ac
-index dbd1541..3f128d8 100644
+index c77000645..5d71ed6f0 100644
 --- a/configure.ac
 +++ b/configure.ac
-@@ -2107,6 +2107,12 @@ if test "x$HAVE_LTC" = "xyes"; then
+@@ -2111,6 +2111,12 @@ if test "x$HAVE_LTC" = "xyes"; then
    AC_DEFINE(HAVE_LTC, 1, [Use libltc])
  fi
  
@@ -39,7 +39,7 @@ index dbd1541..3f128d8 100644
  else
  
  dnl not building plugins with external dependencies,
-@@ -2188,6 +2194,7 @@ AM_CONDITIONAL(USE_X265, false)
+@@ -2192,6 +2198,7 @@ AM_CONDITIONAL(USE_X265, false)
  AM_CONDITIONAL(USE_DTLS, false)
  AM_CONDITIONAL(USE_TTML, false)
  AM_CONDITIONAL(USE_SCTP, false)
@@ -47,7 +47,7 @@ index dbd1541..3f128d8 100644
  
  fi dnl of EXT plugins
  
-@@ -2479,6 +2486,7 @@ ext/webrtc/Makefile
+@@ -2483,6 +2490,7 @@ ext/webrtc/Makefile
  ext/webrtcdsp/Makefile
  ext/wpe/Makefile
  ext/ttml/Makefile
@@ -56,7 +56,7 @@ index dbd1541..3f128d8 100644
  pkgconfig/Makefile
  pkgconfig/gstreamer-plugins-bad.pc
 diff --git a/ext/Makefile.am b/ext/Makefile.am
-index 17e427d..ab978a4 100644
+index 17e427da3..ab978a433 100644
 --- a/ext/Makefile.am
 +++ b/ext/Makefile.am
 @@ -400,6 +400,12 @@ else
@@ -92,7 +92,7 @@ index 17e427d..ab978a4 100644
  
  include $(top_srcdir)/common/parallel-subdirs.mak
 diff --git a/ext/meson.build b/ext/meson.build
-index 1d3320c..324e8cc 100644
+index 1d3320c59..324e8ccb4 100644
 --- a/ext/meson.build
 +++ b/ext/meson.build
 @@ -64,3 +64,4 @@ subdir('wildmidi')
@@ -103,7 +103,7 @@ index 1d3320c..324e8cc 100644
 \ No newline at end of file
 diff --git a/ext/svthevcenc/Makefile.am b/ext/svthevcenc/Makefile.am
 new file mode 100644
-index 0000000..6d7f55a
+index 000000000..6d7f55aa9
 --- /dev/null
 +++ b/ext/svthevcenc/Makefile.am
 @@ -0,0 +1,18 @@
@@ -127,10 +127,10 @@ index 0000000..6d7f55a
 +noinst_HEADERS = gstsvthevcenc.h
 diff --git a/ext/svthevcenc/gstsvthevcenc.c b/ext/svthevcenc/gstsvthevcenc.c
 new file mode 100644
-index 0000000..b98e19c
+index 000000000..6337b3768
 --- /dev/null
 +++ b/ext/svthevcenc/gstsvthevcenc.c
-@@ -0,0 +1,1803 @@
+@@ -0,0 +1,1807 @@
 +/* GStreamer H265 encoder plugin
 + * Copyright (C) 2019 Yeongjin Jeong <yeongjin.jeong@navercorp.com>
 + *
@@ -1526,6 +1526,8 @@ index 0000000..b98e19c
 +  EB_ERRORTYPE svt_ret;
 +
 +  if (encoder->svt_eos_flag == EOS_TOTRIGGER) {
++    if (frame)
++      gst_video_codec_frame_unref (frame);
 +    return GST_FLOW_EOS;
 +  }
 +
@@ -1537,6 +1539,8 @@ index 0000000..b98e19c
 +  fdata = gst_svthevc_enc_queue_frame (encoder, frame, info);
 +  if (!fdata) {
 +    GST_ERROR_OBJECT (encoder, "Failed to map frame");
++    if (frame)
++      gst_video_codec_frame_unref (frame);
 +    return GST_FLOW_ERROR;
 +  }
 +
@@ -1936,7 +1940,7 @@ index 0000000..b98e19c
 +    plugin_init, VERSION, "GPL", GST_PACKAGE_NAME, GST_PACKAGE_ORIGIN)
 diff --git a/ext/svthevcenc/gstsvthevcenc.h b/ext/svthevcenc/gstsvthevcenc.h
 new file mode 100644
-index 0000000..8ad57f7
+index 000000000..8ad57f7f4
 --- /dev/null
 +++ b/ext/svthevcenc/gstsvthevcenc.h
 @@ -0,0 +1,116 @@
@@ -2058,7 +2062,7 @@ index 0000000..8ad57f7
 +#endif /* __GST_SVTHEVC_ENC_H__ */
 diff --git a/ext/svthevcenc/meson.build b/ext/svthevcenc/meson.build
 new file mode 100644
-index 0000000..8733aef
+index 000000000..8733aef60
 --- /dev/null
 +++ b/ext/svthevcenc/meson.build
 @@ -0,0 +1,18 @@
@@ -2081,7 +2085,7 @@ index 0000000..8733aef
 +  plugins += [gstsvthevcenc]
 +endif
 diff --git a/tests/check/Makefile.am b/tests/check/Makefile.am
-index c36fa9f..fb15aba 100644
+index c36fa9f0b..fb15aba52 100644
 --- a/tests/check/Makefile.am
 +++ b/tests/check/Makefile.am
 @@ -240,6 +240,12 @@ else
@@ -2106,7 +2110,7 @@ index c36fa9f..fb15aba 100644
  
  noinst_HEADERS = elements/mxfdemux.h libs/isoff.h
 diff --git a/tests/check/elements/.gitignore b/tests/check/elements/.gitignore
-index ca99cec..7a6834b 100644
+index ca99cecfa..7a6834bd7 100644
 --- a/tests/check/elements/.gitignore
 +++ b/tests/check/elements/.gitignore
 @@ -61,4 +61,5 @@ voaacenc
@@ -2117,7 +2121,7 @@ index ca99cec..7a6834b 100644
  zbar
 diff --git a/tests/check/elements/svthevcenc.c b/tests/check/elements/svthevcenc.c
 new file mode 100644
-index 0000000..0545b3c
+index 000000000..0545b3c68
 --- /dev/null
 +++ b/tests/check/elements/svthevcenc.c
 @@ -0,0 +1,228 @@
@@ -2350,7 +2354,7 @@ index 0000000..0545b3c
 +
 +GST_CHECK_MAIN (svthevcenc);
 diff --git a/tests/check/meson.build b/tests/check/meson.build
-index 2218dab..98183a6 100644
+index 2218dab00..98183a68b 100644
 --- a/tests/check/meson.build
 +++ b/tests/check/meson.build
 @@ -35,6 +35,7 @@ base_tests = [
@@ -2362,5 +2366,5 @@ index 2218dab..98183a6 100644
    [['elements/pnm.c']],
    [['elements/rtponvifparse.c']],
 -- 
-2.7.4
+2.17.1
 

--- a/gstreamer-plugin/git-patch/0001-svthevcenc-Add-svthevc-encoder-element.patch
+++ b/gstreamer-plugin/git-patch/0001-svthevcenc-Add-svthevc-encoder-element.patch
@@ -1,4 +1,4 @@
-From f384eea601907fdfd0ac8f32a281b93b78cbd9fd Mon Sep 17 00:00:00 2001
+From 2191e0446947bcfb217df49a6e5459e1a2a29ee9 Mon Sep 17 00:00:00 2001
 From: Yeongjin Jeong <yeongjin.jeong@navercorp.com>
 Date: Sat, 23 Mar 2019 21:01:51 +0900
 Subject: [PATCH] svthevcenc: Add svthevc encoder element
@@ -8,14 +8,14 @@ Subject: [PATCH] svthevcenc: Add svthevc encoder element
  ext/Makefile.am                   |   12 +-
  ext/meson.build                   |    1 +
  ext/svthevcenc/Makefile.am        |   18 +
- ext/svthevcenc/gstsvthevcenc.c    | 1865 +++++++++++++++++++++++++++++
+ ext/svthevcenc/gstsvthevcenc.c    | 1874 +++++++++++++++++++++++++++++
  ext/svthevcenc/gstsvthevcenc.h    |  116 ++
  ext/svthevcenc/meson.build        |   18 +
  tests/check/Makefile.am           |    7 +
  tests/check/elements/.gitignore   |    1 +
  tests/check/elements/svthevcenc.c |  228 ++++
  tests/check/meson.build           |    1 +
- 11 files changed, 2273 insertions(+), 2 deletions(-)
+ 11 files changed, 2282 insertions(+), 2 deletions(-)
  create mode 100644 ext/svthevcenc/Makefile.am
  create mode 100644 ext/svthevcenc/gstsvthevcenc.c
  create mode 100644 ext/svthevcenc/gstsvthevcenc.h
@@ -127,10 +127,10 @@ index 000000000..6d7f55aa9
 +noinst_HEADERS = gstsvthevcenc.h
 diff --git a/ext/svthevcenc/gstsvthevcenc.c b/ext/svthevcenc/gstsvthevcenc.c
 new file mode 100644
-index 000000000..6096f6cf0
+index 000000000..e61fbbe05
 --- /dev/null
 +++ b/ext/svthevcenc/gstsvthevcenc.c
-@@ -0,0 +1,1865 @@
+@@ -0,0 +1,1874 @@
 +/* GStreamer H265 encoder plugin
 + * Copyright (C) 2019 Yeongjin Jeong <yeongjin.jeong@navercorp.com>
 + *
@@ -916,8 +916,17 @@ index 000000000..6096f6cf0
 +
 +  param->predStructure = encoder->pred_structure;
 +
-+  /* Send VPS, SPS and PPS Insertion in first IDR frame */
-+  param->codeVpsSpsPps = 1;
++  /*
++   * NOTE: codeVpsSpsPps flag allows the VPS, SPS and PPS Insertion and
++   * sending in first IDR frame. But in the SVT-HEVC specific version,
++   * If codeVpsSpsPps enabled and using the EbH265EncStreamHeader API
++   * before receiving encoded packets, It cause bug which encoded packets
++   * are not output.
++   */
++  if (SVT_CHECK_VERSION (1, 5, 0))
++    param->codeVpsSpsPps = 1;
++  else
++    param->codeVpsSpsPps = 0;
 +
 +  /*
 +   * NOTE: h265parser's eos nal unit processing will cause an unexpected

--- a/gstreamer-plugin/git-patch/0001-svthevcenc-Add-svthevc-encoder-element.patch
+++ b/gstreamer-plugin/git-patch/0001-svthevcenc-Add-svthevc-encoder-element.patch
@@ -1,4 +1,4 @@
-From 5c7b2b5e97328cffce30f0c4db905c2800f77429 Mon Sep 17 00:00:00 2001
+From 2be99ff9ba5e2e0d09ef89e6091ae6f0cc913069 Mon Sep 17 00:00:00 2001
 From: Yeongjin Jeong <yeongjin.jeong@navercorp.com>
 Date: Sat, 23 Mar 2019 21:01:51 +0900
 Subject: [PATCH] svthevcenc: Add svthevc encoder element
@@ -8,14 +8,14 @@ Subject: [PATCH] svthevcenc: Add svthevc encoder element
  ext/Makefile.am                   |   12 +-
  ext/meson.build                   |    1 +
  ext/svthevcenc/Makefile.am        |   18 +
- ext/svthevcenc/gstsvthevcenc.c    | 1807 +++++++++++++++++++++++++++++
+ ext/svthevcenc/gstsvthevcenc.c    | 1818 +++++++++++++++++++++++++++++
  ext/svthevcenc/gstsvthevcenc.h    |  116 ++
  ext/svthevcenc/meson.build        |   18 +
  tests/check/Makefile.am           |    7 +
  tests/check/elements/.gitignore   |    1 +
  tests/check/elements/svthevcenc.c |  228 ++++
  tests/check/meson.build           |    1 +
- 11 files changed, 2215 insertions(+), 2 deletions(-)
+ 11 files changed, 2226 insertions(+), 2 deletions(-)
  create mode 100644 ext/svthevcenc/Makefile.am
  create mode 100644 ext/svthevcenc/gstsvthevcenc.c
  create mode 100644 ext/svthevcenc/gstsvthevcenc.h
@@ -127,10 +127,10 @@ index 000000000..6d7f55aa9
 +noinst_HEADERS = gstsvthevcenc.h
 diff --git a/ext/svthevcenc/gstsvthevcenc.c b/ext/svthevcenc/gstsvthevcenc.c
 new file mode 100644
-index 000000000..6337b3768
+index 000000000..97ea9eb85
 --- /dev/null
 +++ b/ext/svthevcenc/gstsvthevcenc.c
-@@ -0,0 +1,1807 @@
+@@ -0,0 +1,1818 @@
 +/* GStreamer H265 encoder plugin
 + * Copyright (C) 2019 Yeongjin Jeong <yeongjin.jeong@navercorp.com>
 + *
@@ -1655,55 +1655,66 @@ index 000000000..6337b3768
 +    return GST_FLOW_OK;
 +  }
 +
++  if (svt_ret != EB_ErrorNone || !output_buffer) {
++    GST_ELEMENT_ERROR (encoder, STREAM, ENCODE,
++        ("Encode svthevc frame failed."),
++        ("EbH265GetPacket return code=%d", svt_ret));
++    return GST_FLOW_ERROR;
++  }
++
 +  GST_LOG_OBJECT (encoder, "got %d from svt", output_buffer->nFlags);
 +
 +  *got_packet = TRUE;
 +
-+  /* Get oldest frame */
 +  frame =
 +      gst_svthevc_encoder_get_frame (GST_VIDEO_ENCODER (encoder),
 +      output_buffer->pts);
-+  if (!frame) {
-+    frame = gst_video_encoder_get_oldest_frame (GST_VIDEO_ENCODER (encoder));
++
++  if (!frame && send) {
++    GST_ELEMENT_ERROR (encoder, STREAM, ENCODE,
++        ("Encode svthevc frame failed."), ("Frame not found."));
++    ret = GST_FLOW_ERROR;
++    goto out;
 +  }
 +
 +  if (!send || !frame) {
 +    GST_LOG_OBJECT (encoder, "not sending (%d) or frame not found (%d)", send,
 +        frame != NULL);
++    ret = GST_FLOW_OK;
++    goto out;
 +  }
 +
 +  GST_DEBUG_OBJECT (encoder,
 +      "output picture ready system=%d frame found %d",
 +      frame->system_frame_number, frame != NULL);
 +
-+  if (send) {
-+    out_buf = gst_buffer_new_allocate (NULL, output_buffer->nFilledLen, NULL);
-+    gst_buffer_fill (out_buf, 0, output_buffer->pBuffer,
-+        output_buffer->nFilledLen);
++  out_buf = gst_buffer_new_allocate (NULL, output_buffer->nFilledLen, NULL);
++  gst_buffer_fill (out_buf, 0, output_buffer->pBuffer,
++      output_buffer->nFilledLen);
 +
-+    frame->output_buffer = out_buf;
++  frame->output_buffer = out_buf;
 +
-+    if (output_buffer->sliceType == EB_IDR_PICTURE) {
-+      GST_VIDEO_CODEC_FRAME_SET_SYNC_POINT (frame);
-+    } else {
-+      GST_VIDEO_CODEC_FRAME_UNSET_SYNC_POINT (frame);
-+    }
-+
-+    if (encoder->push_header) {
-+      GstBuffer *header;
-+
-+      header = gst_svthevc_enc_get_header_buffer (encoder);
-+      frame->output_buffer = gst_buffer_append (header, frame->output_buffer);
-+      encoder->push_header = FALSE;
-+    }
-+
-+    frame->pts = output_buffer->pts;
-+
-+    GST_LOG_OBJECT (encoder,
-+        "output: frame dts %" G_GINT64_FORMAT " pts %" G_GINT64_FORMAT,
-+        (gint64) frame->dts, (gint64) frame->pts);
++  if (output_buffer->sliceType == EB_IDR_PICTURE) {
++    GST_VIDEO_CODEC_FRAME_SET_SYNC_POINT (frame);
++  } else {
++    GST_VIDEO_CODEC_FRAME_UNSET_SYNC_POINT (frame);
 +  }
 +
++  if (encoder->push_header) {
++    GstBuffer *header;
++
++    header = gst_svthevc_enc_get_header_buffer (encoder);
++    frame->output_buffer = gst_buffer_append (header, frame->output_buffer);
++    encoder->push_header = FALSE;
++  }
++
++  frame->pts = output_buffer->pts;
++
++  GST_LOG_OBJECT (encoder,
++      "output: frame dts %" G_GINT64_FORMAT " pts %" G_GINT64_FORMAT,
++      (gint64) frame->dts, (gint64) frame->pts);
++
++out:
 +  if (output_buffer->nFlags == EB_BUFFERFLAG_EOS) {
 +    encoder->svt_eos_flag = EOS_TOTRIGGER;
 +  }

--- a/gstreamer-plugin/git-patch/0001-svthevcenc-Add-svthevc-encoder-element.patch
+++ b/gstreamer-plugin/git-patch/0001-svthevcenc-Add-svthevc-encoder-element.patch
@@ -1,4 +1,4 @@
-From 2191e0446947bcfb217df49a6e5459e1a2a29ee9 Mon Sep 17 00:00:00 2001
+From 0b082bc3b45081cea26633c000aa8c7e65d0993c Mon Sep 17 00:00:00 2001
 From: Yeongjin Jeong <yeongjin.jeong@navercorp.com>
 Date: Sat, 23 Mar 2019 21:01:51 +0900
 Subject: [PATCH] svthevcenc: Add svthevc encoder element
@@ -23,10 +23,10 @@ Subject: [PATCH] svthevcenc: Add svthevc encoder element
  create mode 100644 tests/check/elements/svthevcenc.c
 
 diff --git a/configure.ac b/configure.ac
-index c77000645..5d71ed6f0 100644
+index dbd15419d..3f128d83b 100644
 --- a/configure.ac
 +++ b/configure.ac
-@@ -2111,6 +2111,12 @@ if test "x$HAVE_LTC" = "xyes"; then
+@@ -2107,6 +2107,12 @@ if test "x$HAVE_LTC" = "xyes"; then
    AC_DEFINE(HAVE_LTC, 1, [Use libltc])
  fi
  
@@ -39,7 +39,7 @@ index c77000645..5d71ed6f0 100644
  else
  
  dnl not building plugins with external dependencies,
-@@ -2192,6 +2198,7 @@ AM_CONDITIONAL(USE_X265, false)
+@@ -2188,6 +2194,7 @@ AM_CONDITIONAL(USE_X265, false)
  AM_CONDITIONAL(USE_DTLS, false)
  AM_CONDITIONAL(USE_TTML, false)
  AM_CONDITIONAL(USE_SCTP, false)
@@ -47,7 +47,7 @@ index c77000645..5d71ed6f0 100644
  
  fi dnl of EXT plugins
  
-@@ -2483,6 +2490,7 @@ ext/webrtc/Makefile
+@@ -2479,6 +2486,7 @@ ext/webrtc/Makefile
  ext/webrtcdsp/Makefile
  ext/wpe/Makefile
  ext/ttml/Makefile
@@ -2421,13 +2421,13 @@ index 000000000..0545b3c68
 +
 +GST_CHECK_MAIN (svthevcenc);
 diff --git a/tests/check/meson.build b/tests/check/meson.build
-index 2218dab00..98183a68b 100644
+index 9ad6439be..76a25f28d 100644
 --- a/tests/check/meson.build
 +++ b/tests/check/meson.build
-@@ -35,6 +35,7 @@ base_tests = [
-   [['elements/mxfdemux.c']],
+@@ -36,6 +36,7 @@ base_tests = [
    [['elements/mxfmux.c']],
    [['elements/nvenc.c'], false, [gmodule_dep, gstgl_dep]],
+   [['elements/nvdec.c'], not gstgl_dep.found(), [gmodule_dep, gstgl_dep]],
 +  [['elements/svthevcenc.c'], not svthevcenc_dep.found(), [svthevcenc_dep]],
    [['elements/pcapparse.c'], false, [libparser_dep]],
    [['elements/pnm.c']],

--- a/gstreamer-plugin/git-patch/0001-svthevcenc-Add-svthevc-encoder-element.patch
+++ b/gstreamer-plugin/git-patch/0001-svthevcenc-Add-svthevc-encoder-element.patch
@@ -1,4 +1,4 @@
-From 5dd397a8945000e72dedb5b970b0e9c29f435a1d Mon Sep 17 00:00:00 2001
+From 7ce46057db9daae39a188352c89c0397c2945a3d Mon Sep 17 00:00:00 2001
 From: Yeongjin Jeong <yeongjin.jeong@navercorp.com>
 Date: Sat, 23 Mar 2019 21:01:51 +0900
 Subject: [PATCH] svthevcenc: Add svthevc encoder element
@@ -8,14 +8,14 @@ Subject: [PATCH] svthevcenc: Add svthevc encoder element
  ext/Makefile.am                   |   12 +-
  ext/meson.build                   |    1 +
  ext/svthevcenc/Makefile.am        |   18 +
- ext/svthevcenc/gstsvthevcenc.c    | 1868 +++++++++++++++++++++++++++++
- ext/svthevcenc/gstsvthevcenc.h    |  116 ++
+ ext/svthevcenc/gstsvthevcenc.c    | 1878 +++++++++++++++++++++++++++++
+ ext/svthevcenc/gstsvthevcenc.h    |  117 ++
  ext/svthevcenc/meson.build        |   18 +
  tests/check/Makefile.am           |    7 +
  tests/check/elements/.gitignore   |    1 +
  tests/check/elements/svthevcenc.c |  228 ++++
  tests/check/meson.build           |    1 +
- 11 files changed, 2276 insertions(+), 2 deletions(-)
+ 11 files changed, 2287 insertions(+), 2 deletions(-)
  create mode 100644 ext/svthevcenc/Makefile.am
  create mode 100644 ext/svthevcenc/gstsvthevcenc.c
  create mode 100644 ext/svthevcenc/gstsvthevcenc.h
@@ -127,10 +127,10 @@ index 000000000..6d7f55aa9
 +noinst_HEADERS = gstsvthevcenc.h
 diff --git a/ext/svthevcenc/gstsvthevcenc.c b/ext/svthevcenc/gstsvthevcenc.c
 new file mode 100644
-index 000000000..7230e439b
+index 000000000..b49fbca3a
 --- /dev/null
 +++ b/ext/svthevcenc/gstsvthevcenc.c
-@@ -0,0 +1,1868 @@
+@@ -0,0 +1,1878 @@
 +/* GStreamer H265 encoder plugin
 + * Copyright (C) 2019 Yeongjin Jeong <yeongjin.jeong@navercorp.com>
 + *
@@ -700,6 +700,7 @@ index 000000000..7230e439b
 +
 +  encoder->svthevc_version = (const gchar *) g_string_free (string, FALSE);
 +  encoder->push_header = TRUE;
++  encoder->first_buffer = TRUE;
 +}
 +
 +typedef struct
@@ -1013,6 +1014,7 @@ index 000000000..7230e439b
 +  }
 +
 +  encoder->push_header = TRUE;
++  encoder->first_buffer = TRUE;
 +  encoder->reconfig = FALSE;
 +
 +  /* good start, will be corrected if needed */
@@ -1622,6 +1624,13 @@ index 000000000..7230e439b
 +out:
 +  if (!headerPtr) {
 +    EB_BUFFERHEADERTYPE headerPtrLast;
++
++    if (encoder->first_buffer) {
++      GST_DEBUG_OBJECT (encoder, "No need to send eos buffer");
++      encoder->svt_eos_flag = EOS_TOTRIGGER;
++      return GST_FLOW_OK;
++    }
++
 +    headerPtrLast.nAllocLen = 0;
 +    headerPtrLast.nFilledLen = 0;
 +    headerPtrLast.nTickCount = 0;
@@ -1635,6 +1644,7 @@ index 000000000..7230e439b
 +  } else {
 +    GST_INFO_OBJECT (encoder, "encode frame");
 +    svt_ret = EbH265EncSendPicture (encoder->svt_handle, headerPtr);
++    encoder->first_buffer = FALSE;
 +  }
 +
 +  GST_DEBUG_OBJECT (encoder, "encoder result (%d)", svt_ret);
@@ -2001,10 +2011,10 @@ index 000000000..7230e439b
 +    plugin_init, VERSION, "GPL", GST_PACKAGE_NAME, GST_PACKAGE_ORIGIN)
 diff --git a/ext/svthevcenc/gstsvthevcenc.h b/ext/svthevcenc/gstsvthevcenc.h
 new file mode 100644
-index 000000000..8ad57f7f4
+index 000000000..5a2bdcd14
 --- /dev/null
 +++ b/ext/svthevcenc/gstsvthevcenc.h
-@@ -0,0 +1,116 @@
+@@ -0,0 +1,117 @@
 +/* GStreamer H265 encoder plugin
 + * Copyright (C) 2019 Yeongjin Jeong <yeongjin.jeong@navercorp.com>
 + *
@@ -2069,6 +2079,7 @@ index 000000000..8ad57f7f4
 +
 +  GstClockTime dts_offset;
 +  gboolean push_header;
++  gboolean first_buffer;
 +
 +  /* List of frame/buffer mapping structs for
 +   * pending frames */

--- a/gstreamer-plugin/git-patch/0001-svthevcenc-Add-svthevc-encoder-element.patch
+++ b/gstreamer-plugin/git-patch/0001-svthevcenc-Add-svthevc-encoder-element.patch
@@ -1,4 +1,4 @@
-From 36076a5d6faf8e19e1ef8a4eb28bfe096b248c6b Mon Sep 17 00:00:00 2001
+From 6aa6816e6f217e02315e9bbd7cb5c7fc16026192 Mon Sep 17 00:00:00 2001
 From: Yeongjin Jeong <yeongjin.jeong@navercorp.com>
 Date: Sat, 23 Mar 2019 21:01:51 +0900
 Subject: [PATCH] svthevcenc: Add svthevc encoder element
@@ -23,17 +23,17 @@ Subject: [PATCH] svthevcenc: Add svthevc encoder element
  create mode 100644 tests/check/elements/svthevcenc.c
 
 diff --git a/configure.ac b/configure.ac
-index dbd1541..3b25d04 100644
+index dbd1541..3f128d8 100644
 --- a/configure.ac
 +++ b/configure.ac
 @@ -2107,6 +2107,12 @@ if test "x$HAVE_LTC" = "xyes"; then
    AC_DEFINE(HAVE_LTC, 1, [Use libltc])
  fi
  
-+dnl *** svthevcenc : works with libSVT-HEVC 1.3.0 ***
++dnl *** svthevcenc : works with libSVT-HEVC 1.4.0 ***
 +translit(dnm, m, l) AM_CONDITIONAL(USE_SVTHEVCENC, true)
 +AG_GST_CHECK_FEATURE(SVTHEVCENC, [svthevcenc plug-in], svthevcenc, [
-+  AG_GST_PKG_CHECK_MODULES(SVTHEVCENC, SvtHevcEnc >= 1.3.0)
++  AG_GST_PKG_CHECK_MODULES(SVTHEVCENC, SvtHevcEnc >= 1.4.0)
 +])
 +
  else
@@ -2075,7 +2075,7 @@ index 0000000..92087e2
 +#endif /* __GST_SVTHEVC_ENC_H__ */
 diff --git a/ext/svthevcenc/meson.build b/ext/svthevcenc/meson.build
 new file mode 100644
-index 0000000..941d7ad
+index 0000000..8733aef
 --- /dev/null
 +++ b/ext/svthevcenc/meson.build
 @@ -0,0 +1,18 @@
@@ -2083,7 +2083,7 @@ index 0000000..941d7ad
 +  'gstsvthevcenc.c',
 +]
 +
-+svthevcenc_dep = dependency('SvtHevcEnc', version : '>= 1.3.0', required: false)
++svthevcenc_dep = dependency('SvtHevcEnc', version : '>= 1.4.0', required: false)
 +
 +if svthevcenc_dep.found()
 +  gstsvthevcenc = library('gstsvthevcenc',

--- a/gstreamer-plugin/git-patch/0001-svthevcenc-Add-svthevc-encoder-element.patch
+++ b/gstreamer-plugin/git-patch/0001-svthevcenc-Add-svthevc-encoder-element.patch
@@ -1,4 +1,4 @@
-From b5de27131f9a9ede34e194ca5994e8653674ac79 Mon Sep 17 00:00:00 2001
+From b34d8368ff323b2974d984f8e7f8d367db19b7cf Mon Sep 17 00:00:00 2001
 From: Yeongjin Jeong <yeongjin.jeong@navercorp.com>
 Date: Sat, 23 Mar 2019 21:01:51 +0900
 Subject: [PATCH] svthevcenc: Add svthevc encoder element
@@ -8,14 +8,14 @@ Subject: [PATCH] svthevcenc: Add svthevc encoder element
  ext/Makefile.am                   |   12 +-
  ext/meson.build                   |    1 +
  ext/svthevcenc/Makefile.am        |   18 +
- ext/svthevcenc/gstsvthevcenc.c    | 1695 +++++++++++++++++++++++++++++++++++++
+ ext/svthevcenc/gstsvthevcenc.c    | 1696 +++++++++++++++++++++++++++++++++++++
  ext/svthevcenc/gstsvthevcenc.h    |  119 +++
  ext/svthevcenc/meson.build        |   18 +
  tests/check/Makefile.am           |    7 +
  tests/check/elements/.gitignore   |    1 +
  tests/check/elements/svthevcenc.c |  228 +++++
  tests/check/meson.build           |    1 +
- 11 files changed, 2106 insertions(+), 2 deletions(-)
+ 11 files changed, 2107 insertions(+), 2 deletions(-)
  create mode 100644 ext/svthevcenc/Makefile.am
  create mode 100644 ext/svthevcenc/gstsvthevcenc.c
  create mode 100644 ext/svthevcenc/gstsvthevcenc.h
@@ -127,10 +127,10 @@ index 0000000..6d7f55a
 +noinst_HEADERS = gstsvthevcenc.h
 diff --git a/ext/svthevcenc/gstsvthevcenc.c b/ext/svthevcenc/gstsvthevcenc.c
 new file mode 100644
-index 0000000..461fd62
+index 0000000..1ac1dcc
 --- /dev/null
 +++ b/ext/svthevcenc/gstsvthevcenc.c
-@@ -0,0 +1,1695 @@
+@@ -0,0 +1,1696 @@
 +/* GStreamer H265 encoder plugin
 + * Copyright (C) 2019 Yeongjin Jeong <yeongjin.jeong@navercorp.com>
 + *
@@ -1430,6 +1430,7 @@ index 0000000..461fd62
 +  read_in_data (&encoder->enc_params, fdata, headerPtr);
 +
 +  headerPtr->nFlags = 0;
++  headerPtr->sliceType = EB_INVALID_PICTURE;
 +  headerPtr->pAppPrivate = NULL;
 +  headerPtr->pts = frame->pts;
 +

--- a/gstreamer-plugin/git-patch/0001-svthevcenc-Add-svthevc-encoder-element.patch
+++ b/gstreamer-plugin/git-patch/0001-svthevcenc-Add-svthevc-encoder-element.patch
@@ -1,4 +1,4 @@
-From b34d8368ff323b2974d984f8e7f8d367db19b7cf Mon Sep 17 00:00:00 2001
+From 36076a5d6faf8e19e1ef8a4eb28bfe096b248c6b Mon Sep 17 00:00:00 2001
 From: Yeongjin Jeong <yeongjin.jeong@navercorp.com>
 Date: Sat, 23 Mar 2019 21:01:51 +0900
 Subject: [PATCH] svthevcenc: Add svthevc encoder element
@@ -8,14 +8,14 @@ Subject: [PATCH] svthevcenc: Add svthevc encoder element
  ext/Makefile.am                   |   12 +-
  ext/meson.build                   |    1 +
  ext/svthevcenc/Makefile.am        |   18 +
- ext/svthevcenc/gstsvthevcenc.c    | 1696 +++++++++++++++++++++++++++++++++++++
+ ext/svthevcenc/gstsvthevcenc.c    | 1817 +++++++++++++++++++++++++++++++++++++
  ext/svthevcenc/gstsvthevcenc.h    |  119 +++
  ext/svthevcenc/meson.build        |   18 +
  tests/check/Makefile.am           |    7 +
  tests/check/elements/.gitignore   |    1 +
  tests/check/elements/svthevcenc.c |  228 +++++
  tests/check/meson.build           |    1 +
- 11 files changed, 2107 insertions(+), 2 deletions(-)
+ 11 files changed, 2228 insertions(+), 2 deletions(-)
  create mode 100644 ext/svthevcenc/Makefile.am
  create mode 100644 ext/svthevcenc/gstsvthevcenc.c
  create mode 100644 ext/svthevcenc/gstsvthevcenc.h
@@ -127,10 +127,10 @@ index 0000000..6d7f55a
 +noinst_HEADERS = gstsvthevcenc.h
 diff --git a/ext/svthevcenc/gstsvthevcenc.c b/ext/svthevcenc/gstsvthevcenc.c
 new file mode 100644
-index 0000000..1ac1dcc
+index 0000000..b5635f3
 --- /dev/null
 +++ b/ext/svthevcenc/gstsvthevcenc.c
-@@ -0,0 +1,1696 @@
+@@ -0,0 +1,1817 @@
 +/* GStreamer H265 encoder plugin
 + * Copyright (C) 2019 Yeongjin Jeong <yeongjin.jeong@navercorp.com>
 + *
@@ -251,7 +251,7 @@ index 0000000..1ac1dcc
 +        "width = (int) [ 64, 8192 ], " "height = (int) [ 64, 4320 ], "
 +        "stream-format = (string) byte-stream, "
 +        "alignment = (string) au, "
-+        "profile = (string) { main, main-10, main-444 }")
++        "profile = (string) { main, main-10, main-422-10, main-444, main-444-10 }")
 +    );
 +
 +static void gst_svthevc_enc_finalize (GObject * object);
@@ -312,20 +312,27 @@ index 0000000..1ac1dcc
 +}
 +
 +static void
-+check_formats (const gchar * str, gboolean * has_420, gboolean * has_420_10,
-+    gboolean * has_422, gboolean * has_444)
++check_formats (const gchar * profile, guint * max_bit_depth,
++    guint * max_chroma_format)
 +{
-+  if (g_str_has_prefix (str, "main-10"))
-+    *has_420 = *has_420_10 = TRUE;
-+  else if (g_str_has_prefix (str, "main-444"))
-+    *has_420 = *has_420_10 = *has_422 = *has_444 = TRUE;
-+  else if (g_str_has_prefix (str, "main"))
-+    *has_420 = TRUE;
++  *max_bit_depth = *max_bit_depth > 0 ? *max_bit_depth : 8;
++  *max_chroma_format = *max_chroma_format > 0 ? *max_chroma_format : 1;
++
++  if (g_strrstr (profile, "-12"))
++    *max_bit_depth = 12;
++  else if (g_strrstr (profile, "-10"))
++    *max_bit_depth = *max_bit_depth >= 10 ? *max_bit_depth : 10;
++
++  if (g_strrstr (profile, "-444"))
++    *max_chroma_format = 3;
++  else if (g_strrstr (profile, "-422"))
++    *max_chroma_format = *max_chroma_format >= 2 ? *max_chroma_format : 2;
 +}
 +
 +static gboolean
 +gst_svthevc_enc_add_chroma_format (GstStructure * s, gboolean allow_420,
-+    gboolean allow_420_10, gboolean allow_422, gboolean allow_444)
++    gboolean allow_422, gboolean allow_444, gboolean allow_8bits,
++    gboolean allow_10bits)
 +{
 +  GValue fmts = G_VALUE_INIT;
 +  GValue fmt = G_VALUE_INIT;
@@ -334,42 +341,50 @@ index 0000000..1ac1dcc
 +  g_value_init (&fmts, GST_TYPE_LIST);
 +  g_value_init (&fmt, G_TYPE_STRING);
 +
-+  if (allow_420) {
-+    g_value_set_string (&fmt, "I420");
-+    gst_value_list_append_value (&fmts, &fmt);
++  if (allow_8bits) {
++    if (allow_420) {
++      g_value_set_string (&fmt, "I420");
++      gst_value_list_append_value (&fmts, &fmt);
++    }
++
++    if (allow_422) {
++      g_value_set_string (&fmt, "Y42B");
++      gst_value_list_append_value (&fmts, &fmt);
++    }
++
++    if (allow_444) {
++      g_value_set_string (&fmt, "Y444");
++      gst_value_list_append_value (&fmts, &fmt);
++    }
 +  }
 +
-+  if (allow_420_10) {
-+    if (G_BYTE_ORDER == G_LITTLE_ENDIAN)
-+      g_value_set_string (&fmt, "I420_10LE");
-+    else
-+      g_value_set_string (&fmt, "I420_10BE");
++  if (allow_10bits) {
++    if (allow_420) {
++      if (G_BYTE_ORDER == G_LITTLE_ENDIAN)
++        g_value_set_string (&fmt, "I420_10LE");
++      else
++        g_value_set_string (&fmt, "I420_10BE");
 +
-+    gst_value_list_append_value (&fmts, &fmt);
-+  }
++      gst_value_list_append_value (&fmts, &fmt);
++    }
 +
-+  if (allow_422) {
-+    g_value_set_string (&fmt, "Y42B");
-+    gst_value_list_append_value (&fmts, &fmt);
++    if (allow_422) {
++      if (G_BYTE_ORDER == G_LITTLE_ENDIAN)
++        g_value_set_string (&fmt, "I422_10LE");
++      else
++        g_value_set_string (&fmt, "I422_10BE");
 +
-+    if (G_BYTE_ORDER == G_LITTLE_ENDIAN)
-+      g_value_set_string (&fmt, "I422_10LE");
-+    else
-+      g_value_set_string (&fmt, "I422_10BE");
++      gst_value_list_append_value (&fmts, &fmt);
++    }
 +
-+    gst_value_list_append_value (&fmts, &fmt);
-+  }
++    if (allow_444) {
++      if (G_BYTE_ORDER == G_LITTLE_ENDIAN)
++        g_value_set_string (&fmt, "Y444_10LE");
++      else
++        g_value_set_string (&fmt, "Y444_10BE");
 +
-+  if (allow_444) {
-+    g_value_set_string (&fmt, "Y444");
-+    gst_value_list_append_value (&fmts, &fmt);
-+
-+    if (G_BYTE_ORDER == G_LITTLE_ENDIAN)
-+      g_value_set_string (&fmt, "Y444_10LE");
-+    else
-+      g_value_set_string (&fmt, "Y444_10BE");
-+
-+    gst_value_list_append_value (&fmts, &fmt);
++      gst_value_list_append_value (&fmts, &fmt);
++    }
 +  }
 +
 +  if (gst_value_list_get_size (&fmts) != 0) {
@@ -424,26 +439,41 @@ index 0000000..1ac1dcc
 +        gst_structure_set_value (s, "height", val);
 +
 +      if ((val = gst_structure_get_value (allowed_s, "profile"))) {
++        guint max_bit_depth = 0;
++        guint max_chroma_format = 0;
 +        gboolean has_420 = FALSE;
-+        gboolean has_420_10 = FALSE;
 +        gboolean has_422 = FALSE;
 +        gboolean has_444 = FALSE;
++        gboolean has_8bits = FALSE;
++        gboolean has_10bits = FALSE;
 +
 +        if (G_VALUE_HOLDS_STRING (val)) {
-+          check_formats (g_value_get_string (val), &has_420, &has_420_10,
-+              &has_422, &has_444);
++          check_formats (g_value_get_string (val), &max_bit_depth,
++              &max_chroma_format);
 +        } else if (GST_VALUE_HOLDS_LIST (val)) {
 +          for (k = 0; k < gst_value_list_get_size (val); k++) {
 +            const GValue *vlist = gst_value_list_get_value (val, k);
 +
 +            if (G_VALUE_HOLDS_STRING (vlist))
-+              check_formats (g_value_get_string (vlist), &has_420, &has_420_10,
-+                  &has_422, &has_444);
++              check_formats (g_value_get_string (vlist), &max_bit_depth,
++                  &max_chroma_format);
 +          }
 +        }
 +
-+        gst_svthevc_enc_add_chroma_format (s, has_420, has_420_10,
-+            has_422, has_444);
++        if (max_bit_depth >= 8)
++          has_8bits = TRUE;
++        if (max_bit_depth >= 10)
++          has_10bits = TRUE;
++
++        if (max_chroma_format >= 1)
++          has_420 = TRUE;
++        if (max_chroma_format >= 2)
++          has_422 = TRUE;
++        if (max_chroma_format >= 3)
++          has_444 = TRUE;
++
++        gst_svthevc_enc_add_chroma_format (s, has_420, has_422, has_444,
++            has_8bits, has_10bits);
 +      }
 +
 +      filter_caps = gst_caps_merge_structure (filter_caps, s);
@@ -1190,6 +1220,94 @@ index 0000000..1ac1dcc
 +  gst_video_encoder_set_latency (GST_VIDEO_ENCODER (encoder), latency, latency);
 +}
 +
++typedef struct
++{
++  const gchar *gst_profile;
++  const guint profile;
++} GstSvtHevcEncProfileTable;
++
++static const guint
++gst_svthevc_enc_profile_from_gst (const gchar * profile)
++{
++  gint i;
++  static const GstSvtHevcEncProfileTable profile_table[] = {
++    {"main", 1},
++    {"main-10", 2},
++    {"main-still-picture", 0},
++    {"main-12", 0},
++    {"main-422-10", 4},
++    {"main-422-12", 4},
++    {"main-444", 4},
++    {"main-444-10", 4},
++    {"main-444-12", 4},
++    {"main-intra", 0},
++    {"main-10-intra", 0},
++    {"main-12-intra", 0},
++    {"main-422-10-intra", 0},
++    {"main-422-12-intra", 0},
++    {"main-444-intra", 0},
++    {"main-444-10-intra", 0},
++    {"main-444-12-intra", 0},
++    {"main-444-16-intra", 0},
++    {"main-444-still-picture", 0},
++    {"main-444-16-still-picture", 0},
++  };
++
++  for (i = 0; i < G_N_ELEMENTS (profile_table); i++) {
++    if (!strcmp (profile, profile_table[i].gst_profile))
++      return profile_table[i].profile;
++  }
++
++  GST_WARNING ("Unsupported profile string '%s'", profile);
++  return 0;
++}
++
++static guint
++gst_svthevc_enc_level_from_gst (const gchar * level)
++{
++  if (g_str_equal (level, "1"))
++    return 10;
++  else if (g_str_equal (level, "2"))
++    return 20;
++  else if (g_str_equal (level, "2.1"))
++    return 21;
++  else if (g_str_equal (level, "3"))
++    return 30;
++  else if (g_str_equal (level, "3.1"))
++    return 31;
++  else if (g_str_equal (level, "4"))
++    return 40;
++  else if (g_str_equal (level, "4.1"))
++    return 41;
++  else if (g_str_equal (level, "5"))
++    return 50;
++  else if (g_str_equal (level, "5.1"))
++    return 51;
++  else if (g_str_equal (level, "5.2"))
++    return 52;
++  else if (g_str_equal (level, "6"))
++    return 60;
++  else if (g_str_equal (level, "6.1"))
++    return 61;
++  else if (g_str_equal (level, "6.2"))
++    return 62;
++
++  GST_WARNING ("Unsupported level string '%s'", level);
++  return LEVEL_DEFAULT;
++}
++
++static guint
++gst_svthevc_enc_tier_from_gst (const gchar * level)
++{
++  if (g_str_equal (level, "main"))
++    return 0;
++  else if (g_str_equal (level, "high"))
++    return 1;
++
++  GST_WARNING ("Unsupported tier string '%s'", level);
++  return TIER_DEFAULT;
++}
++
 +static gboolean
 +gst_svthevc_enc_set_format (GstVideoEncoder * video_enc,
 +    GstVideoCodecState * state)
@@ -1257,65 +1375,68 @@ index 0000000..1ac1dcc
 +      return FALSE;
 +    }
 +
-+    allowed_caps = gst_caps_make_writable (allowed_caps);
-+    allowed_caps = gst_caps_fixate (allowed_caps);
 +    s = gst_caps_get_structure (allowed_caps, 0);
 +
-+    profile = gst_structure_get_string (s, "profile");
-+    if (profile) {
-+      if (g_str_has_prefix (profile, "main-10")) {
-+        encoder->profile = 2;
-+      } else if (g_str_has_prefix (profile, "main-444")) {
-+        encoder->profile = 4;
-+      } else if (g_str_has_prefix (profile, "main")) {
-+        encoder->profile = 1;
-+      } else {
-+        g_assert_not_reached ();
++    if (gst_structure_has_field (s, "profile")) {
++      const GValue *v = gst_structure_get_value (s, "profile");
++      guint enc_profile = 0;
++      guint max_bit_depth = 0;
++      guint max_chroma_format = 0;
++      guint bit_depth = GST_VIDEO_INFO_COMP_DEPTH (info, 0);
++      guint chroma_format =
++          gst_svthevc_enc_gst_to_svthevc_video_format (info->finfo->format,
++          NULL);
++
++      if (GST_VALUE_HOLDS_LIST (v)) {
++        const gint list_size = gst_value_list_get_size (v);
++        gint i;
++
++        for (i = 0; i < list_size; i++) {
++          const GValue *list_val = gst_value_list_get_value (v, i);
++          profile = g_value_get_string (list_val);
++
++          if (profile) {
++            max_bit_depth = max_chroma_format = 0;
++            check_formats (profile, &max_bit_depth, &max_chroma_format);
++            if (bit_depth <= max_bit_depth
++                && chroma_format <= max_chroma_format) {
++              enc_profile = gst_svthevc_enc_profile_from_gst (profile);
++            }
++          }
++
++          if (enc_profile != 0)
++            break;
++        }
++      } else if (G_VALUE_HOLDS_STRING (v)) {
++        profile = g_value_get_string (v);
++
++        if (profile) {
++          max_bit_depth = max_chroma_format = 0;
++          check_formats (profile, &max_bit_depth, &max_chroma_format);
++          if (bit_depth <= max_bit_depth && chroma_format <= max_chroma_format) {
++            enc_profile = gst_svthevc_enc_profile_from_gst (profile);
++          }
++        }
 +      }
++
++      if (enc_profile == 0) {
++        GST_ERROR_OBJECT (encoder, "Could't apply peer profile");
++        gst_caps_unref (template_caps);
++        gst_caps_unref (allowed_caps);
++        return FALSE;
++      }
++
++      encoder->profile = enc_profile;
 +    }
 +
 +    level = gst_structure_get_string (s, "level");
 +    if (level) {
-+      if (g_str_has_prefix (level, "2.1")) {
-+        encoder->level = 21;
-+      } else if (g_str_has_prefix (level, "3.1")) {
-+        encoder->level = 31;
-+      } else if (g_str_has_prefix (level, "4.1")) {
-+        encoder->level = 41;
-+      } else if (g_str_has_prefix (level, "5.1")) {
-+        encoder->level = 51;
-+      } else if (g_str_has_prefix (level, "5.2")) {
-+        encoder->level = 52;
-+      } else if (g_str_has_prefix (level, "6.1")) {
-+        encoder->level = 61;
-+      } else if (g_str_has_prefix (level, "6.2")) {
-+        encoder->level = 62;
-+      } else if (g_str_has_prefix (level, "1")) {
-+        encoder->level = 10;
-+      } else if (g_str_has_prefix (level, "2")) {
-+        encoder->level = 20;
-+      } else if (g_str_has_prefix (level, "3")) {
-+        encoder->level = 30;
-+      } else if (g_str_has_prefix (level, "4")) {
-+        encoder->level = 40;
-+      } else if (g_str_has_prefix (level, "5")) {
-+        encoder->level = 50;
-+      } else if (g_str_has_prefix (level, "6")) {
-+        encoder->level = 60;
-+      } else {
-+        g_assert_not_reached ();
-+      }
++      encoder->level = gst_svthevc_enc_level_from_gst (level);
 +    }
 +
 +    tier = gst_structure_get_string (s, "tier");
 +    if (tier) {
-+      if (g_str_has_prefix (tier, "main")) {
-+        encoder->tier = 0;
-+      } else if (g_str_has_prefix (tier, "high")) {
-+        encoder->tier = 1;
-+      } else {
-+        g_assert_not_reached ();
-+      }
++      encoder->tier = gst_svthevc_enc_tier_from_gst (tier);
 +    }
 +
 +    gst_caps_unref (allowed_caps);

--- a/gstreamer-plugin/git-patch/0001-svthevcenc-Add-svthevc-encoder-element.patch
+++ b/gstreamer-plugin/git-patch/0001-svthevcenc-Add-svthevc-encoder-element.patch
@@ -1,4 +1,4 @@
-From bec356845f246158f2d9f377c4b72028312f3a1f Mon Sep 17 00:00:00 2001
+From 517b3d95feead6bc775d01d860d504265bda62b2 Mon Sep 17 00:00:00 2001
 From: Yeongjin Jeong <yeongjin.jeong@navercorp.com>
 Date: Sat, 23 Mar 2019 21:01:51 +0900
 Subject: [PATCH] svthevcenc: Add svthevc encoder element
@@ -9,13 +9,13 @@ Subject: [PATCH] svthevcenc: Add svthevc encoder element
  ext/meson.build                   |    1 +
  ext/svthevcenc/Makefile.am        |   18 +
  ext/svthevcenc/gstsvthevcenc.c    | 1803 +++++++++++++++++++++++++++++++++++++
- ext/svthevcenc/gstsvthevcenc.h    |  118 +++
+ ext/svthevcenc/gstsvthevcenc.h    |  116 +++
  ext/svthevcenc/meson.build        |   18 +
  tests/check/Makefile.am           |    7 +
  tests/check/elements/.gitignore   |    1 +
  tests/check/elements/svthevcenc.c |  228 +++++
  tests/check/meson.build           |    1 +
- 11 files changed, 2213 insertions(+), 2 deletions(-)
+ 11 files changed, 2211 insertions(+), 2 deletions(-)
  create mode 100644 ext/svthevcenc/Makefile.am
  create mode 100644 ext/svthevcenc/gstsvthevcenc.c
  create mode 100644 ext/svthevcenc/gstsvthevcenc.h
@@ -1936,10 +1936,10 @@ index 0000000..b98e19c
 +    plugin_init, VERSION, "GPL", GST_PACKAGE_NAME, GST_PACKAGE_ORIGIN)
 diff --git a/ext/svthevcenc/gstsvthevcenc.h b/ext/svthevcenc/gstsvthevcenc.h
 new file mode 100644
-index 0000000..b9681e2
+index 0000000..8ad57f7
 --- /dev/null
 +++ b/ext/svthevcenc/gstsvthevcenc.h
-@@ -0,0 +1,118 @@
+@@ -0,0 +1,116 @@
 +/* GStreamer H265 encoder plugin
 + * Copyright (C) 2019 Yeongjin Jeong <yeongjin.jeong@navercorp.com>
 + *
@@ -1966,8 +1966,6 @@ index 0000000..b9681e2
 +#include <gst/video/video.h>
 +#include <gst/video/gstvideoencoder.h>
 +
-+#include <EbErrorCodes.h>
-+#include <EbTime.h>
 +#include <EbApi.h>
 +
 +G_BEGIN_DECLS

--- a/gstreamer-plugin/git-patch/0001-svthevcenc-Add-svthevc-encoder-element.patch
+++ b/gstreamer-plugin/git-patch/0001-svthevcenc-Add-svthevc-encoder-element.patch
@@ -1,4 +1,4 @@
-From d61986d829fe80870103c3c5788321cec7d54597 Mon Sep 17 00:00:00 2001
+From f384eea601907fdfd0ac8f32a281b93b78cbd9fd Mon Sep 17 00:00:00 2001
 From: Yeongjin Jeong <yeongjin.jeong@navercorp.com>
 Date: Sat, 23 Mar 2019 21:01:51 +0900
 Subject: [PATCH] svthevcenc: Add svthevc encoder element
@@ -8,14 +8,14 @@ Subject: [PATCH] svthevcenc: Add svthevc encoder element
  ext/Makefile.am                   |   12 +-
  ext/meson.build                   |    1 +
  ext/svthevcenc/Makefile.am        |   18 +
- ext/svthevcenc/gstsvthevcenc.c    | 1863 +++++++++++++++++++++++++++++
+ ext/svthevcenc/gstsvthevcenc.c    | 1865 +++++++++++++++++++++++++++++
  ext/svthevcenc/gstsvthevcenc.h    |  116 ++
  ext/svthevcenc/meson.build        |   18 +
  tests/check/Makefile.am           |    7 +
  tests/check/elements/.gitignore   |    1 +
  tests/check/elements/svthevcenc.c |  228 ++++
  tests/check/meson.build           |    1 +
- 11 files changed, 2271 insertions(+), 2 deletions(-)
+ 11 files changed, 2273 insertions(+), 2 deletions(-)
  create mode 100644 ext/svthevcenc/Makefile.am
  create mode 100644 ext/svthevcenc/gstsvthevcenc.c
  create mode 100644 ext/svthevcenc/gstsvthevcenc.h
@@ -127,10 +127,10 @@ index 000000000..6d7f55aa9
 +noinst_HEADERS = gstsvthevcenc.h
 diff --git a/ext/svthevcenc/gstsvthevcenc.c b/ext/svthevcenc/gstsvthevcenc.c
 new file mode 100644
-index 000000000..80b2fe085
+index 000000000..6096f6cf0
 --- /dev/null
 +++ b/ext/svthevcenc/gstsvthevcenc.c
-@@ -0,0 +1,1863 @@
+@@ -0,0 +1,1865 @@
 +/* GStreamer H265 encoder plugin
 + * Copyright (C) 2019 Yeongjin Jeong <yeongjin.jeong@navercorp.com>
 + *
@@ -943,22 +943,24 @@ index 000000000..80b2fe085
 +read_in_data (EB_H265_ENC_CONFIGURATION * config,
 +    FrameData * fdata, EB_BUFFERHEADERTYPE * headerPtr)
 +{
-+  uint8_t is16bit = config->encoderBitDepth > 8;
-+  uint64_t luma_size =
-+      (uint64_t) config->sourceWidth * config->sourceHeight << is16bit;
 +  EB_H265_ENC_INPUT *in_data = (EB_H265_ENC_INPUT *) headerPtr->pBuffer;
 +
 +  in_data->luma = GST_VIDEO_FRAME_PLANE_DATA (&fdata->vframe, 0);
 +  in_data->cb = GST_VIDEO_FRAME_PLANE_DATA (&fdata->vframe, 1);
 +  in_data->cr = GST_VIDEO_FRAME_PLANE_DATA (&fdata->vframe, 2);
 +
-+  in_data->yStride = GST_VIDEO_FRAME_COMP_STRIDE (&fdata->vframe, 0) >> is16bit;
++  in_data->yStride =
++      GST_VIDEO_FRAME_COMP_STRIDE (&fdata->vframe,
++      0) / GST_VIDEO_FRAME_COMP_PSTRIDE (&fdata->vframe, 0);
 +  in_data->cbStride =
-+      GST_VIDEO_FRAME_COMP_STRIDE (&fdata->vframe, 1) >> is16bit;
++      GST_VIDEO_FRAME_COMP_STRIDE (&fdata->vframe,
++      1) / GST_VIDEO_FRAME_COMP_PSTRIDE (&fdata->vframe, 1);
 +  in_data->crStride =
-+      GST_VIDEO_FRAME_COMP_STRIDE (&fdata->vframe, 2) >> is16bit;
++      GST_VIDEO_FRAME_COMP_STRIDE (&fdata->vframe,
++      2) / GST_VIDEO_FRAME_COMP_PSTRIDE (&fdata->vframe, 2);
 +
-+  headerPtr->nAllocLen = headerPtr->nFilledLen = luma_size * 3 / 2u;
++  headerPtr->nAllocLen = headerPtr->nFilledLen =
++      GST_VIDEO_FRAME_SIZE (&fdata->vframe);
 +}
 +
 +/*

--- a/gstreamer-plugin/git-patch/0001-svthevcenc-Add-svthevc-encoder-element.patch
+++ b/gstreamer-plugin/git-patch/0001-svthevcenc-Add-svthevc-encoder-element.patch
@@ -1,4 +1,4 @@
-From 1d1cfa17a2cfa33ff76bb99288184f969f465182 Mon Sep 17 00:00:00 2001
+From 2c2ad0d7a3fd2540d6cf65a7c154f1ecd88194b6 Mon Sep 17 00:00:00 2001
 From: Yeongjin Jeong <yeongjin.jeong@navercorp.com>
 Date: Sat, 23 Mar 2019 21:01:51 +0900
 Subject: [PATCH] svthevcenc: Add svthevc encoder element
@@ -23,17 +23,17 @@ Subject: [PATCH] svthevcenc: Add svthevc encoder element
  create mode 100644 tests/check/elements/svthevcenc.c
 
 diff --git a/configure.ac b/configure.ac
-index dbd15419d..3f128d83b 100644
+index dbd15419d..9c38c427a 100644
 --- a/configure.ac
 +++ b/configure.ac
 @@ -2107,6 +2107,12 @@ if test "x$HAVE_LTC" = "xyes"; then
    AC_DEFINE(HAVE_LTC, 1, [Use libltc])
  fi
  
-+dnl *** svthevcenc : works with libSVT-HEVC 1.4.0 ***
++dnl *** svthevcenc : works with libSVT-HEVC 1.4.1 ***
 +translit(dnm, m, l) AM_CONDITIONAL(USE_SVTHEVCENC, true)
 +AG_GST_CHECK_FEATURE(SVTHEVCENC, [svthevcenc plug-in], svthevcenc, [
-+  AG_GST_PKG_CHECK_MODULES(SVTHEVCENC, SvtHevcEnc >= 1.4.0)
++  AG_GST_PKG_CHECK_MODULES(SVTHEVCENC, SvtHevcEnc >= 1.4.1)
 +])
 +
  else
@@ -127,7 +127,7 @@ index 000000000..6d7f55aa9
 +noinst_HEADERS = gstsvthevcenc.h
 diff --git a/ext/svthevcenc/gstsvthevcenc.c b/ext/svthevcenc/gstsvthevcenc.c
 new file mode 100644
-index 000000000..b49fbca3a
+index 000000000..cb95d55e9
 --- /dev/null
 +++ b/ext/svthevcenc/gstsvthevcenc.c
 @@ -0,0 +1,1878 @@
@@ -918,7 +918,7 @@ index 000000000..b49fbca3a
 +   * before receiving encoded packets, It cause bug which encoded packets
 +   * are not output.
 +   */
-+  if (SVT_CHECK_VERSION (1, 5, 0))
++  if (SVT_CHECK_VERSION (1, 4, 1))
 +    param->codeVpsSpsPps = 1;
 +  else
 +    param->codeVpsSpsPps = 0;
@@ -2134,7 +2134,7 @@ index 000000000..5a2bdcd14
 +#endif /* __GST_SVTHEVC_ENC_H__ */
 diff --git a/ext/svthevcenc/meson.build b/ext/svthevcenc/meson.build
 new file mode 100644
-index 000000000..8733aef60
+index 000000000..2c672deec
 --- /dev/null
 +++ b/ext/svthevcenc/meson.build
 @@ -0,0 +1,18 @@
@@ -2142,7 +2142,7 @@ index 000000000..8733aef60
 +  'gstsvthevcenc.c',
 +]
 +
-+svthevcenc_dep = dependency('SvtHevcEnc', version : '>= 1.4.0', required: false)
++svthevcenc_dep = dependency('SvtHevcEnc', version : '>= 1.4.1', required: false)
 +
 +if svthevcenc_dep.found()
 +  gstsvthevcenc = library('gstsvthevcenc',

--- a/gstreamer-plugin/git-patch/0001-svthevcenc-Add-svthevc-encoder-element.patch
+++ b/gstreamer-plugin/git-patch/0001-svthevcenc-Add-svthevc-encoder-element.patch
@@ -1,4 +1,4 @@
-From 51a65a6a772cba2d5b030b2094f849ad7523bf59 Mon Sep 17 00:00:00 2001
+From d61986d829fe80870103c3c5788321cec7d54597 Mon Sep 17 00:00:00 2001
 From: Yeongjin Jeong <yeongjin.jeong@navercorp.com>
 Date: Sat, 23 Mar 2019 21:01:51 +0900
 Subject: [PATCH] svthevcenc: Add svthevc encoder element
@@ -8,14 +8,14 @@ Subject: [PATCH] svthevcenc: Add svthevc encoder element
  ext/Makefile.am                   |   12 +-
  ext/meson.build                   |    1 +
  ext/svthevcenc/Makefile.am        |   18 +
- ext/svthevcenc/gstsvthevcenc.c    | 1824 +++++++++++++++++++++++++++++
+ ext/svthevcenc/gstsvthevcenc.c    | 1863 +++++++++++++++++++++++++++++
  ext/svthevcenc/gstsvthevcenc.h    |  116 ++
  ext/svthevcenc/meson.build        |   18 +
  tests/check/Makefile.am           |    7 +
  tests/check/elements/.gitignore   |    1 +
  tests/check/elements/svthevcenc.c |  228 ++++
  tests/check/meson.build           |    1 +
- 11 files changed, 2232 insertions(+), 2 deletions(-)
+ 11 files changed, 2271 insertions(+), 2 deletions(-)
  create mode 100644 ext/svthevcenc/Makefile.am
  create mode 100644 ext/svthevcenc/gstsvthevcenc.c
  create mode 100644 ext/svthevcenc/gstsvthevcenc.h
@@ -127,10 +127,10 @@ index 000000000..6d7f55aa9
 +noinst_HEADERS = gstsvthevcenc.h
 diff --git a/ext/svthevcenc/gstsvthevcenc.c b/ext/svthevcenc/gstsvthevcenc.c
 new file mode 100644
-index 000000000..0ab79a44e
+index 000000000..80b2fe085
 --- /dev/null
 +++ b/ext/svthevcenc/gstsvthevcenc.c
-@@ -0,0 +1,1824 @@
+@@ -0,0 +1,1863 @@
 +/* GStreamer H265 encoder plugin
 + * Copyright (C) 2019 Yeongjin Jeong <yeongjin.jeong@navercorp.com>
 + *
@@ -1090,9 +1090,11 @@ index 000000000..0ab79a44e
 +{
 +  EB_BUFFERHEADERTYPE *headerPtr = NULL, *nal = NULL;
 +  EB_ERRORTYPE svt_ret;
-+  gboolean ret = TRUE;
 +  const gchar *level, *tier, *profile;
 +  GstStructure *s;
++  GstCaps *allowed_caps;
++  GstStructure *s2;
++  const gchar *allowed_profile;
 +
 +  GST_DEBUG_OBJECT (encoder, "set profile, level and tier");
 +
@@ -1111,6 +1113,8 @@ index 000000000..0ab79a44e
 +  gst_codec_utils_h265_caps_set_level_tier_and_profile (caps,
 +      nal->pBuffer + 6, nal->nFilledLen - 6);
 +
++  svthevc_nal_free (nal);
++
 +  s = gst_caps_get_structure (caps, 0);
 +  profile = gst_structure_get_string (s, "profile");
 +  tier = gst_structure_get_string (s, "tier");
@@ -1120,9 +1124,44 @@ index 000000000..0ab79a44e
 +  GST_DEBUG_OBJECT (encoder, "tier    : %s", (tier) ? tier : "---");
 +  GST_DEBUG_OBJECT (encoder, "level   : %s", (level) ? level : "---");
 +
-+  svthevc_nal_free (nal);
++  /* Relaxing the profile condition since libSvtHevcEnc can generate
++   * wrong bitstream indication for conformance to profile than requested one.
++   * See : https://github.com/OpenVisualCloud/SVT-HEVC/pull/320
++   */
++  allowed_caps = gst_pad_get_allowed_caps (GST_VIDEO_ENCODER_SRC_PAD (encoder));
 +
-+  return ret;
++  if (allowed_caps == NULL)
++    goto no_peer;
++
++  if (!gst_caps_can_intersect (allowed_caps, caps)) {
++    guint peer_bitdepth = 0;
++    guint peer_chroma_format = 0;
++    guint bitdepth = 0;
++    guint chroma_format = 0;
++
++    allowed_caps = gst_caps_make_writable (allowed_caps);
++    allowed_caps = gst_caps_truncate (allowed_caps);
++    s2 = gst_caps_get_structure (allowed_caps, 0);
++    gst_structure_fixate_field_string (s2, "profile", profile);
++    allowed_profile = gst_structure_get_string (s2, "profile");
++
++    check_formats (allowed_profile, &peer_chroma_format, &peer_bitdepth);
++    check_formats (profile, &chroma_format, &bitdepth);
++
++    if (chroma_format <= peer_chroma_format && bitdepth <= peer_bitdepth) {
++      GST_INFO_OBJECT (encoder, "downstream requested %s profile, but "
++          "encoder will now output %s profile (which is a subset), due "
++          "to how it's been configured", allowed_profile, profile);
++      gst_structure_set (s, "profile", G_TYPE_STRING, allowed_profile, NULL);
++    } else {
++      gst_caps_unref (allowed_caps);
++      return FALSE;
++    }
++  }
++  gst_caps_unref (allowed_caps);
++
++no_peer:
++  return TRUE;
 +}
 +
 +static GstBuffer *

--- a/gstreamer-plugin/git-patch/0001-svthevcenc-Add-svthevc-encoder-element.patch
+++ b/gstreamer-plugin/git-patch/0001-svthevcenc-Add-svthevc-encoder-element.patch
@@ -1,4 +1,4 @@
-From 6aa6816e6f217e02315e9bbd7cb5c7fc16026192 Mon Sep 17 00:00:00 2001
+From bec356845f246158f2d9f377c4b72028312f3a1f Mon Sep 17 00:00:00 2001
 From: Yeongjin Jeong <yeongjin.jeong@navercorp.com>
 Date: Sat, 23 Mar 2019 21:01:51 +0900
 Subject: [PATCH] svthevcenc: Add svthevc encoder element
@@ -8,14 +8,14 @@ Subject: [PATCH] svthevcenc: Add svthevc encoder element
  ext/Makefile.am                   |   12 +-
  ext/meson.build                   |    1 +
  ext/svthevcenc/Makefile.am        |   18 +
- ext/svthevcenc/gstsvthevcenc.c    | 1817 +++++++++++++++++++++++++++++++++++++
- ext/svthevcenc/gstsvthevcenc.h    |  119 +++
+ ext/svthevcenc/gstsvthevcenc.c    | 1803 +++++++++++++++++++++++++++++++++++++
+ ext/svthevcenc/gstsvthevcenc.h    |  118 +++
  ext/svthevcenc/meson.build        |   18 +
  tests/check/Makefile.am           |    7 +
  tests/check/elements/.gitignore   |    1 +
  tests/check/elements/svthevcenc.c |  228 +++++
  tests/check/meson.build           |    1 +
- 11 files changed, 2228 insertions(+), 2 deletions(-)
+ 11 files changed, 2213 insertions(+), 2 deletions(-)
  create mode 100644 ext/svthevcenc/Makefile.am
  create mode 100644 ext/svthevcenc/gstsvthevcenc.c
  create mode 100644 ext/svthevcenc/gstsvthevcenc.h
@@ -127,10 +127,10 @@ index 0000000..6d7f55a
 +noinst_HEADERS = gstsvthevcenc.h
 diff --git a/ext/svthevcenc/gstsvthevcenc.c b/ext/svthevcenc/gstsvthevcenc.c
 new file mode 100644
-index 0000000..b5635f3
+index 0000000..b98e19c
 --- /dev/null
 +++ b/ext/svthevcenc/gstsvthevcenc.c
-@@ -0,0 +1,1817 @@
+@@ -0,0 +1,1803 @@
 +/* GStreamer H265 encoder plugin
 + * Copyright (C) 2019 Yeongjin Jeong <yeongjin.jeong@navercorp.com>
 + *
@@ -190,7 +190,6 @@ index 0000000..b5635f3
 +  PROP_QP_MIN,
 +  PROP_SCENE_CHANGE_DETECTION,
 +  PROP_TUNE,
-+  PROP_LATENCY_MODE,
 +  PROP_BASE_LAYER_SWITCH_MODE,
 +  PROP_BITRATE,
 +  PROP_KEY_INT_MAX,
@@ -213,7 +212,6 @@ index 0000000..b5635f3
 +#define PROP_QP_MIN_DEFAULT                 10
 +#define PROP_SCENE_CHANGE_DETECTION_DEFAULT TRUE
 +#define PROP_TUNE_DEFAULT                   1
-+#define PROP_LATENCY_MODE_DEFAULT           0
 +#define PROP_BASE_LAYER_SWITCH_MODE_DEFAULT 0
 +#define PROP_BITRATE_DEFAULT                (7 * 1000)
 +#define PROP_KEY_INT_MAX_DEFAULT            -2
@@ -591,12 +589,6 @@ index 0000000..b5635f3
 +          0, 2, PROP_TUNE_DEFAULT,
 +          G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS | G_PARAM_DEPRECATED));
 +
-+  g_object_class_install_property (gobject_class, PROP_LATENCY_MODE,
-+      g_param_spec_uint ("latency-mode", "Latency Mode",
-+          "Flag to enable for lower latency mode: 0=Normal Latency, 1=Low Latency",
-+          0, 1, PROP_LATENCY_MODE_DEFAULT,
-+          G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
-+
 +  g_object_class_install_property (gobject_class, PROP_BASE_LAYER_SWITCH_MODE,
 +      g_param_spec_uint ("baselayer-mode", "Base Layer Switch Mode",
 +          "Random Access Prediction Structure type setting: 0=Use B-frames in the base layer pointing to the same past picture, 1=Use P-frames in the base layer",
@@ -895,7 +887,7 @@ index 0000000..b5635f3
 +  param->rateControlMode = encoder->rc_mode;
 +  param->sceneChangeDetection = encoder->scene_change_detection;
 +  param->tune = encoder->tune;
-+  param->latencyMode = encoder->latency_mode;
++  param->latencyMode = 0;
 +  param->baseLayerSwitchMode = encoder->base_layer_switch_mode;
 +  param->qp = encoder->qp;
 +  param->accessUnitDelimiter = encoder->aud;
@@ -1807,9 +1799,6 @@ index 0000000..b5635f3
 +    case PROP_TUNE:
 +      encoder->tune = g_value_get_uint (value);
 +      break;
-+    case PROP_LATENCY_MODE:
-+      encoder->latency_mode = g_value_get_uint (value);
-+      break;
 +    case PROP_BASE_LAYER_SWITCH_MODE:
 +      encoder->base_layer_switch_mode = g_value_get_uint (value);
 +      break;
@@ -1896,9 +1885,6 @@ index 0000000..b5635f3
 +    case PROP_TUNE:
 +      g_value_set_uint (value, encoder->tune);
 +      break;
-+    case PROP_LATENCY_MODE:
-+      g_value_set_uint (value, encoder->latency_mode);
-+      break;
 +    case PROP_BASE_LAYER_SWITCH_MODE:
 +      g_value_set_uint (value, encoder->base_layer_switch_mode);
 +      break;
@@ -1950,10 +1936,10 @@ index 0000000..b5635f3
 +    plugin_init, VERSION, "GPL", GST_PACKAGE_NAME, GST_PACKAGE_ORIGIN)
 diff --git a/ext/svthevcenc/gstsvthevcenc.h b/ext/svthevcenc/gstsvthevcenc.h
 new file mode 100644
-index 0000000..92087e2
+index 0000000..b9681e2
 --- /dev/null
 +++ b/ext/svthevcenc/gstsvthevcenc.h
-@@ -0,0 +1,119 @@
+@@ -0,0 +1,118 @@
 +/* GStreamer H265 encoder plugin
 + * Copyright (C) 2019 Yeongjin Jeong <yeongjin.jeong@navercorp.com>
 + *
@@ -2037,7 +2023,6 @@ index 0000000..92087e2
 +  guint qp_min;
 +  gboolean scene_change_detection;
 +  guint tune;
-+  guint latency_mode;
 +  guint base_layer_switch_mode;
 +  guint bitrate;
 +  gint keyintmax;

--- a/gstreamer-plugin/git-patch/0001-svthevcenc-Add-svthevc-encoder-element.patch
+++ b/gstreamer-plugin/git-patch/0001-svthevcenc-Add-svthevc-encoder-element.patch
@@ -1,4 +1,4 @@
-From 7ce46057db9daae39a188352c89c0397c2945a3d Mon Sep 17 00:00:00 2001
+From 1d1cfa17a2cfa33ff76bb99288184f969f465182 Mon Sep 17 00:00:00 2001
 From: Yeongjin Jeong <yeongjin.jeong@navercorp.com>
 Date: Sat, 23 Mar 2019 21:01:51 +0900
 Subject: [PATCH] svthevcenc: Add svthevc encoder element
@@ -13,9 +13,9 @@ Subject: [PATCH] svthevcenc: Add svthevc encoder element
  ext/svthevcenc/meson.build        |   18 +
  tests/check/Makefile.am           |    7 +
  tests/check/elements/.gitignore   |    1 +
- tests/check/elements/svthevcenc.c |  228 ++++
+ tests/check/elements/svthevcenc.c |  261 ++++
  tests/check/meson.build           |    1 +
- 11 files changed, 2287 insertions(+), 2 deletions(-)
+ 11 files changed, 2320 insertions(+), 2 deletions(-)
  create mode 100644 ext/svthevcenc/Makefile.am
  create mode 100644 ext/svthevcenc/gstsvthevcenc.c
  create mode 100644 ext/svthevcenc/gstsvthevcenc.h
@@ -2193,10 +2193,10 @@ index ca99cecfa..7a6834bd7 100644
  zbar
 diff --git a/tests/check/elements/svthevcenc.c b/tests/check/elements/svthevcenc.c
 new file mode 100644
-index 000000000..0545b3c68
+index 000000000..bb25a1ede
 --- /dev/null
 +++ b/tests/check/elements/svthevcenc.c
-@@ -0,0 +1,228 @@
+@@ -0,0 +1,261 @@
 +/* GStreamer
 + * Copyright (C) 2019 Yeongjin Jeong <yeongjin.jeong@navercorp.com>
 + *
@@ -2410,6 +2410,38 @@ index 000000000..0545b3c68
 +
 +GST_END_TEST;
 +
++GST_START_TEST (test_no_encoding)
++{
++  GstElement *svthevcenc;
++  GstCaps *outcaps, *srccaps;
++  GstSegment seg;
++
++  svthevcenc =
++      setup_svthevcenc
++      ("video/x-raw,format=(string)I420,width=(int)320,height=(int)240,framerate=(fraction)25/1",
++      &srccaps);
++
++  ASSERT_SET_STATE (svthevcenc, GST_STATE_PLAYING, GST_STATE_CHANGE_SUCCESS);
++
++  gst_segment_init (&seg, GST_FORMAT_TIME);
++  seg.stop = gst_util_uint64_scale (10, GST_SECOND, 25);
++
++  gst_check_setup_events (srcpad, svthevcenc, srccaps, GST_FORMAT_TIME);
++  fail_unless (gst_pad_push_event (srcpad, gst_event_new_segment (&seg)));
++  fail_unless (gst_pad_push_event (srcpad, gst_event_new_eos ()));
++
++  outcaps =
++      gst_caps_from_string
++      ("video/x-h265,width=(int)320,height=(int)240,framerate=(fraction)25/1");
++
++  gst_caps_unref (outcaps);
++  gst_caps_unref (srccaps);
++
++  cleanup_svthevcenc (svthevcenc);
++}
++
++GST_END_TEST;
++
 +static Suite *
 +svthevcenc_suite (void)
 +{
@@ -2420,13 +2452,14 @@ index 000000000..0545b3c68
 +
 +  tcase_add_test (tc_chain, test_encode_simple);
 +  tcase_add_test (tc_chain, test_reuse);
++  tcase_add_test (tc_chain, test_no_encoding);
 +
 +  return s;
 +}
 +
 +GST_CHECK_MAIN (svthevcenc);
 diff --git a/tests/check/meson.build b/tests/check/meson.build
-index 9ad6439be..76a25f28d 100644
+index 3f08a6973..e34091dc9 100644
 --- a/tests/check/meson.build
 +++ b/tests/check/meson.build
 @@ -36,6 +36,7 @@ base_tests = [


### PR DESCRIPTION
* Fix deadlock on encoder initializing failure
Don't miss unlock before returning.

* Ensure that slice type is initialized to default value
Don't keep the previous slice type. This may request an unintended slice type.

* Enhance profile setting with requested profile by peer
SVT-HEVC encoder does not yet support auto profile selection, So try
all profiles allowed by peer until SVT-HEVC encoder can accept one of them.

* Consider subset relations of profiles when setting srcpad caps
Relaxing the profile condition since libSvtHevcEnc can generate
wrong bitstream indication for conformance to profile than requested one.

* Don't use deprecated latency_mode parameter
The SVT-HEVC encoder does not support latency_mode parameter since 1.4.0.

* Remove unused headers

* Bump libsvthevcenc requirement to 1.4.1

* Disable codeVpsSpsPps flag depending on version

* Fix merge conflict in latest Gstreamer