### PR TITLE
Fixed the encoding crashing issue for some legacy CPUs.

### DIFF
--- a/Source/Lib/ASM_AVX2/EbIntraPrediction_Intrinsic_AVX2.c
+++ b/Source/Lib/ASM_AVX2/EbIntraPrediction_Intrinsic_AVX2.c
@@ -1873,115 +1873,31 @@ void IntraModeVerticalChroma_AVX2_INTRIN(
 
     // Jing: 
     // TODO: add size == 32 for 444
-    if (!skip) {
-        if (size == 32) {
-            __m256i xmm0;
-            EB_U64 size_to_write;
-            EB_U32 count;
+    if (!skip && (size == 32)) {
+        __m256i xmm0;
+        EB_U64 size_to_write;
+        EB_U32 count;
 
-            // Each storeu calls stores 32 bytes. Hence each iteration stores 8 * 32 bytes.
-            // Depending on skip, we need 4 or 2 iterations to store 32x32 bytes.
-            size_to_write = 4 >> (skip ? 1 : 0);
-            pStride = pStride << (skip ? 1 : 0);
+        // Each storeu calls stores 32 bytes. Hence each iteration stores 8 * 32 bytes.
+        // Depending on skip, we need 4 or 2 iterations to store 32x32 bytes.
+        size_to_write = 4 >> (skip ? 1 : 0);
+        pStride = pStride << (skip ? 1 : 0);
 
-            xmm0 = _mm256_loadu_si256((__m256i *)(refSamples + topOffset));
+        xmm0 = _mm256_loadu_si256((__m256i *)(refSamples + topOffset));
 
-            for (count = 0; count < size_to_write; count ++) {
-                _mm256_storeu_si256((__m256i *)(predictionPtr), xmm0);                    
-                _mm256_storeu_si256((__m256i *)(predictionPtr + pStride), xmm0);          
-                _mm256_storeu_si256((__m256i *)(predictionPtr + 2 * pStride), xmm0);      
-                _mm256_storeu_si256((__m256i *)(predictionPtr + 3 * pStride), xmm0);         
+        for (count = 0; count < size_to_write; count ++) {
+            _mm256_storeu_si256((__m256i *)(predictionPtr), xmm0);
+            _mm256_storeu_si256((__m256i *)(predictionPtr + pStride), xmm0);
+            _mm256_storeu_si256((__m256i *)(predictionPtr + 2 * pStride), xmm0);
+            _mm256_storeu_si256((__m256i *)(predictionPtr + 3 * pStride), xmm0);
 
-                predictionPtr += (pStride << 2);                                          
-                _mm256_storeu_si256((__m256i *)(predictionPtr), xmm0);                    
-                _mm256_storeu_si256((__m256i *)(predictionPtr + pStride), xmm0);          
-                _mm256_storeu_si256((__m256i *)(predictionPtr + 2 * pStride), xmm0);      
-                _mm256_storeu_si256((__m256i *)(predictionPtr + 3 * pStride), xmm0);         
+            predictionPtr += (pStride << 2);
+            _mm256_storeu_si256((__m256i *)(predictionPtr), xmm0);
+            _mm256_storeu_si256((__m256i *)(predictionPtr + pStride), xmm0);
+            _mm256_storeu_si256((__m256i *)(predictionPtr + 2 * pStride), xmm0);
+            _mm256_storeu_si256((__m256i *)(predictionPtr + 3 * pStride), xmm0);
 
-                predictionPtr += (pStride << 2);                                          
-            }
-        } else if (size == 16) {
-            __m128i xmm0 = _mm_loadu_si128((__m128i *)(refSamples + topOffset)); 
-            _mm_storeu_si128((__m128i *)predictionPtr, xmm0);                    
-            _mm_storeu_si128((__m128i *)(predictionPtr + pStride), xmm0);        
-            _mm_storeu_si128((__m128i *)(predictionPtr + 2 * pStride), xmm0);    
-            _mm_storeu_si128((__m128i *)(predictionPtr + 3 * pStride), xmm0);       
-            predictionPtr = predictionPtr + (pStride << 2);                         
-            _mm_storeu_si128((__m128i *)predictionPtr, xmm0);                    
-            _mm_storeu_si128((__m128i *)(predictionPtr + pStride), xmm0);        
-            _mm_storeu_si128((__m128i *)(predictionPtr + 2 * pStride), xmm0);    
-            _mm_storeu_si128((__m128i *)(predictionPtr + 3 * pStride), xmm0);       
-            predictionPtr = predictionPtr + (pStride << 2);                         
-            _mm_storeu_si128((__m128i *)predictionPtr, xmm0);                    
-            _mm_storeu_si128((__m128i *)(predictionPtr + pStride), xmm0);        
-            _mm_storeu_si128((__m128i *)(predictionPtr + 2 * pStride), xmm0);    
-            _mm_storeu_si128((__m128i *)(predictionPtr + 3 * pStride), xmm0);       
-            predictionPtr = predictionPtr + (pStride << 2);                         
-            _mm_storeu_si128((__m128i *)predictionPtr, xmm0);                    
-            _mm_storeu_si128((__m128i *)(predictionPtr + pStride), xmm0);        
-            _mm_storeu_si128((__m128i *)(predictionPtr + 2 * pStride), xmm0);    
-            _mm_storeu_si128((__m128i *)(predictionPtr + 3 * pStride), xmm0);       
-        }
-        else if (size == 8) {
-            __m128i xmm0 = _mm_loadl_epi64((__m128i *)(refSamples + topOffset)); 
-            _mm_storel_epi64((__m128i *)(predictionPtr), xmm0);                  
-            _mm_storel_epi64((__m128i *)(predictionPtr + pStride), xmm0);        
-            _mm_storel_epi64((__m128i *)(predictionPtr + 2 * pStride), xmm0);    
-            _mm_storel_epi64((__m128i *)(predictionPtr + 3 * pStride), xmm0);       
-            predictionPtr = predictionPtr + (pStride << 2);                         
-            _mm_storel_epi64((__m128i *)predictionPtr, xmm0);                    
-            _mm_storel_epi64((__m128i *)(predictionPtr + pStride), xmm0);        
-            _mm_storel_epi64((__m128i *)(predictionPtr + 2 * pStride), xmm0);    
-            _mm_storel_epi64((__m128i *)(predictionPtr + 3 * pStride), xmm0);       
-        }
-        else {
-            EB_U32 top = *(EB_U32*)(refSamples + topOffset);         
-            *(EB_U32*)(predictionPtr) = top;
-            *(EB_U32*)(predictionPtr + pStride) = top;
-            *(EB_U32*)(predictionPtr + 2 * pStride) = top;
-            *(EB_U32*)(predictionPtr + 3 * pStride) = top;
-        }
-    }
-    else {
-        pStride <<= 1;
-        if (size == 32) {
-            EB_U32 columnIndex, rowIndex;
-            EB_U32 writeIndex;
-            EB_U32 topOffset = (size << 1) + 1;
-            EB_U32 rowStride = skip ? 2 : 1;
-
-            for (columnIndex = 0; columnIndex < size; ++columnIndex) {
-                writeIndex = columnIndex;
-                for (rowIndex = 0; rowIndex < size; rowIndex += rowStride) {
-                    predictionPtr[writeIndex] = refSamples[topOffset + columnIndex];
-                    writeIndex += rowStride * predictionBufferStride;
-                }
-            }
-        } else if (size == 16) {
-            
-            __m128i xmm0 = _mm_loadu_si128((__m128i *)(refSamples + topOffset)); 
-            _mm_storeu_si128((__m128i *)(predictionPtr), xmm0);                  
-            _mm_storeu_si128((__m128i *)(predictionPtr + pStride), xmm0);        
-            _mm_storeu_si128((__m128i *)(predictionPtr + 2 * pStride), xmm0);    
-            _mm_storeu_si128((__m128i *)(predictionPtr + 3 * pStride), xmm0);       
-            predictionPtr = predictionPtr + (pStride << 2);                         
-            _mm_storeu_si128((__m128i *)(predictionPtr), xmm0);                  
-            _mm_storeu_si128((__m128i *)(predictionPtr + pStride), xmm0);        
-            _mm_storeu_si128((__m128i *)(predictionPtr + 2 * pStride), xmm0);    
-            _mm_storeu_si128((__m128i *)(predictionPtr + 3 * pStride), xmm0);       
-        }
-        else if (size == 8) {
-            
-            __m128i xmm0 = _mm_loadl_epi64((__m128i *)(refSamples + topOffset)); 
-            _mm_storel_epi64((__m128i *)predictionPtr, xmm0);                    
-            _mm_storel_epi64((__m128i *)(predictionPtr + pStride), xmm0);        
-            _mm_storel_epi64((__m128i *)(predictionPtr + 2 * pStride), xmm0);    
-            _mm_storel_epi64((__m128i *)(predictionPtr + 3 * pStride), xmm0);       
-        }
-        else {
-            EB_U32 top = *(EB_U32*)(refSamples + topOffset); 
-            *(EB_U32*)(predictionPtr) = top;
-            *(EB_U32*)(predictionPtr + pStride) = top;
+            predictionPtr += (pStride << 2);
         }
     }
 }

--- a/Source/Lib/ASM_SSE2/EbIntraPrediction_Intrinsic_SSE2.c
+++ b/Source/Lib/ASM_SSE2/EbIntraPrediction_Intrinsic_SSE2.c
@@ -939,3 +939,93 @@ void IntraModePlanar16bit_SSE2_INTRIN(
         }
     }
 }
