### PR TITLE
10bit YUV422 2bit compressed

### DIFF
--- a/Source/App/EbAppConfig.c
+++ b/Source/App/EbAppConfig.c
@@ -989,8 +989,8 @@ static EB_ERRORTYPE VerifySettings(EbConfig_t *config, uint32_t channelNumber)
         return_error = EB_ErrorBadParameter;
     }
 
-    if (config->encoderColorFormat != EB_YUV420 && config->compressedTenBitFormat ) {
-        fprintf(config->errorLogFile, "SVT [Error]: Instance %u : -compressed-ten-bit-format 1 is only supported for 420 color format\n", channelNumber + 1);
+    if ((config->encoderColorFormat != EB_YUV420 && config->encoderColorFormat != EB_YUV422) && config->compressedTenBitFormat) {
+        fprintf(config->errorLogFile, "SVT [Error]: Instance %u : -compressed-ten-bit-format 1 is only supported for 420 and 422 color formats\n", channelNumber + 1);
         return_error = EB_ErrorBadParameter;
     }
 

--- a/Source/App/EbAppProcessCmd.c
+++ b/Source/App/EbAppProcessCmd.c
@@ -25,7 +25,6 @@
 #define FUTURE_WINDOW_WIDTH                 4
 #define SIZE_OF_ONE_FRAME_IN_BYTES(width, height, csp, is16bit) \
     ( (((width)*(height)) + 2*(((width)*(height))>>(3-csp)) )<<is16bit)
-#define YUV4MPEG2_IND_SIZE 9
 extern volatile int32_t keepRunning;
 
 /***************************************

--- a/Source/App/EbAppProcessCmd.c
+++ b/Source/App/EbAppProcessCmd.c
@@ -25,6 +25,7 @@
 #define FUTURE_WINDOW_WIDTH                 4
 #define SIZE_OF_ONE_FRAME_IN_BYTES(width, height, csp, is16bit) \
     ( (((width)*(height)) + 2*(((width)*(height))>>(3-csp)) )<<is16bit)
+#define YUV4MPEG2_IND_SIZE 9
 extern volatile int32_t keepRunning;
 
 /***************************************
@@ -1120,7 +1121,7 @@ APPEXITCONDITIONTYPE ProcessInputBuffer(EbConfig_t *config, EbAppContext_t *appC
     int64_t                  remainingByteCount;
     const EB_COLOR_FORMAT colorFormat = (EB_COLOR_FORMAT)config->encoderColorFormat;
     int ret;
-    uint32_t compressed10bitFrameSize = (uint32_t)((inputPaddedWidth*inputPaddedHeight) + 2 * ((inputPaddedWidth*inputPaddedWidth) >> (3 - colorFormat)));
+    uint32_t compressed10bitFrameSize = (uint32_t)((inputPaddedWidth*inputPaddedHeight) + 2 * ((inputPaddedWidth*inputPaddedHeight) >> (3 - colorFormat)));
     compressed10bitFrameSize += compressed10bitFrameSize / 4;
 
     if (config->injector && config->processedFrameCount)

--- a/Source/Lib/Codec/EbCodingLoop.c
+++ b/Source/Lib/Codec/EbCodingLoop.c
@@ -2867,11 +2867,11 @@ void EncodePassPackLcu(
     if ((sequenceControlSetPtr->staticConfig.compressedTenBitFormat == 1))
     {
 
-        const EB_U32 inputLumaOffset = ((lcuOriginY + inputPicture->originY)       * inputPicture->strideY) + (lcuOriginX + inputPicture->originX);
-        const EB_U32 inputCbOffset = (((lcuOriginY + inputPicture->originY) >> 1)  * inputPicture->strideCb) + ((lcuOriginX + inputPicture->originX) >> 1);
-        const EB_U32 inputCrOffset = (((lcuOriginY + inputPicture->originY) >> 1)  * inputPicture->strideCr) + ((lcuOriginX + inputPicture->originX) >> 1);
+        const EB_U32 inputLumaOffset = ((lcuOriginY + inputPicture->originY)                      * inputPicture->strideY) + (lcuOriginX + inputPicture->originX);
+        const EB_U32 inputCbOffset = (((lcuOriginY + inputPicture->originY) >> subHeightCMinus1)  * inputPicture->strideCb) + ((lcuOriginX + inputPicture->originX) >> subWidthCMinus1);
+        const EB_U32 inputCrOffset = (((lcuOriginY + inputPicture->originY) >> subHeightCMinus1)  * inputPicture->strideCr) + ((lcuOriginX + inputPicture->originX) >> subWidthCMinus1);
         const EB_U16 luma2BitWidth = inputPicture->width / 4;
-        const EB_U16 chroma2BitWidth = inputPicture->width / 8;
+        const EB_U16 chroma2BitWidth = (inputPicture->width / 4) >> subWidthCMinus1;
 
 
         CompressedPackLcu(
@@ -2887,22 +2887,22 @@ void EncodePassPackLcu(
         CompressedPackLcu(
             inputPicture->bufferCb + inputCbOffset,
             inputPicture->strideCb,
-            inputPicture->bufferBitIncCb + lcuOriginY / 2 * chroma2BitWidth + (lcuOriginX / 8)*(lcuHeight / 2),
-            lcuWidth / 8,
+            inputPicture->bufferBitIncCb + (lcuOriginY >> subHeightCMinus1) * chroma2BitWidth + ((lcuOriginX >> subWidthCMinus1) / 4)*(lcuHeight  >> subHeightCMinus1),
+            (lcuWidth >> subWidthCMinus1) / 4,
             (EB_U16 *)contextPtr->inputSample16bitBuffer->bufferCb,
             MAX_LCU_SIZE_CHROMA,
-            lcuWidth >> 1,
-            lcuHeight >> 1);
+            lcuWidth >> subWidthCMinus1,
+            lcuHeight >> subHeightCMinus1);
 
         CompressedPackLcu(
             inputPicture->bufferCr + inputCrOffset,
             inputPicture->strideCr,
-            inputPicture->bufferBitIncCr + lcuOriginY / 2 * chroma2BitWidth + (lcuOriginX / 8)*(lcuHeight / 2),
-            lcuWidth / 8,
+            inputPicture->bufferBitIncCr + (lcuOriginY >> subHeightCMinus1) * chroma2BitWidth + ((lcuOriginX >> subWidthCMinus1 / 4))*(lcuHeight >> subHeightCMinus1),
+            (lcuWidth >> subWidthCMinus1) / 4,
             (EB_U16 *)contextPtr->inputSample16bitBuffer->bufferCr,
             MAX_LCU_SIZE_CHROMA,
-            lcuWidth >> 1,
-            lcuHeight >> 1);
+            lcuWidth >> subWidthCMinus1,
+            lcuHeight >> subHeightCMinus1);
 
     }
     else {

--- a/Source/Lib/Codec/EbCodingLoop.c
+++ b/Source/Lib/Codec/EbCodingLoop.c
@@ -2863,7 +2863,6 @@ void EncodePassPackLcu(
     const EB_U16 subWidthCMinus1 = (colorFormat == EB_YUV444 ? 1 : 2) - 1;
     const EB_U16 subHeightCMinus1 = (colorFormat >= EB_YUV422 ? 1 : 2) - 1;
 
-    //TODO: Jing, need change here later 
     if ((sequenceControlSetPtr->staticConfig.compressedTenBitFormat == 1))
     {
 

--- a/Source/Lib/Codec/EbCodingLoop.c
+++ b/Source/Lib/Codec/EbCodingLoop.c
@@ -2866,7 +2866,7 @@ void EncodePassPackLcu(
     if ((sequenceControlSetPtr->staticConfig.compressedTenBitFormat == 1))
     {
 
-        const EB_U32 inputLumaOffset = ((lcuOriginY + inputPicture->originY)                      * inputPicture->strideY) + (lcuOriginX + inputPicture->originX);
+        const EB_U32 inputLumaOffset = ((lcuOriginY + inputPicture->originY)       * inputPicture->strideY) + (lcuOriginX + inputPicture->originX);
         const EB_U32 inputCbOffset = (((lcuOriginY + inputPicture->originY) >> subHeightCMinus1)  * inputPicture->strideCb) + ((lcuOriginX + inputPicture->originX) >> subWidthCMinus1);
         const EB_U32 inputCrOffset = (((lcuOriginY + inputPicture->originY) >> subHeightCMinus1)  * inputPicture->strideCr) + ((lcuOriginX + inputPicture->originX) >> subWidthCMinus1);
         const EB_U16 luma2BitWidth = inputPicture->width / 4;

--- a/Source/Lib/Codec/EbCodingLoop.c
+++ b/Source/Lib/Codec/EbCodingLoop.c
@@ -2896,7 +2896,7 @@ void EncodePassPackLcu(
         CompressedPackLcu(
             inputPicture->bufferCr + inputCrOffset,
             inputPicture->strideCr,
-            inputPicture->bufferBitIncCr + (lcuOriginY >> subHeightCMinus1) * chroma2BitWidth + ((lcuOriginX >> subWidthCMinus1 / 4))*(lcuHeight >> subHeightCMinus1),
+            inputPicture->bufferBitIncCr + (lcuOriginY >> subHeightCMinus1) * chroma2BitWidth + ((lcuOriginX >> subWidthCMinus1) / 4)*(lcuHeight >> subHeightCMinus1),
             (lcuWidth >> subWidthCMinus1) / 4,
             (EB_U16 *)contextPtr->inputSample16bitBuffer->bufferCr,
             MAX_LCU_SIZE_CHROMA,

--- a/Source/Lib/Codec/EbEncHandle.c
+++ b/Source/Lib/Codec/EbEncHandle.c
@@ -2459,6 +2459,10 @@ void SetParamBasedOnInput(
     SequenceControlSet_t       *sequenceControlSetPtr)
 
 {
+    EB_U32 chromaFormat = EB_YUV420;
+    EB_U32 subWidthCMinus1 = 1;
+    EB_U32 subHeightCMinus1 = 1;
+
     if (sequenceControlSetPtr->interlacedVideo == EB_FALSE) {
 
         sequenceControlSetPtr->generalFrameOnlyConstraintFlag = 0;
@@ -2501,10 +2505,25 @@ void SetParamBasedOnInput(
     sequenceControlSetPtr->topPadding   = MAX_LCU_SIZE + 4;
     sequenceControlSetPtr->rightPadding = MAX_LCU_SIZE + 4;
     sequenceControlSetPtr->botPadding   = MAX_LCU_SIZE + 4;
-    sequenceControlSetPtr->chromaWidth  = sequenceControlSetPtr->maxInputLumaWidth >> 1;
-    sequenceControlSetPtr->chromaHeight = sequenceControlSetPtr->maxInputLumaHeight >> 1;
     sequenceControlSetPtr->lumaWidth    = sequenceControlSetPtr->maxInputLumaWidth;
     sequenceControlSetPtr->lumaHeight   = sequenceControlSetPtr->maxInputLumaHeight;
+
+    chromaFormat = sequenceControlSetPtr->chromaFormatIdc;
+    subWidthCMinus1 = (chromaFormat == EB_YUV444 ? 1 : 2) - 1;
+    subHeightCMinus1 = (chromaFormat >= EB_YUV422 ? 1 : 2) - 1;
+
+    sequenceControlSetPtr->chromaWidth = sequenceControlSetPtr->maxInputLumaWidth >> subWidthCMinus1;
+    sequenceControlSetPtr->chromaHeight = sequenceControlSetPtr->maxInputLumaHeight >> subHeightCMinus1;
+
+    sequenceControlSetPtr->padRight = sequenceControlSetPtr->maxInputPadRight;
+    sequenceControlSetPtr->croppingRightOffset = sequenceControlSetPtr->padRight;
+    sequenceControlSetPtr->padBottom = sequenceControlSetPtr->maxInputPadBottom;
+    sequenceControlSetPtr->croppingBottomOffset = sequenceControlSetPtr->padBottom;
+
+    if (sequenceControlSetPtr->padRight != 0 || sequenceControlSetPtr->padBottom != 0)
+        sequenceControlSetPtr->conformanceWindowFlag = 1;
+    else
+        sequenceControlSetPtr->conformanceWindowFlag = 0;
 
     DeriveInputResolution(
         sequenceControlSetPtr,

--- a/Source/Lib/Codec/EbEncHandle.c
+++ b/Source/Lib/Codec/EbEncHandle.c
@@ -2505,6 +2505,7 @@ void SetParamBasedOnInput(
     sequenceControlSetPtr->topPadding   = MAX_LCU_SIZE + 4;
     sequenceControlSetPtr->rightPadding = MAX_LCU_SIZE + 4;
     sequenceControlSetPtr->botPadding   = MAX_LCU_SIZE + 4;
+
     sequenceControlSetPtr->lumaWidth    = sequenceControlSetPtr->maxInputLumaWidth;
     sequenceControlSetPtr->lumaHeight   = sequenceControlSetPtr->maxInputLumaHeight;
 
@@ -2512,12 +2513,12 @@ void SetParamBasedOnInput(
     subWidthCMinus1 = (chromaFormat == EB_YUV444 ? 1 : 2) - 1;
     subHeightCMinus1 = (chromaFormat >= EB_YUV422 ? 1 : 2) - 1;
 
-    sequenceControlSetPtr->chromaWidth = sequenceControlSetPtr->maxInputLumaWidth >> subWidthCMinus1;
+    sequenceControlSetPtr->chromaWidth  = sequenceControlSetPtr->maxInputLumaWidth >> subWidthCMinus1;
     sequenceControlSetPtr->chromaHeight = sequenceControlSetPtr->maxInputLumaHeight >> subHeightCMinus1;
 
-    sequenceControlSetPtr->padRight = sequenceControlSetPtr->maxInputPadRight;
-    sequenceControlSetPtr->croppingRightOffset = sequenceControlSetPtr->padRight;
-    sequenceControlSetPtr->padBottom = sequenceControlSetPtr->maxInputPadBottom;
+    sequenceControlSetPtr->padRight             = sequenceControlSetPtr->maxInputPadRight;
+    sequenceControlSetPtr->croppingRightOffset  = sequenceControlSetPtr->padRight;
+    sequenceControlSetPtr->padBottom            = sequenceControlSetPtr->maxInputPadBottom;
     sequenceControlSetPtr->croppingBottomOffset = sequenceControlSetPtr->padBottom;
 
     if (sequenceControlSetPtr->padRight != 0 || sequenceControlSetPtr->padBottom != 0)


### PR DESCRIPTION
Adding support for:
10bit YUV422 2bit compressed

1) Adjusted the frame size in the
sample encoder app (ProcessInputBuffer)

2) Adjusted the size of the incremental Cb and Cr buffers in
EbEncHandle.c/AllocateFrameBuffer()

3) Adjusted the offsets and widths in EbCodingLoop.s/EncodePassPackLcu()

Verified using:
ParkJoy_864x480_10bit_50Hz_P422.yuv

and checked for regressions using:
Netflix_Crosswalk_3840x2160_10bit_60Hz_P420.yuv

Changes also made to YUVTools to support chroma modes other than YUV422.