### PR TITLE
Appveyor: Add ffmpeg build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,7 @@ script:
     cmake $TRAVIS_BUILD_DIR -G"Unix Makefiles" -DCMAKE_BUILD_TYPE=$build_type ${CMAKE_EFLAGS[@]}
     cmake -j $(if [ $TRAVIS_OS_NAME = osx ]; then sysctl -n hw.ncpu; else nproc; fi) --build . &&
     sudo cmake --build . --target install && cd $TRAVIS_BUILD_DIR
-  - SvtHevcEncApp -encMode 9 -i akiyo_cif.y4m -b test1.h265
+  - travis_wait SvtHevcEncApp -encMode 9 -i akiyo_cif.y4m -b test1.h265
 before_cache:
   - "sudo chown -R travis: $HOME/.ccache"
 matrix:
@@ -67,8 +67,8 @@ matrix:
     - os: osx
       compiler: gcc # gcc = clang in macOS, unecessary duplicate
   include:
-  # valgrind --tool=memcheck --leak-check=yes --show-reachable=yes ./SvtHevcEncApp -help
-  # Coding style check
+    # valgrind --tool=memcheck --leak-check=yes --show-reachable=yes ./SvtHevcEncApp -help
+    # Coding style check
     - name: Style check
       stage: style
       addons: skip
@@ -77,28 +77,28 @@ matrix:
       script:
         - git grep -InP --heading "\t|\r| $" -- .  && IS_FAIL=true || true
         - git grep -I -l -z "" -- . | while IFS= read -r -d '' i; do
-              if [ -n "$(tail -c 1 "$i")" ]; then
-                  echo "No newline at end of $i";
-                  IS_FAIL=true;
-              fi;
+          if [ -n "$(tail -c 1 "$i")" ]; then
+          echo "No newline at end of $i";
+          IS_FAIL=true;
+          fi;
           done
         - git remote rm upstream 2> /dev/null || true
         - git remote add upstream https://github.com/OpenVisualCloud/SVT-HEVC.git
         - git fetch -q upstream master
         - for i in $(git rev-list HEAD ^upstream/master); do
-              echo "Checking commit message of $i";
-              msg="$(git log --format=%B -n 1 $i)";
-              if [ -n "$(echo "$msg" | awk "NR==2")" ]; then
-                  echo "Malformed commit message in $i, second line must be empty";
-                  IS_FAIL=true;
-              fi;
-              if echo "$msg" | head -1 | grep -q '\.$'; then
-                  echo "Malformed commit message in $i, trailing period in subject line";
-                  IS_FAIL=true;
-              fi;
+          echo "Checking commit message of $i";
+          msg="$(git log --format=%B -n 1 $i)";
+          if [ -n "$(echo "$msg" | awk "NR==2")" ]; then
+          echo "Malformed commit message in $i, second line must be empty";
+          IS_FAIL=true;
+          fi;
+          if echo "$msg" | head -1 | grep -q '\.$'; then
+          echo "Malformed commit message in $i, trailing period in subject line";
+          IS_FAIL=true;
+          fi;
           done
         - test -z "$IS_FAIL"
-   # FFmpeg interation build
+    # FFmpeg interation build
     - name: FFmpeg patch
       stage: test
       compiler: gcc
@@ -136,15 +136,15 @@ matrix:
         - mv -t $HOME akiyo_cif.y4m
         - *base_script
         - cd $HOME
-        - SvtHevcEncApp -encMode 9 -i akiyo_cif.y4m -n 120 -b test-pr-m9.h265
-        - SvtHevcEncApp -encMode 0 -i akiyo_cif.y4m -n 3 -b test-pr-m0.h265
+        - travis_wait SvtHevcEncApp -encMode 9 -i akiyo_cif.y4m -n 120 -b test-pr-m9.h265
+        - travis_wait SvtHevcEncApp -encMode 0 -i akiyo_cif.y4m -n 3 -b test-pr-m0.h265
         - rm -rf $TRAVIS_BUILD_DIR
         - git clone --depth 1 https://github.com/OpenVisualCloud/SVT-HEVC.git $TRAVIS_BUILD_DIR && cd $TRAVIS_BUILD_DIR
         - *base_script
         - mkdir -p $TRAVIS_BUILD_DIR/Build/linux/$build_type
         - cd $HOME
