### PR TITLE
Fix reading overflow when estimating bits for SAO offset values in 10bit

### DIFF
--- a/Source/Lib/Codec/EbMdRateEstimation.c
+++ b/Source/Lib/Codec/EbMdRateEstimation.c
@@ -258,6 +258,10 @@ EB_ERRORTYPE GetSaoOffsetsFractionBits(
     *fractionBitNum = 0;
 
     if(saoType != 0) {
+        EB_U32 offset0 = MIN(NUMBER_OF_SAO_OFFSET_TRUNUNARY_CASES - 1, ABS(offset[0]));
+        EB_U32 offset1 = MIN(NUMBER_OF_SAO_OFFSET_TRUNUNARY_CASES - 1, ABS(offset[1]));
+        EB_U32 offset2 = MIN(NUMBER_OF_SAO_OFFSET_TRUNUNARY_CASES - 1, ABS(offset[2]));
+        EB_U32 offset3 = MIN(NUMBER_OF_SAO_OFFSET_TRUNUNARY_CASES - 1, ABS(offset[3]));
 
         // Band Offset
         if(saoType == 5) { // Add macros
@@ -266,24 +270,24 @@ EB_ERRORTYPE GetSaoOffsetsFractionBits(
             *fractionBitNum += 163840; //32768*5
 
             // code abs value of offsets
-            *fractionBitNum +=  mdRateEstimationArray->saoOffsetTrunUnaryBits[ABS(offset[0])];
-            *fractionBitNum +=  mdRateEstimationArray->saoOffsetTrunUnaryBits[ABS(offset[1])];
-            *fractionBitNum +=  mdRateEstimationArray->saoOffsetTrunUnaryBits[ABS(offset[2])];
-            *fractionBitNum +=  mdRateEstimationArray->saoOffsetTrunUnaryBits[ABS(offset[3])];
+            *fractionBitNum += mdRateEstimationArray->saoOffsetTrunUnaryBits[offset0];
+            *fractionBitNum += mdRateEstimationArray->saoOffsetTrunUnaryBits[offset1];
+            *fractionBitNum += mdRateEstimationArray->saoOffsetTrunUnaryBits[offset2];
+            *fractionBitNum += mdRateEstimationArray->saoOffsetTrunUnaryBits[offset3];
 
             // code the sign of offsets
-            *fractionBitNum += (offset[0] != 0) ? 32768: 0;
-            *fractionBitNum += (offset[1] != 0) ? 32768: 0;
-            *fractionBitNum += (offset[2] != 0) ? 32768: 0;
-            *fractionBitNum += (offset[3] != 0) ? 32768: 0;
+            *fractionBitNum += (offset0 != 0) ? 32768: 0;
+            *fractionBitNum += (offset1 != 0) ? 32768: 0;
+            *fractionBitNum += (offset2 != 0) ? 32768: 0;
+            *fractionBitNum += (offset3 != 0) ? 32768: 0;
         }
         // Edge Offset
         else {
             // code the offset values
-            *fractionBitNum +=  mdRateEstimationArray->saoOffsetTrunUnaryBits[ABS(offset[0])];
-            *fractionBitNum +=  mdRateEstimationArray->saoOffsetTrunUnaryBits[ABS(offset[1])];
-            *fractionBitNum +=  mdRateEstimationArray->saoOffsetTrunUnaryBits[ABS(offset[2])];
-            *fractionBitNum +=  mdRateEstimationArray->saoOffsetTrunUnaryBits[ABS(offset[3])];
+            *fractionBitNum += mdRateEstimationArray->saoOffsetTrunUnaryBits[offset0];
+            *fractionBitNum += mdRateEstimationArray->saoOffsetTrunUnaryBits[offset1];
+            *fractionBitNum += mdRateEstimationArray->saoOffsetTrunUnaryBits[offset2];
+            *fractionBitNum += mdRateEstimationArray->saoOffsetTrunUnaryBits[offset3];
         }
     }
     return return_error;


### PR DESCRIPTION
In 10bit coding, the offset value can be larger than 7. The range is defined as follows in file `EbSampleAdaptiveOffsetGenerationDecisioin.c`.

```
static EB_S32 MinSaoOffsetvalueEO[2 /*8bit+10bit*/][SAO_EO_CATEGORIES] = { {0, 0, -7, -7},{0,  0, -31, -31} };
static EB_S32 MaxSaoOffsetvalueEO[2 /*8bit+10bit*/][SAO_EO_CATEGORIES] = { {7, 7,  0,  0},{31, 31, 0,    0} };
static EB_S32 MaxSaoOffsetvalueBO[2 /*8bit+10bit*/] = { 7 , 31 };
static EB_S32 MinSaoOffsetvalueBO[2 /*8bit+10bit*/] = { -7 ,-31 };
```
When the offset value is larger than the array size of `saoOffsetTrunUnaryBits`, reading overflow would happen.

This commit forces a maxminum value of 7.