### PR TITLE
Enabling segment override for each LCU separatelly

### DIFF
--- a/Config/SVTSegmentOvFile.txt
+++ b/Config/SVTSegmentOvFile.txt
@@ -1,0 +1,19 @@
+# Copyright(c) 2019 Intel Corporation 
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+
+#====================== Segment Override File ======================
+# One input frame have to be preceded by the number of regions
+# Each region consist of 6 numbers (X1,Y1,X2,Y2, data, mode) i.e (X1,Y1)top left and (X2,Y2)bottom right corner
+# Mode parameter have to be in range [1..5]. This allow user to specify what to override by the [data]
+#    1.   Set qp value for each region, [data] is clipped to [0:51]
+#    2.   Change qp value i.e increase or decrease by the [data] clipped to [-25:25]
+#    3.   Use this mode to modify not only quality but also blocks splitting, behaviour depends on parameter 1 and 2
+#    4.   Use this mode to modify blocks splitting i.e increase or decrease by the [data] clipped to [-25:25], negative value increase block division
+#    5.   Update first stage of quantization in range [-7;7] positive value reduce bitrate, negative increase
+3
+0 0 500 500 50 1
+500 500 1000 0 -20 4
+500 500 1000 1000 20 4
+2
+0 0 500 500 20 1
+0 0 300 200 20 1

--- a/Config/Sample.cfg
+++ b/Config/Sample.cfg
@@ -8,6 +8,7 @@ ErrorFile                       : SVTEncoderLog.log     # Error log displaying c
 #ReconFile                      : SVTRecon.yuv          # Output reconstructed video [disabled by default]
 UseQpFile                       : 0                     # When set to 1, overwrite the encoder picture qp assignment using qp values in QpFile (0: OFF, 1: ON)
 QpFile                          : SVTQPFile.txt         # File with rows of QP values corresponding to QP values for each frame
+#SegmentOvFile                  : SVTSegmentOvFile.txt  # File with row and cols of QP values corresponding to values for each LCU and frame [disabled by default]
 
 # ====================== Tiles ===============================
 TileRowCount                    : 1                     # Number of row tiles 

--- a/Docs/svt-hevc_encoder_user_guide.md
+++ b/Docs/svt-hevc_encoder_user_guide.md
@@ -264,6 +264,7 @@ The encoder parameters present in the Sample.cfg file are listed in this table b
 | **ReconFile** | -o | any string | null | Output reconstructed yuv used for debug purposes. **Note:** using this feature will affect the speed of the encoder significantly. This should only be used for debugging purposes. |
 | **UseQpFile** | -use-q-file | [0, 1] | 0 | When set to 1, overwrite the picture qp assignment using qp values in QpFile |
 | **QpFile** | -qp-file | any string | null | Path to qp file |
+| **SegmentOvFile** | -segment-ov-file | any string | null | Path to segment override file, diffrence between largest and smallest value should be less or equal 25. **Note:** using this feature will disable ImproveSharpness and BitRateReduction parameters |
 | **EncoderMode** | -encMode | [0 - 11] | 7 | A preset defining the quality vs density tradeoff point that the encoding is to be performed at. (e.g. 0 is the highest quality mode, 11 is the highest density mode). Section 3.4 outlines the preset availability per resolution |
 | **EncoderBitDepth** | -bit-depth | [8, 10] | 8 | Specifies the bit depth of input video |
 | **EncoderColorFormat** | -color-format | [1, 2, 3] | 1 | Specifies the chroma subsampling of input video(1: 420, 2: 422, 3: 444) |

