### PR TITLE
Worked around the incorrect tranform issue with AVX unsupported CPU.

### DIFF
--- a/Source/Lib/Codec/EbTransforms.c
+++ b/Source/Lib/Codec/EbTransforms.c
@@ -3357,7 +3357,7 @@ EB_ERRORTYPE EncodeTransform(
 
     if (transCoeffShape == DEFAULT_SHAPE) {
         if (!((!!(ASM_TYPES & AVX2_MASK)))) { // C Only
-            (*transformFunctionTableEncode0[(!!(ASM_TYPES & PREAVX2_MASK))][transformSizeFlag + dstTransformFlag])(
+            (*transformFunctionTableEncode0[/*ASM_TYPES*/((bitIncrement & BIT_INCREMENT_10BIT) ? EB_ASM_C : (!!(ASM_TYPES & PREAVX2_MASK)))][transformSizeFlag + dstTransformFlag])(
                 residualBuffer,
                 residualStride,
                 coeffBuffer,
@@ -3367,7 +3367,7 @@ EB_ERRORTYPE EncodeTransform(
                 );
         }
         else {
-            (*transformFunctionTableEncode1[/*ASM_TYPES*/((bitIncrement & 2) ? EB_ASM_C : (!!(ASM_TYPES & PREAVX2_MASK)))][transformSizeFlag + dstTransformFlag])(
+            (*transformFunctionTableEncode1[/*ASM_TYPES*/((bitIncrement & BIT_INCREMENT_10BIT) ? EB_ASM_C : (!!(ASM_TYPES & PREAVX2_MASK)))][transformSizeFlag + dstTransformFlag])(
                 residualBuffer,
                 residualStride,
                 coeffBuffer,
@@ -3380,7 +3380,7 @@ EB_ERRORTYPE EncodeTransform(
 
     else if (transCoeffShape == N2_SHAPE) {
             if (!((!!(ASM_TYPES & AVX2_MASK)))) { // C Only
-                (*PfreqN2TransformTable0[(!!(ASM_TYPES & AVX2_MASK))][transformSizeFlag + dstTransformFlag])(
+                (*PfreqN2TransformTable0[/*ASM_TYPES*/((bitIncrement & BIT_INCREMENT_10BIT) ? EB_ASM_C : (!!(ASM_TYPES & AVX2_MASK)))][transformSizeFlag + dstTransformFlag])(
                     residualBuffer,
                     residualStride,
                     coeffBuffer,
@@ -3390,7 +3390,7 @@ EB_ERRORTYPE EncodeTransform(
                     );
             }
             else {
-                (*PfreqN2TransformTable1[/*ASM_TYPES*/((bitIncrement & 2) ? EB_ASM_C : (!!(ASM_TYPES & AVX2_MASK)))][transformSizeFlag + dstTransformFlag])(
+                (*PfreqN2TransformTable1[/*ASM_TYPES*/((bitIncrement & BIT_INCREMENT_10BIT) ? EB_ASM_C : (!!(ASM_TYPES & AVX2_MASK)))][transformSizeFlag + dstTransformFlag])(
                     residualBuffer,
                     residualStride,
                     coeffBuffer,
@@ -3403,7 +3403,7 @@ EB_ERRORTYPE EncodeTransform(
 
     else if (transCoeffShape == N4_SHAPE) {
         if (!((!!(ASM_TYPES & AVX2_MASK)))) { // C Only
-            (*PfreqN4TransformTable0[!!(ASM_TYPES & AVX2_MASK)][transformSizeFlag + dstTransformFlag])(
+            (*PfreqN4TransformTable0[/*ASM_TYPES*/((bitIncrement & BIT_INCREMENT_10BIT) ? EB_ASM_C : (!!(ASM_TYPES & AVX2_MASK)))][transformSizeFlag + dstTransformFlag])(
                 residualBuffer,
                 residualStride,
                 coeffBuffer,
@@ -3412,7 +3412,7 @@ EB_ERRORTYPE EncodeTransform(
                 bitIncrement);
         }
         else {
-            (*PfreqN4TransformTable1[/*ASM_TYPES*/((bitIncrement & 2) ? EB_ASM_C : (!!(ASM_TYPES & AVX2_MASK)))][transformSizeFlag + dstTransformFlag])(
+            (*PfreqN4TransformTable1[/*ASM_TYPES*/((bitIncrement & BIT_INCREMENT_10BIT) ? EB_ASM_C : (!!(ASM_TYPES & AVX2_MASK)))][transformSizeFlag + dstTransformFlag])(
                 residualBuffer,
                 residualStride,
                 coeffBuffer,


### PR DESCRIPTION
The issue can be reproduced in legacy CPUs without AVX intrinsic, or
by hard coding ASM_TYPES with 1. It's caused by some incorrect
implementation of Transform8x8_SSE4_1_INTRIN() for 10-bit YUV source.
(Need to check whether the issue also happens or not with 8-bit YUV
source.)

So temporarily worked around this issue, like what the function
transformFunctionTableEncode1() is invoked since v1.2.0. And did the
same change for N2 and N4 transform coefficient shapes in addition to
the default one, just in case.

Resolved #[259](https://github.com/OpenVisualCloud/SVT-HEVC/issues/259).

Signed-off-by: Austin Hu <austin.hu@intel.com>