-        - SvtHevcEncApp -encMode 9 -i akiyo_cif.y4m -n 120 -b test-master-m9.h265
-        - SvtHevcEncApp -encMode 0 -i akiyo_cif.y4m -n 3 -b test-master-m0.h265
+        - travis_wait SvtHevcEncApp -encMode 9 -i akiyo_cif.y4m -n 120 -b test-master-m9.h265
+        - travis_wait SvtHevcEncApp -encMode 0 -i akiyo_cif.y4m -n 3 -b test-master-m0.h265
         - diff test-pr-m9.h265 test-master-m9.h265
         - diff test-pr-m0.h265 test-master-m0.h265
     - name: Coveralls Linux+gcc
@@ -155,7 +155,7 @@ matrix:
       script:
         - *base_script
         - &coveralls_script |
-          SvtHevcEncApp -encMode 9 -i akiyo_cif.y4m -b test1.h265
+          travis_wait SvtHevcEncApp -encMode 9 -i akiyo_cif.y4m -b test1.h265
           git clone https://github.com/FFmpeg/FFmpeg ffmpeg --depth=1 --branch release/4.1
           cd ffmpeg
           git am $TRAVIS_BUILD_DIR/ffmpeg_plugin/0001-lavc-svt_hevc-add-libsvt-hevc-encoder-wrapper.patch &&
@@ -166,7 +166,7 @@ matrix:
           sudo make install
           cd $TRAVIS_BUILD_DIR
           ffmpeg -i akiyo_cif.y4m -c:v libsvt_hevc test.h265
-          SvtHevcEncApp -i stdin -w 352 -h 288 -fps 30 -n 150 -b test2.h265 < akiyo_cif.y4m
+          travis_wait SvtHevcEncApp -i stdin -w 352 -h 288 -fps 30 -n 150 -b test2.h265 < akiyo_cif.y4m
       after_script: &after_coveralls_script |
         if [ $CC = "clang" ] && [ $TRAVIS_OS_NAME = linux ]; then
           GCOV_FILE=llvm-cov GCOV_OPTIONS='gcov -pl'
@@ -190,4 +190,4 @@ matrix:
       env: build_type=debug
       script:
         - *base_script
-        - valgrind -- SvtHevcEncApp -encMode 9 -i akiyo_cif.y4m -n 150 -b test1.h265
+        - travis_wait valgrind -- SvtHevcEncApp -encMode 9 -i akiyo_cif.y4m -n 150 -b test1.h265

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,13 +2,21 @@ image: Visual Studio 2019
 configuration:
   - Debug
   - Release
+  - Release ffmpeg
 
 environment:
+  APPVEYOR_SAVE_CACHE_ON_ERROR: true
   matrix:
     - generator: Visual Studio 2019
       CC: cl
-    - generator: Ninja
-      CC: gcc
+    - generator: Unix Makefiles
+      CC: ccache gcc
+
+matrix:
+  exclude:
+    - configuration: Release ffmpeg
+      generator: Visual Studio 2019
+
 install:
   - '"C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvarsall.bat" x64'
   - set "PATH=C:\msys64\mingw64\bin;C:\msys64\usr\bin;%PATH%"
@@ -16,7 +24,7 @@ install:
   - set MSYS2_PATH_TYPE=inherit
   - bash -lc 'exit'
   - pacman -Syyuu --ask=20 --noconfirm --noprogressbar --needed
-  - pacman -Sy --ask=20 --noconfirm --noprogressbar --needed mingw-w64-x86_64-yasm mingw-w64-x86_64-ccache mingw-w64-x86_64-cmake mingw-w64-x86_64-gcc mingw-w64-x86_64-ninja
+  - pacman -Sy --ask=20 --noconfirm --noprogressbar --needed mingw-w64-x86_64-yasm mingw-w64-x86_64-ccache mingw-w64-x86_64-cmake mingw-w64-x86_64-gcc pkg-config make
   - cd Build
   - ps: |
       if ($env:APPVEYOR_JOB_NAME -match "Debug") {
@@ -26,27 +34,56 @@ install:
       }
       if ("$env:generator" -match "Visual*") {
         if ("$env:generator" -match "2019") {
-          cmake .. -G "Visual Studio 16 2019" -A x64 -DCMAKE_C_COMPILER_LAUNCHER=ccache
+          cmake .. -G "Visual Studio 16 2019" -A x64 -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_INSTALL_PREFIX=C:/msys2/mingw64 -DBUILD_SHARED_LIBS=off
         } else {
-          cmake .. -G "$env:generator" -DCMAKE_C_COMPILER_LAUNCHER=ccache
+          cmake .. -G "$env:generator" -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_INSTALL_PREFIX=C:/msys2/mingw64 -DBUILD_SHARED_LIBS=off
         }
       } elseif ($null -ne $env:generator){
-        cmake .. -G "$env:generator" -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE="$configuration"
+        cmake .. -G "$env:generator" -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE="$configuration" -DCMAKE_INSTALL_PREFIX=C:/msys2/mingw64 -DBUILD_SHARED_LIBS=off
       } else {
-        cmake .. -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE="$configuration"
+        cmake .. -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE="$configuration" -DCMAKE_INSTALL_PREFIX=C:/msys2/mingw64 -DBUILD_SHARED_LIBS=off
       }
   - ccache -s
