### PR TITLE
Update AppVeyor to only deploy VS19 Release build to GitHub Releases

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -113,7 +113,7 @@ deploy:
   - provider: GitHub
     artifact: $(APPVEYOR_PROJECT_NAME)
     auth_token:
-      secure: "hY5Mk6KOwgQ97TzEBsM7Woqr1ZIm5QTvHg8EvxMV1x8j3wk/3mNBMqWFFbEIBK0i"
+      secure: 'sf0pQXlPI+X6LoAR8QUJB74jjzNxcLGOXI3H0nbxJq8llvGPG/TAUd87hq5iHZXo'
     prerelease: true
     on:
       appveyor_repo_tag: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -117,3 +117,5 @@ deploy:
     prerelease: true
     on:
       appveyor_repo_tag: true
+      generator: Visual Studio 2019
+      configuration: Release


### PR DESCRIPTION
Instead of trying to push all 5 builds to GitHub on a release, it now only deploys the Release build from Visual Studio 2019.

Aside from that, it seems that the `secure auth_token` is not working, since [AppVeyor did fail](https://ci.appveyor.com/project/OpenVisualCloud/svt-hevc/builds/27345109) on the v1.4.1 tag.
```
Deploying using GitHub provider
Creating "v1.4.1" release for repository "OpenVisualCloud/SVT-HEVC" tag "v1.4.1" commit "02fd1261966acfae6b363d8213710ef7505f0f31"...Error creating GitHub release: Provider setting not found or it's value is empty. If secure setting is used please check that value was encrypted (or YAML was exported) while being logged under correct account.
Parameter name: auth_token
```
I think it wasn't changed (correctly) when #92 got merged. @hassount or @tianjunwork, could you check if the token is correct (line 116 in the `appveyor.yml`) and if not change it according to the instructions in #92?

Thanks @michaellarabel for noticing this issue in https://github.com/phoronix-test-suite/test-profiles/pull/98#issuecomment-530414442.