### PR TITLE
Fixed the Y4M header analysis issue in SvtHevcEncApp.

### DIFF
--- a/Source/App/EbAppConfig.c
+++ b/Source/App/EbAppConfig.c
@@ -768,7 +768,7 @@ static void ParseConfigFile(
                 // Cap the length of the variable name
                 argLen[0] = (argLen[0] > CONFIG_FILE_MAX_VAR_LEN - 1) ? CONFIG_FILE_MAX_VAR_LEN - 1 : argLen[0];
                 // Copy the variable name
-                EB_STRNCPY(varName, argv[0], argLen[0]);
+                EB_STRNCPY(varName, sizeof(varName), argv[0], argLen[0]);
                 // Null terminate the variable name
                 varName[argLen[0]] = CONFIG_FILE_NULL_CHAR;
 
@@ -777,7 +777,7 @@ static void ParseConfigFile(
                     // Cap the length of the variable
                     argLen[valueIndex+2] = (argLen[valueIndex+2] > CONFIG_FILE_MAX_VAR_LEN - 1) ? CONFIG_FILE_MAX_VAR_LEN - 1 : argLen[valueIndex+2];
                     // Copy the variable name
-                    EB_STRNCPY(varValue[valueIndex], argv[valueIndex+2], argLen[valueIndex+2]);
+                    EB_STRNCPY(varValue[valueIndex], sizeof(varValue[valueIndex]), argv[valueIndex + 2], argLen[valueIndex + 2]);
                     // Null terminate the variable name
                     varValue[valueIndex][argLen[valueIndex+2]] = CONFIG_FILE_NULL_CHAR;
 

--- a/Source/App/EbAppConfig.h
+++ b/Source/App/EbAppConfig.h
@@ -151,8 +151,8 @@ extern errno_t strncpy_ss(char *dest, rsize_t dmax, const char *src, rsize_t sle
 /* string length */
 extern rsize_t strnlen_ss(const char *s, rsize_t smax);
 
-#define EB_STRNCPY(dst, src, count) \
-	strncpy_ss(dst, sizeof(dst), src, count)
+#define EB_STRNCPY(dst, max_size, src, count) \
+	strncpy_ss(dst, max_size, src, count)
 
 #define EB_STRCPY(dst, size, src) \
 	strcpy_ss(dst, size, src)

--- a/Source/App/EbAppInputy4m.h
+++ b/Source/App/EbAppInputy4m.h
@@ -10,7 +10,7 @@
 
 #include "EbAppConfig.h"
 
-#define YUV4MPEG2_IND_SIZE EB_STRLEN("YUV4MPEG2", MAX_STRING_LENGTH)
+#define YUV4MPEG2_IND_SIZE 9 // EB_STRLEN("YUV4MPEG2", MAX_STRING_LENGTH)
 
 int32_t read_y4m_header(EbConfig_t *cfg);
 

--- a/Source/App/EbAppInputy4m.h
+++ b/Source/App/EbAppInputy4m.h
@@ -10,6 +10,8 @@
 
 #include "EbAppConfig.h"
 
+#define YUV4MPEG2_IND_SIZE EB_STRLEN("YUV4MPEG2", MAX_STRING_LENGTH)
+
 int32_t read_y4m_header(EbConfig_t *cfg);
 
 int32_t read_y4m_frame_delimiter(EbConfig_t *cfg);

--- a/Source/App/EbAppProcessCmd.c
+++ b/Source/App/EbAppProcessCmd.c
@@ -25,7 +25,6 @@
 #define FUTURE_WINDOW_WIDTH                 4
 #define SIZE_OF_ONE_FRAME_IN_BYTES(width, height, csp, is16bit) \
     ( (((width)*(height)) + 2*(((width)*(height))>>(3-csp)) )<<is16bit)
-#define YUV4MPEG2_IND_SIZE 9
 extern volatile int32_t keepRunning;
 
 /***************************************


### PR DESCRIPTION
The issue was caused by the definition of EB_STRNCPY invoking strncpy_ss
with sizeof(dst). sizeof() an array can return the memory size of the
array, while sizeof a pointer pointing to an array would return the size
of the pointer (8 in 64bit machine, and 4 in 32bit one). So that dmax of
strncpy_ss was always 8 or 4, and would cause the byte assignment issue
once the size of source was greater or equal than dmax.

Signed-off-by: Austin Hu <austin.hu@intel.com>