+
+void IntraModeVerticalChroma_SSE2_INTRIN(
+    const EB_U32      size,                   //input parameter, denotes the size of the current PU
+    EB_U8            *refSamples,             //input parameter, pointer to the reference samples
+    EB_U8            *predictionPtr,          //output parameter, pointer to the prediction
+    const EB_U32      predictionBufferStride, //input parameter, denotes the stride for the prediction ptr
+    const EB_BOOL     skip)                   //skip one row
+{
+    EB_U32 pStride = predictionBufferStride;
+    EB_U32 topOffset = (size << 1) + 1;
+
+    if (!skip) {
+        if (size == 16) {
+            __m128i xmm0 = _mm_loadu_si128((__m128i *)(refSamples + topOffset));
+            _mm_storeu_si128((__m128i *)predictionPtr, xmm0);
+            _mm_storeu_si128((__m128i *)(predictionPtr + pStride), xmm0);
+            _mm_storeu_si128((__m128i *)(predictionPtr + 2 * pStride), xmm0);
+            _mm_storeu_si128((__m128i *)(predictionPtr + 3 * pStride), xmm0);
+            predictionPtr = predictionPtr + (pStride << 2);
+            _mm_storeu_si128((__m128i *)predictionPtr, xmm0);
+            _mm_storeu_si128((__m128i *)(predictionPtr + pStride), xmm0);
+            _mm_storeu_si128((__m128i *)(predictionPtr + 2 * pStride), xmm0);
+            _mm_storeu_si128((__m128i *)(predictionPtr + 3 * pStride), xmm0);
+            predictionPtr = predictionPtr + (pStride << 2);
+            _mm_storeu_si128((__m128i *)predictionPtr, xmm0);
+            _mm_storeu_si128((__m128i *)(predictionPtr + pStride), xmm0);
+            _mm_storeu_si128((__m128i *)(predictionPtr + 2 * pStride), xmm0);
+            _mm_storeu_si128((__m128i *)(predictionPtr + 3 * pStride), xmm0);
+            predictionPtr = predictionPtr + (pStride << 2);
+            _mm_storeu_si128((__m128i *)predictionPtr, xmm0);
+            _mm_storeu_si128((__m128i *)(predictionPtr + pStride), xmm0);
+            _mm_storeu_si128((__m128i *)(predictionPtr + 2 * pStride), xmm0);
+            _mm_storeu_si128((__m128i *)(predictionPtr + 3 * pStride), xmm0);
+        } else if (size == 8) {
+            __m128i xmm0 = _mm_loadl_epi64((__m128i *)(refSamples + topOffset));
+            _mm_storel_epi64((__m128i *)(predictionPtr), xmm0);
+            _mm_storel_epi64((__m128i *)(predictionPtr + pStride), xmm0);
+            _mm_storel_epi64((__m128i *)(predictionPtr + 2 * pStride), xmm0);
+            _mm_storel_epi64((__m128i *)(predictionPtr + 3 * pStride), xmm0);
+            predictionPtr = predictionPtr + (pStride << 2);
+            _mm_storel_epi64((__m128i *)predictionPtr, xmm0);
+            _mm_storel_epi64((__m128i *)(predictionPtr + pStride), xmm0);
+            _mm_storel_epi64((__m128i *)(predictionPtr + 2 * pStride), xmm0);
+            _mm_storel_epi64((__m128i *)(predictionPtr + 3 * pStride), xmm0);
+        } else {
+            EB_U32 top = *(EB_U32*)(refSamples + topOffset);
+            *(EB_U32*)(predictionPtr) = top;
+            *(EB_U32*)(predictionPtr + pStride) = top;
+            *(EB_U32*)(predictionPtr + 2 * pStride) = top;
+            *(EB_U32*)(predictionPtr + 3 * pStride) = top;
+        }
+    } else {
+        pStride <<= 1;
+        if (size == 32) {
+            EB_U32 columnIndex, rowIndex;
+            EB_U32 writeIndex;
+            EB_U32 topOffset = (size << 1) + 1;
+            EB_U32 rowStride = skip ? 2 : 1;
+
+            for (columnIndex = 0; columnIndex < size; ++columnIndex) {
+                writeIndex = columnIndex;
+                for (rowIndex = 0; rowIndex < size; rowIndex += rowStride) {
+                    predictionPtr[writeIndex] = refSamples[topOffset + columnIndex];
+                    writeIndex += rowStride * predictionBufferStride;
+                }
+            }
+        } else if (size == 16) {
+            __m128i xmm0 = _mm_loadu_si128((__m128i *)(refSamples + topOffset));
+            _mm_storeu_si128((__m128i *)(predictionPtr), xmm0);
+            _mm_storeu_si128((__m128i *)(predictionPtr + pStride), xmm0);
+            _mm_storeu_si128((__m128i *)(predictionPtr + 2 * pStride), xmm0);
+            _mm_storeu_si128((__m128i *)(predictionPtr + 3 * pStride), xmm0);
+            predictionPtr = predictionPtr + (pStride << 2);
+            _mm_storeu_si128((__m128i *)(predictionPtr), xmm0);
+            _mm_storeu_si128((__m128i *)(predictionPtr + pStride), xmm0);
+            _mm_storeu_si128((__m128i *)(predictionPtr + 2 * pStride), xmm0);
+            _mm_storeu_si128((__m128i *)(predictionPtr + 3 * pStride), xmm0);
+        } else if (size == 8) {
+            __m128i xmm0 = _mm_loadl_epi64((__m128i *)(refSamples + topOffset));
+            _mm_storel_epi64((__m128i *)predictionPtr, xmm0);
+            _mm_storel_epi64((__m128i *)(predictionPtr + pStride), xmm0);
+            _mm_storel_epi64((__m128i *)(predictionPtr + 2 * pStride), xmm0);
+            _mm_storel_epi64((__m128i *)(predictionPtr + 3 * pStride), xmm0);
+        } else {
+            EB_U32 top = *(EB_U32*)(refSamples + topOffset);
+            *(EB_U32*)(predictionPtr) = top;
+            *(EB_U32*)(predictionPtr + pStride) = top;
+        }
+    }
+}

