### PR TITLE
10bit compressed check

### DIFF
--- a/Source/App/EbAppConfig.c
+++ b/Source/App/EbAppConfig.c
@@ -955,6 +955,12 @@ static EB_ERRORTYPE VerifySettings(EbConfig_t *config, uint32_t channelNumber)
         return_error = EB_ErrorBadParameter;
     }
 
+    if (config->encoderBitDepth != 10 && config->compressedTenBitFormat == EB_TRUE)
+    {
+        fprintf(config->errorLogFile, "SVT [Error]: Instance %u: Compressed 10 bit format inconsistent with encoder bit depth\n", channelNumber + 1);
+        return_error = EB_ErrorBadParameter;
+    }
+
     if (config->injector > 1 ){
         fprintf(config->errorLogFile, "SVT [Error]: Instance %u: Invalid injector [0 - 1]\n",channelNumber+1);
         return_error = EB_ErrorBadParameter;


### PR DESCRIPTION
Adding a configuration check that the compressed 10 bit format can only
be used if the encoder bit depth is also 10 bits.

Signed-off-by: Mark Feldman <mark.feldman@intel.com>