+  - bash -lc 'ccache -s'
   - pacman -Sc --noconfirm
 
 for:
   - matrix:
       only:
-        - generator: Ninja
+        - configuration: Release ffmpeg
+    build_script:
+      - if "%APPVEYOR_JOB_NAME:~0,5%"=="Debug" (set config=Debug) else set config=Release
+      - if "%GENERATOR:~0,6%"=="Visual" set config=%config% -- /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
+      - cmake --build . --config %config%
+      - cmake --build . --target install
+      - set "PKG_CONFIG_PATH=C:/msys2/mingw64/lib/pkgconfig"
+      - pkg-config --debug --exists --print-errors SvtHevcEnc
+      - git clone https://github.com/FFmpeg/FFmpeg.git ffmpeg
+      - cd ffmpeg
+      - curl -L https://raw.githubusercontent.com/OpenVisualCloud/SVT-HEVC/master/ffmpeg_plugin/0001-lavc-svt_hevc-add-libsvt-hevc-encoder-wrapper.patch | patch --binary -sN -p1
+      - ps: |
+          $path = [System.Environment]::GetEnvironmentVariable('PATH', 'Machine')
+          $path = ($path.Split(';') | Where-Object { $_ -notmatch 'Git' }) -join ';'
+          [System.Environment]::SetEnvironmentVariable('PATH', $path, 'Machine')
+      - bash -c 'if test "$(echo $generator | cut -c1-6)" = "Visual"; then
+        ./configure --target-os=win64 --arch=x86_64 --toolchain=msvc --cc=cl --cxx=cl --extra-cflags="-MD" --disable-everything --enable-libsvthevc --enable-encoder=libsvt_hevc;
+        else
+        ./configure --arch=x86_64 --cc="ccache gcc" --cxx="ccache g++" --enable-libsvthevc --enable-encoder=libsvt_hevc;
+        fi || cat ffbuild/config.log'
+      - make -j 10
+      - ps: (New-Object System.Net.WebClient).DownloadFile('https://raw.githubusercontent.com/OpenVisualCloud/SVT-AV1-Resources/master/video.tar.gz', "$PWD\video.tar.gz")
+      - tar xf video.tar.gz
+      - ffmpeg -i akiyo_cif.y4m -c:v libsvt_hevc akiyo.h265
+      - cd ..
+
+  - matrix:
+      only:
+        - generator: Unix Makefiles
     artifacts:
       - path: bin\Release\*.*
         name: $(APPVEYOR_PROJECT_NAME)_MINGW64
     build_script:
-      - ninja -j10
+      - make -j
   - matrix:
       only:
         - generator: Visual Studio 2019
@@ -57,15 +94,15 @@ for:
         name: $(APPVEYOR_PROJECT_NAME)_MSVC2019
 
 test_script:
-  - ps: cd ../Bin/$($env:APPVEYOR_JOB_NAME.Split(" ")[-1])
+  - ps: if ($env:APPVEYOR_JOB_NAME -match "Debug") {cd ../Bin/Debug} else {cd ../Bin/Release}
   - ps: (New-Object System.Net.WebClient).DownloadFile('https://raw.githubusercontent.com/OpenVisualCloud/SVT-AV1-Resources/master/video.tar.gz', "$PWD\video.tar.gz")
-  - 7z x -aoa video.tar.gz
-  - 7z x -aoa video.tar
+  - tar xf video.tar.gz
   - SvtHevcEncApp -n 50 -encMode 9 -i akiyo_cif.y4m -b test1.h265
   - del video.tar.gz video.tar akiyo_cif.y4m bus_cif.y4m test1.h265
 
 cache:
   - 'C:\Users\appveyor\AppData\Roaming\.ccache'
+  - 'C:\msys64\home\appveyor\.ccache'
   - 'C:\msys64\var\cache\pacman\pkg'
 
 artifacts:


### PR DESCRIPTION
Add ffmpeg builds to appveyor for testing windows mingw-w64 builds. Orignally had a msvc ffmpeg build, but is excluded since it takes a lot of time and can not easily be speed up