--- a/Source/Lib/ASM_SSE2/EbIntraPrediction_SSE2.h
+++ b/Source/Lib/ASM_SSE2/EbIntraPrediction_SSE2.h
@@ -106,6 +106,12 @@ void IntraModeAngular16bit_Horizontal_Kernel_SSE2_INTRIN(
     const EB_BOOL  skip,
     EB_S32         intraPredAngle);
 
+void IntraModeVerticalChroma_SSE2_INTRIN(
+    const EB_U32      size,                   //input parameter, denotes the size of the current PU
+    EB_U8            *refSamples,             //input parameter, pointer to the reference samples
+    EB_U8            *predictionPtr,          //output parameter, pointer to the prediction
+    const EB_U32      predictionBufferStride, //input parameter, denotes the stride for the prediction ptr
+    const EB_BOOL     skip);                  //skip one row
 
 #ifdef __cplusplus
 }

--- a/Source/Lib/Codec/EbDefinitions.h
+++ b/Source/Lib/Codec/EbDefinitions.h
@@ -366,6 +366,8 @@ typedef EB_U8 EB_MODETYPE;
 #endif
 #define ASM_AVX2_BIT    3
 
+#define BIT(nr)         (1UL << (nr))
+
 /** INTRA_4x4 offsets
 */
 static const EB_U8 INTRA_4x4_OFFSET_X[4] = { 0, 4, 0, 4 };