--- a/Source/API/EbApi.h
+++ b/Source/API/EbApi.h
@@ -38,6 +38,33 @@ extern "C" {
 #define EB_NON_REF_PICTURE   4
 #define EB_INVALID_PICTURE   0xFF
 
+#define EB_SEGMENT_BLOCK_SIZE 64
+    typedef struct
+    {
+        uint8_t ovFlags;
+        int8_t  qpOv;
+        int8_t  deblockOv;
+        int8_t  filterOv;
+    } SegmentOverride_t;
+
+    typedef enum EB_OV_FLAGS
+    {
+        /* Do no ovveride default values */
+        EB_NO_OV              = 0,
+        /* Set qp value in range [0:51] */
+        EB_QP_OV_DIRECT       = 1 << 0,
+        /* Change original qp value in range [-25:25] */
+        EB_QP_OV_DELTA        = 1 << 1,
+        /* Use qpOv for deblock, behaviour depends on EB_QP_OV* flag */
+        EB_DENSITY_QP_OV      = 1 << 2,
+        /* Use deblockOv for deblock in range [-25:25];
+        * positive value decrease density, negative increase */
+        EB_DENSITY_DEBLOCK_OV = 1 << 3,
+        /* Change first stage of quantization in range [-7;7];
+        * positive value reduce bitrate, negative increase */
+        EB_TU_FILTER_OV       = 1 << 4,
+    } EB_OV_FLAGS;
+
     typedef struct EB_BUFFERHEADERTYPE
     {
         // EB_BUFFERHEADERTYPE size
@@ -72,6 +99,7 @@ extern "C" {
         uint32_t naluPayloadType;
         uint8_t* naluBase64Encode;
 
+        SegmentOverride_t *segmentOvPtr;
     } EB_BUFFERHEADERTYPE;
 
     typedef struct EB_COMPONENTTYPE
@@ -629,6 +657,10 @@ typedef struct EB_H265_ENC_CONFIGURATION
     uint16_t                whitePointX, whitePointY;
     uint32_t                maxDisplayMasteringLuminance;
     uint32_t                minDisplayMasteringLuminance;
+
+    /* Flag to enable SegmentOverride overwrite per LCU
+    * Default is 0. */
+    uint32_t                segmentOvEnabled;
 
 } EB_H265_ENC_CONFIGURATION;
 

--- a/Source/App/EbAppConfig.c
+++ b/Source/App/EbAppConfig.c
@@ -32,6 +32,7 @@
 #define ERROR_FILE_TOKEN                "-errlog"
 #define STAT_FILE_TOKEN                 "-stat-file"
 #define QP_FILE_TOKEN                   "-qp-file"
+#define SEGMENT_OV_FILE_TOKEN           "-segment-ov-file"
 #define WIDTH_TOKEN                     "-w"
 #define HEIGHT_TOKEN                    "-h"
 #define NUMBER_OF_PICTURES_TOKEN        "-n"
@@ -166,6 +167,15 @@ static void SetCfgQpFile                        (const char *value, EbConfig_t *
     if (cfg->qpFile) { fclose(cfg->qpFile); }
     FOPEN(cfg->qpFile,value, "r");
 };
+static void SetCfgSegmentOvFile(const char *value, EbConfig_t *cfg)
+{
+    if (cfg->segmentOvFile) { fclose(cfg->segmentOvFile); }
+    FOPEN(cfg->segmentOvFile, value, "r");
+    if (cfg->segmentOvFile)
+        cfg->segmentOvEnabled = EB_TRUE;
+    else
+        printf("Error segment Override file: %s does not exist, won't use\n",value);
+};
 static void SetCfgDolbyVisionRpuFile			(const char *value, EbConfig_t *cfg)
 {
     if (cfg->dolbyVisionRpuFile) { fclose(cfg->dolbyVisionRpuFile); }
@@ -299,6 +309,7 @@ config_entry_t config_entry[] = {
     { SINGLE_INPUT, OUTPUT_RECON_TOKEN, "ReconFile", SetCfgReconFile },
     { SINGLE_INPUT, USE_QP_FILE_TOKEN, "UseQpFile", SetCfgUseQpFile },
     { SINGLE_INPUT, QP_FILE_TOKEN, "QpFile", SetCfgQpFile },
+    { SINGLE_INPUT, SEGMENT_OV_FILE_TOKEN, "SegmentOvFile", SetCfgSegmentOvFile},
 
     // Interlaced Video
     { SINGLE_INPUT, INTERLACED_VIDEO_TOKEN, "InterlacedVideo", SetInterlacedVideo },
@@ -440,6 +451,7 @@ void EbConfigCtor(EbConfig_t *configPtr)
     configPtr->bufferFile                           = NULL;
     configPtr->useQpFile                            = EB_FALSE;
     configPtr->qpFile                               = NULL;
+    configPtr->segmentOvFile                        = NULL;
 
     configPtr->y4m_input                            = EB_FALSE;
 
@@ -598,6 +610,7 @@ void EbConfigCtor(EbConfig_t *configPtr)
     configPtr->processedFrameCount                  = 0;
     configPtr->processedByteCount                   = 0;
 
+    configPtr->segmentOvEnabled                     = EB_FALSE;
     return;
 }
 
@@ -646,6 +659,11 @@ void EbConfigDtor(EbConfig_t *configPtr)
     if (configPtr->dolbyVisionRpuFile) {
         fclose(configPtr->dolbyVisionRpuFile);
         configPtr->dolbyVisionRpuFile = (FILE *)NULL;
+    }
+
+    if (configPtr->segmentOvFile) {
+        fclose(configPtr->segmentOvFile);
+        configPtr->segmentOvFile = (FILE*)NULL;
     }
 
     return;

--- a/Source/App/EbAppConfig.h
+++ b/Source/App/EbAppConfig.h
@@ -233,6 +233,7 @@ typedef struct EbConfig_s
 
     FILE                   *qpFile;
 
+    FILE                   *segmentOvFile;
     // y4m format support
     EB_BOOL                 y4m_input;
     unsigned char           y4m_buf[9];
@@ -405,6 +406,7 @@ typedef struct EbConfig_s
     uint32_t     maxDisplayMasteringLuminance;
     uint32_t     minDisplayMasteringLuminance;
 
+    EB_BOOL      segmentOvEnabled;
 } EbConfig_t;
 
 extern void EbConfigCtor(EbConfig_t *configPtr);

--- a/Source/App/EbAppContext.c
+++ b/Source/App/EbAppContext.c
@@ -273,6 +273,8 @@ EB_ERRORTYPE CopyConfigurationParameters(
     callbackData->ebEncParameters.maxDisplayMasteringLuminance = config->maxDisplayMasteringLuminance;
     callbackData->ebEncParameters.minDisplayMasteringLuminance = config->minDisplayMasteringLuminance;
 
+    callbackData->ebEncParameters.segmentOvEnabled = config->segmentOvEnabled;
+
     return return_error;
 
 }
@@ -379,6 +381,13 @@ EB_ERRORTYPE AllocateInputBuffers(
         // Assign the variables
         callbackData->inputBufferPool->pAppPrivate = NULL;
         callbackData->inputBufferPool->sliceType   = EB_INVALID_PICTURE;
+    }
+
+    if (callbackData->ebEncParameters.segmentOvEnabled) {
+        size_t pictureWidthInLcu = (config->sourceWidth + EB_SEGMENT_BLOCK_SIZE - 1) / EB_SEGMENT_BLOCK_SIZE;
+        size_t pictureHeightInLcu = (config->sourceHeight + EB_SEGMENT_BLOCK_SIZE - 1) / EB_SEGMENT_BLOCK_SIZE;
+        size_t lcuTotalCount = pictureWidthInLcu * pictureHeightInLcu;
+        EB_APP_MALLOC(SegmentOverride_t*, callbackData->inputBufferPool->segmentOvPtr, sizeof(SegmentOverride_t) * lcuTotalCount, EB_N_PTR, EB_ErrorInsufficientResources);
     }
 
     return return_error;

--- a/Source/Lib/Codec/EbEntropyCoding.c
+++ b/Source/Lib/Codec/EbEntropyCoding.c
@@ -6240,9 +6240,9 @@ static void CodePPS(
 	// "cu_qp_delta_enabled_flag"
 	WriteFlagCavlc(
 		bitstreamPtr,
-        scsPtr->staticConfig.improveSharpness || scsPtr->staticConfig.bitRateReduction);// pcsPtr->useDeltaQp);
+        scsPtr->staticConfig.improveSharpness || scsPtr->staticConfig.bitRateReduction || scsPtr->staticConfig.segmentOvEnabled);// pcsPtr->useDeltaQp);
 
-	if (scsPtr->staticConfig.improveSharpness || scsPtr->staticConfig.bitRateReduction) { //pcsPtr->useDeltaQp) {
+	if (scsPtr->staticConfig.improveSharpness || scsPtr->staticConfig.bitRateReduction || scsPtr->staticConfig.segmentOvEnabled) { //pcsPtr->useDeltaQp) {
 		// "diff_cu_qp_delta_depth"
 		WriteUvlc(
 			bitstreamPtr,
@@ -7440,7 +7440,7 @@ EB_ERRORTYPE EncodeLcu(
                     cuOriginY,
                     cuSize,
                     sequenceControlSetPtr->lcuSize,
-					sequenceControlSetPtr->staticConfig.improveSharpness || sequenceControlSetPtr->staticConfig.bitRateReduction ? EB_TRUE : EB_FALSE,
+					sequenceControlSetPtr->staticConfig.improveSharpness || sequenceControlSetPtr->staticConfig.bitRateReduction || sequenceControlSetPtr->staticConfig.segmentOvEnabled ? EB_TRUE : EB_FALSE,
                     &entropyDeltaQpNotCoded,
                     pictureControlSetPtr->difCuDeltaQpDepth,
                     &pictureControlSetPtr->prevCodedQp[tileIdx],

--- a/Source/Lib/Codec/EbModeDecisionProcess.c
+++ b/Source/Lib/Codec/EbModeDecisionProcess.c
@@ -685,7 +685,7 @@ void ModeDecisionConfigureLcu(
         contextPtr,
         lcuPtr);
 
-    if (sequenceControlSetPtr->staticConfig.rateControlMode == 0 && sequenceControlSetPtr->staticConfig.improveSharpness == 0) { 
+    if (sequenceControlSetPtr->staticConfig.rateControlMode == 0 && sequenceControlSetPtr->staticConfig.improveSharpness == 0 && sequenceControlSetPtr->staticConfig.segmentOvEnabled == 0) {
 		contextPtr->qp = (EB_U8)pictureQp;
         lcuPtr->qp = (EB_U8)contextPtr->qp;
     }

--- a/Source/Lib/Codec/EbPictureControlSet.c
+++ b/Source/Lib/Codec/EbPictureControlSet.c
@@ -889,6 +889,10 @@ EB_ERRORTYPE PictureParentControlSetCtor(
 
     EB_MALLOC(EB_LCU_DEPTH_MODE*, objectPtr->lcuMdModeArray, sizeof(EB_LCU_DEPTH_MODE) * objectPtr->lcuTotalCount, EB_N_PTR);
 
+    if (initDataPtr->segmentOvEnabled) {
+        EB_MALLOC(SegmentOverride_t*, objectPtr->segmentOvArray, sizeof(SegmentOverride_t) * objectPtr->lcuTotalCount, EB_N_PTR);
+    }
+
     return return_error;
 }
 

--- a/Source/Lib/Codec/EbPictureControlSet.h
+++ b/Source/Lib/Codec/EbPictureControlSet.h
@@ -602,6 +602,8 @@ typedef struct PictureParentControlSet_s
     EB_BOOL                               enableHmeLevel1Flag;
     EB_BOOL                               enableHmeLevel2Flag;
 	EB_BOOL                               disableVarianceFlag;
+
+    SegmentOverride_t                    *segmentOvArray;
 } PictureParentControlSet_t;
 
 
@@ -632,6 +634,8 @@ typedef struct PictureControlSetInitData_s
 
     EB_U16                           tileRowCount;
     EB_U16                           tileColumnCount;
+
+    EB_BOOL                          segmentOvEnabled;
 } PictureControlSetInitData_t;
 
 /**************************************

--- a/Source/Lib/Codec/EbPictureManagerProcess.c
+++ b/Source/Lib/Codec/EbPictureManagerProcess.c
@@ -801,7 +801,7 @@ void* PictureManagerKernel(void *inputPtr)
 
                     // Rate Control 
 
-                    ChildPictureControlSetPtr->useDeltaQp =  (EB_U8)(entrySequenceControlSetPtr->staticConfig.improveSharpness || entrySequenceControlSetPtr->staticConfig.bitRateReduction);
+                    ChildPictureControlSetPtr->useDeltaQp =  (EB_U8)(entrySequenceControlSetPtr->staticConfig.improveSharpness || entrySequenceControlSetPtr->staticConfig.bitRateReduction || sequenceControlSetPtr->staticConfig.segmentOvEnabled);
 
                     // Check resolution
                     if (entrySequenceControlSetPtr->inputResolution < INPUT_SIZE_1080p_RANGE)

--- a/Source/Lib/Codec/EbResourceCoordinationProcess.c
+++ b/Source/Lib/Codec/EbResourceCoordinationProcess.c
@@ -665,7 +665,9 @@ void* ResourceCoordinationKernel(void *inputPtr)
 
         prevPictureControlSetWrapperPtr = pictureControlSetWrapperPtr;
 
-
+        if (sequenceControlSetPtr->staticConfig.segmentOvEnabled) {
+            EB_MEMCPY(pictureControlSetPtr->segmentOvArray, ebInputPtr->segmentOvPtr, sizeof(SegmentOverride_t) * sequenceControlSetPtr->lcuTotalCount);
+        }
 
 #if DEADLOCK_DEBUG
         SVT_LOG("POC %lld RESCOOR OUT \n", pictureControlSetPtr->pictureNumber);


### PR DESCRIPTION
Hi, I want to introduce new feature for HEVC
The point is to give users ability to change QP and densilty for each LCU and image separately.
This feature is rather for very specific use-case like surveillance systems, where objects like pedestrians or vehicles are detected and tracked (encoded with higher quality) while background is encoded with worse quality. Thanks to encoding only key areas with good quality bitstream is smaller and still have high value

I added new parameter "-segment-ov-file" which read qp values from file and send it to encoder (as example)

I am open to any suggestions.