### PR TITLE
Fix integer wrap-around in fillerBytes for CBR VBV.

### DIFF
--- a/Source/Lib/Codec/EbPacketizationProcess.c
+++ b/Source/Lib/Codec/EbPacketizationProcess.c
@@ -881,7 +881,9 @@ void* PacketizationKernel(void *inputPtr)
                     {
                         filler = buffer - encodeContextPtr->vbvBufsize;
                         queueEntryPtr->fillerBitsFinal = filler;
-                        fillerBytes = ((EB_U32)(filler >> 3)) - FILLER_DATA_OVERHEAD;
+                        fillerBytes = (EB_U32)(filler >> 3);
+                        fillerBytes = (fillerBytes < FILLER_DATA_OVERHEAD) ? 0 : fillerBytes - FILLER_DATA_OVERHEAD;
+
                         // Reset the bitstream
                         ResetBitstream(queueEntryPtr->bitStreamPtr2->outputBitstreamPtr);
 


### PR DESCRIPTION
Set fillerBytes to 0 if it would wrap-around to max uint32. This will end up sending FILLER_DATA_OVERHEAD(6) bytes as filler still with no ff_bytes (which is valid).