--- a/Source/Lib/Codec/EbEncHandle.c
+++ b/Source/Lib/Codec/EbEncHandle.c
@@ -522,14 +522,20 @@ int CheckXcr0Ymm()
 EB_S32 Check4thGenIntelCoreFeatures()
 {
     int abcd[4];
-    int fma_movbe_osxsave_mask = ((1 << 12) | (1 << 22) | (1 << 27));
+#define ECX_REG_FMA     BIT(12)
+#define ECX_REG_MOVBE   BIT(22)
+#define ECX_REG_XSAVE   BIT(26)
+#define ECX_REG_OSXSAVE BIT(27)
+    int ecx_reg_mask = ECX_REG_FMA | ECX_REG_MOVBE | ECX_REG_XSAVE | ECX_REG_OSXSAVE;
     int avx2_bmi12_mask = (1 << 5) | (1 << 3) | (1 << 8);
 
     /* CPUID.(EAX=01H, ECX=0H):ECX.FMA[bit 12]==1   &&
        CPUID.(EAX=01H, ECX=0H):ECX.MOVBE[bit 22]==1 &&
+       CPUID.(EAX=01H, ECX=0H):ECX.XSAVE[bit 26]==1 &&
        CPUID.(EAX=01H, ECX=0H):ECX.OSXSAVE[bit 27]==1 */
     RunCpuid( 1, 0, abcd );
-    if ( (abcd[2] & fma_movbe_osxsave_mask) != fma_movbe_osxsave_mask )
+    /* To make sure the processor supports XGETBV instruction, and OS has enabled it. */
+    if ((abcd[2] & ecx_reg_mask) != ecx_reg_mask)
         return 0;
 
     if ( ! CheckXcr0Ymm() )
@@ -571,19 +577,22 @@ int CheckXcr0Zmm()
 static EB_S32 CanUseIntelAVX512()
 {
     int abcd[4];
+    int avx512_ebx_mask = 0;
 
-    /*  CPUID.(EAX=07H, ECX=0):EBX[bit 16]==1 AVX512F
-        CPUID.(EAX=07H, ECX=0):EBX[bit 17] AVX512DQ
-        CPUID.(EAX=07H, ECX=0):EBX[bit 28] AVX512CD
-        CPUID.(EAX=07H, ECX=0):EBX[bit 30] AVX512BW
-        CPUID.(EAX=07H, ECX=0):EBX[bit 31] AVX512VL */
+#define ECX_REG_FMA     BIT(12)
+#define ECX_REG_MOVBE   BIT(22)
+#define ECX_REG_XSAVE   BIT(26)
+#define ECX_REG_OSXSAVE BIT(27)
+    int ecx_reg_mask = ECX_REG_FMA | ECX_REG_MOVBE | ECX_REG_XSAVE | ECX_REG_OSXSAVE;
 
-    int avx512_ebx_mask =
-          (1 << 16)  // AVX-512F
-        | (1 << 17)  // AVX-512DQ
-        | (1 << 28)  // AVX-512CD
-        | (1 << 30)  // AVX-512BW
-        | (1 << 31); // AVX-512VL
+    /* CPUID.(EAX=01H, ECX=0H):ECX.FMA[bit 12]==1   &&
+       CPUID.(EAX=01H, ECX=0H):ECX.MOVBE[bit 22]==1 &&
+       CPUID.(EAX=01H, ECX=0H):ECX.XSAVE[bit 26]==1 &&
+       CPUID.(EAX=01H, ECX=0H):ECX.OSXSAVE[bit 27]==1 */
+    RunCpuid( 1, 0, abcd );
+    /* To make sure the processor supports XGETBV instruction, and OS has enabled it. */
+    if ((abcd[2] & ecx_reg_mask) != ecx_reg_mask)
+        return 0;
 
     // ensure OS supports ZMM registers (and YMM, and XMM)
     if ( ! CheckXcr0Zmm() )
@@ -591,6 +600,19 @@ static EB_S32 CanUseIntelAVX512()
 
     if ( ! Check4thGenIntelCoreFeatures() )
         return 0;
+
+    /* CPUID.(EAX=07H, ECX=0):EBX[bit 16]==1 AVX512F
+       CPUID.(EAX=07H, ECX=0):EBX[bit 17] AVX512DQ
+       CPUID.(EAX=07H, ECX=0):EBX[bit 28] AVX512CD
+       CPUID.(EAX=07H, ECX=0):EBX[bit 30] AVX512BW
+       CPUID.(EAX=07H, ECX=0):EBX[bit 31] AVX512VL */
+
+    avx512_ebx_mask =
+        (1 << 16)  // AVX-512F
+        | (1 << 17)  // AVX-512DQ
+        | (1 << 28)  // AVX-512CD
+        | (1 << 30)  // AVX-512BW
+        | (1 << 31); // AVX-512VL
 
     RunCpuid( 7, 0, abcd );
     if ( (abcd[1] & avx512_ebx_mask) != avx512_ebx_mask )

--- a/Source/Lib/Codec/EbIntraPrediction.c
+++ b/Source/Lib/Codec/EbIntraPrediction.c
@@ -3680,6 +3680,7 @@ EB_ERRORTYPE IntraPredictionCl(
 
     (void) pictureControlSetPtr;
 
+    EB_U8 funcIdx = 0;
 
     CHECK_REPORT_ERROR(
 		(puWidth == puHeight),
@@ -3839,25 +3840,32 @@ EB_ERRORTYPE IntraPredictionCl(
             break;
 
         case 2:
-              
+            if (!!(ASM_TYPES & PREAVX2_MASK)) {
+                if (chromaPuSize != 32)
+                    funcIdx = 1;
+                else
+                    funcIdx = 2;
+            } else
+                funcIdx = 0;
+
             // Cb Intra Prediction
             if (componentMask & PICTURE_BUFFER_DESC_Cb_FLAG) {
-                IntraVerticalChroma_funcPtrArray[!!(ASM_TYPES & PREAVX2_MASK)](
-                    chromaPuSize,
-                    contextPtr->cbIntraReferenceArray,
-                    &(candidateBufferPtr->predictionPtr->bufferCb[puChromaOriginIndex]),
-                    candidateBufferPtr->predictionPtr->strideCb,
-                    EB_FALSE);
+                IntraVerticalChroma_funcPtrArray[funcIdx](
+                        chromaPuSize,
+                        contextPtr->cbIntraReferenceArray,
+                        &(candidateBufferPtr->predictionPtr->bufferCb[puChromaOriginIndex]),
+                        candidateBufferPtr->predictionPtr->strideCb,
+                        EB_FALSE);
             }
-       
+
             // Cr Intra Prediction
             if (componentMask & PICTURE_BUFFER_DESC_Cr_FLAG) {
-				IntraVerticalChroma_funcPtrArray[!!(ASM_TYPES & PREAVX2_MASK)](
-                    chromaPuSize,
-                    contextPtr->crIntraReferenceArray,
-                    &(candidateBufferPtr->predictionPtr->bufferCr[puChromaOriginIndex]),
-                    candidateBufferPtr->predictionPtr->strideCr,
-                    EB_FALSE);
+                IntraVerticalChroma_funcPtrArray[funcIdx](
+                        chromaPuSize,
+                        contextPtr->crIntraReferenceArray,
+                        &(candidateBufferPtr->predictionPtr->bufferCr[puChromaOriginIndex]),
+                        candidateBufferPtr->predictionPtr->strideCr,
+                        EB_FALSE);
             }
 
             break;
@@ -3992,6 +4000,8 @@ EB_ERRORTYPE Intra4x4IntraPredictionCl(
 
     (void) puIndex;
     (void)pictureControlSetPtr;
+
+    EB_U8 funcIdx = 0;
 
     CHECK_REPORT_ERROR(
 		(puWidth == puHeight),
@@ -4135,25 +4145,32 @@ EB_ERRORTYPE Intra4x4IntraPredictionCl(
             break;
 
         case 2:
-              
+            if (!!(ASM_TYPES & PREAVX2_MASK)) {
+                if (chromaPuSize != 32)
+                    funcIdx = 1;
+                else
+                    funcIdx = 2;
+            } else
+                funcIdx = 0;
+
             // Cb Intra Prediction
             if (componentMask & PICTURE_BUFFER_DESC_Cb_FLAG) {
-				IntraVerticalChroma_funcPtrArray[!!(ASM_TYPES & PREAVX2_MASK)](
-                    chromaPuSize,
-                    contextPtr->cbIntraReferenceArray,
-                    &(candidateBufferPtr->predictionPtr->bufferCb[puChromaOriginIndex]),
-                    candidateBufferPtr->predictionPtr->strideCb,
-                    EB_FALSE);
+                IntraVerticalChroma_funcPtrArray[funcIdx](
+                        chromaPuSize,
+                        contextPtr->cbIntraReferenceArray,
+                        &(candidateBufferPtr->predictionPtr->bufferCb[puChromaOriginIndex]),
+                        candidateBufferPtr->predictionPtr->strideCb,
+                        EB_FALSE);
             }
-       
+
             // Cr Intra Prediction
             if (componentMask & PICTURE_BUFFER_DESC_Cr_FLAG) {
-				IntraVerticalChroma_funcPtrArray[!!(ASM_TYPES & PREAVX2_MASK)](
-                    chromaPuSize,
-                    contextPtr->crIntraReferenceArray,
-                    &(candidateBufferPtr->predictionPtr->bufferCr[puChromaOriginIndex]),
-                    candidateBufferPtr->predictionPtr->strideCr,
-                    EB_FALSE);
+                IntraVerticalChroma_funcPtrArray[funcIdx](
+                        chromaPuSize,
+                        contextPtr->crIntraReferenceArray,
+                        &(candidateBufferPtr->predictionPtr->bufferCr[puChromaOriginIndex]),
+                        candidateBufferPtr->predictionPtr->strideCr,
+                        EB_FALSE);
             }
 
             break;
@@ -4388,6 +4405,8 @@ EB_ERRORTYPE EncodePassIntraPrediction(
     EB_U16 subWidthCMinus1 = (colorFormat == EB_YUV444 ? 1 : 2) - 1;
     EB_U16 subHeightCMinus1 = (colorFormat >= EB_YUV422 ? 1 : 2) - 1;
 
+    EB_U8 funcIdx = 0;
+
     //***********************************
     // Luma
     //***********************************
@@ -4528,22 +4547,29 @@ EB_ERRORTYPE EncodePassIntraPrediction(
             break;
 
         case EB_INTRA_VERTICAL:
-              
+            if (!!(ASM_TYPES & PREAVX2_MASK)) {
+                if (puChromaSize != 32)
+                    funcIdx = 1;
+                else
+                    funcIdx = 2;
+            } else
+                funcIdx = 0;
+
             // Cb Intra Prediction
-			IntraVerticalChroma_funcPtrArray[!!(ASM_TYPES & PREAVX2_MASK)](
-                puChromaSize,
-                cbIntraReferenceArrayReverse,
-                predictionPtr->bufferCb + chromaOffset,
-                predictionPtr->strideCb,
-                EB_FALSE);
-       
+            IntraVerticalChroma_funcPtrArray[funcIdx](
+                    puChromaSize,
+                    cbIntraReferenceArrayReverse,
+                    predictionPtr->bufferCb + chromaOffset,
+                    predictionPtr->strideCb,
+                    EB_FALSE);
+
             // Cr Intra Prediction
-			IntraVerticalChroma_funcPtrArray[!!(ASM_TYPES & PREAVX2_MASK)](
-                puChromaSize,
-                crIntraReferenceArrayReverse,
-                predictionPtr->bufferCr + chromaOffset,
-                predictionPtr->strideCr,
-                EB_FALSE);
+            IntraVerticalChroma_funcPtrArray[funcIdx](
+                    puChromaSize,
+                    crIntraReferenceArrayReverse,
+                    predictionPtr->bufferCr + chromaOffset,
+                    predictionPtr->strideCr,
+                    EB_FALSE);
 
             break;
 
@@ -5404,6 +5430,8 @@ EB_ERRORTYPE IntraPredictionOl(
     const EB_U32 puSize        = puWidth;
     const EB_U32 puIndex = mdContextPtr->puItr;
       
+    EB_U8 funcIdx = 0;
+
     // Map the mode to the function table index
     EB_U32 funcIndex =
         (openLoopIntraCandidateIndex < 2)                        ?       openLoopIntraCandidateIndex  :
@@ -5547,10 +5575,17 @@ EB_ERRORTYPE IntraPredictionOl(
 			break;
 
 		case 2:
+			if (!!(ASM_TYPES & PREAVX2_MASK)) {
+				if (chromaPuSize != 32)
+					funcIdx = 1;
+				else
+					funcIdx = 2;
+			} else
+				funcIdx = 0;
 
 			// Cb Intra Prediction
 			if (componentMask & PICTURE_BUFFER_DESC_Cb_FLAG) {
-				IntraVerticalChroma_funcPtrArray[!!(ASM_TYPES & PREAVX2_MASK)](
+				IntraVerticalChroma_funcPtrArray[funcIdx](
 					chromaPuSize,
 					intraRefPtr->cbIntraReferenceArray,
 					&(candidateBufferPtr->predictionPtr->bufferCb[puChromaOriginIndex]),
@@ -5560,7 +5595,7 @@ EB_ERRORTYPE IntraPredictionOl(
 
 			// Cr Intra Prediction
 			if (componentMask & PICTURE_BUFFER_DESC_Cr_FLAG) {
-				IntraVerticalChroma_funcPtrArray[!!(ASM_TYPES & PREAVX2_MASK)](
+				IntraVerticalChroma_funcPtrArray[funcIdx](
 					chromaPuSize,
 					intraRefPtr->crIntraReferenceArray,
 					&(candidateBufferPtr->predictionPtr->bufferCr[puChromaOriginIndex]),

--- a/Source/Lib/Codec/EbIntraPrediction.h
+++ b/Source/Lib/Codec/EbIntraPrediction.h
@@ -485,9 +485,11 @@ static EB_INTRA_NOANG_16bit_TYPE FUNC_TABLE IntraVerticalLuma_16bit_funcPtrArray
     IntraModeVerticalLuma16bit_SSE2_INTRIN,
 };
 
-static EB_INTRA_NOANG_TYPE FUNC_TABLE IntraVerticalChroma_funcPtrArray[EB_ASM_TYPE_TOTAL] = {
+static EB_INTRA_NOANG_TYPE FUNC_TABLE IntraVerticalChroma_funcPtrArray[3] = {
     // C_DEFAULT
     IntraModeVerticalChroma,
+    // SSE2
+    IntraModeVerticalChroma_SSE2_INTRIN,
     // AVX2
     IntraModeVerticalChroma_AVX2_INTRIN,
 };


### PR DESCRIPTION
By checking whether the processor supports XGETBV instruction or not,
beforeing invoking it to check ZMM/YMM/XMM states are enabled in XCR0
register.

Signed-off-by: Austin Hu <austin.hu@intel.com>