### PR TITLE
Fixed the hang issue with each EOS frame.

### DIFF
--- a/Source/Lib/Codec/EbPictureDecisionProcess.c
+++ b/Source/Lib/Codec/EbPictureDecisionProcess.c
@@ -646,6 +646,7 @@ void* PictureDecisionKernel(void *inputPtr)
         queueEntryIndex                                         +=  encodeContextPtr->pictureDecisionReorderQueueHeadIndex;
         queueEntryIndex                                         =   (queueEntryIndex > PICTURE_DECISION_REORDER_QUEUE_MAX_DEPTH - 1) ? queueEntryIndex - PICTURE_DECISION_REORDER_QUEUE_MAX_DEPTH : queueEntryIndex;        
         queueEntryPtr                                           =   encodeContextPtr->pictureDecisionReorderQueue[queueEntryIndex];         
+        // Parent PCS could be NULL, especailly when the 1st frame is an EOS one.
         if ((queueEntryPtr->parentPcsWrapperPtr != NULL) && !pictureControlSetPtr->endOfSequenceFlag) {
             CHECK_REPORT_ERROR_NC(
                 encodeContextPtr->appCallbackPtr, 

--- a/Source/Lib/Codec/EbPictureDecisionProcess.c
+++ b/Source/Lib/Codec/EbPictureDecisionProcess.c
@@ -646,7 +646,7 @@ void* PictureDecisionKernel(void *inputPtr)
         queueEntryIndex                                         +=  encodeContextPtr->pictureDecisionReorderQueueHeadIndex;
         queueEntryIndex                                         =   (queueEntryIndex > PICTURE_DECISION_REORDER_QUEUE_MAX_DEPTH - 1) ? queueEntryIndex - PICTURE_DECISION_REORDER_QUEUE_MAX_DEPTH : queueEntryIndex;        
         queueEntryPtr                                           =   encodeContextPtr->pictureDecisionReorderQueue[queueEntryIndex];         
-        if(queueEntryPtr->parentPcsWrapperPtr != NULL){
+        if ((queueEntryPtr->parentPcsWrapperPtr != NULL) && !pictureControlSetPtr->endOfSequenceFlag) {
             CHECK_REPORT_ERROR_NC(
                 encodeContextPtr->appCallbackPtr, 
                 EB_ENC_PD_ERROR8);

--- a/Source/Lib/Codec/EbResourceCoordinationProcess.c
+++ b/Source/Lib/Codec/EbResourceCoordinationProcess.c
@@ -658,7 +658,13 @@ void* ResourceCoordinationKernel(void *inputPtr)
         ((EbPaReferenceObject_t*)pictureControlSetPtr->paReferencePictureWrapperPtr->objectPtr)->inputPaddedPicturePtr->bufferY = inputPicturePtr->bufferY;
 
         // Get Empty Output Results Object
-        if (((pictureControlSetPtr->pictureNumber > 0) && (prevPictureControlSetWrapperPtr != (EbObjectWrapper_t*)EB_NULL)) || endOfSequenceFlag) {
+        // Note: record the PCS object into output of the Resource Coordination process for EOS frame(s).
+        //       Because EbH265GetPacket() can get the encoded bit stream only if Packetization process has
+        //       posted the buffer as its result, and the buffer belonging to a PCS object is recorded in
+        //       the Initial Rate Control process. So need to record the PCS object immediately once the
+        //       1st frame is EOS, to make it go through the whole encoding kernels.
+        if (((pictureControlSetPtr->pictureNumber > 0) && (prevPictureControlSetWrapperPtr != (EbObjectWrapper_t*)EB_NULL)) ||
+                endOfSequenceFlag) {
             if (prevPictureControlSetWrapperPtr && prevPictureControlSetWrapperPtr->objectPtr)
                 ((PictureParentControlSet_t *)prevPictureControlSetWrapperPtr->objectPtr)->endOfSequenceFlag = endOfSequenceFlag;
 

--- a/Source/Lib/Codec/EbResourceCoordinationProcess.c
+++ b/Source/Lib/Codec/EbResourceCoordinationProcess.c
@@ -658,21 +658,25 @@ void* ResourceCoordinationKernel(void *inputPtr)
         ((EbPaReferenceObject_t*)pictureControlSetPtr->paReferencePictureWrapperPtr->objectPtr)->inputPaddedPicturePtr->bufferY = inputPicturePtr->bufferY;
 
         // Get Empty Output Results Object
-		if (pictureControlSetPtr->pictureNumber > 0 && prevPictureControlSetWrapperPtr != (EbObjectWrapper_t*)EB_NULL)
-		{
-			((PictureParentControlSet_t       *)prevPictureControlSetWrapperPtr->objectPtr)->endOfSequenceFlag = endOfSequenceFlag;
+        if (((pictureControlSetPtr->pictureNumber > 0) && (prevPictureControlSetWrapperPtr != (EbObjectWrapper_t*)EB_NULL)) || endOfSequenceFlag) {
+            if (prevPictureControlSetWrapperPtr && prevPictureControlSetWrapperPtr->objectPtr)
+                ((PictureParentControlSet_t *)prevPictureControlSetWrapperPtr->objectPtr)->endOfSequenceFlag = endOfSequenceFlag;
 
-			EbGetEmptyObject(
-				contextPtr->resourceCoordinationResultsOutputFifoPtr,
-				&outputWrapperPtr);
-			outputResultsPtr = (ResourceCoordinationResults_t*)outputWrapperPtr->objectPtr;
-			outputResultsPtr->pictureControlSetWrapperPtr = prevPictureControlSetWrapperPtr;
+            EbGetEmptyObject(
+                    contextPtr->resourceCoordinationResultsOutputFifoPtr,
+                    &outputWrapperPtr);
+            outputResultsPtr = (ResourceCoordinationResults_t *)outputWrapperPtr->objectPtr;
+            if (endOfSequenceFlag && (pictureControlSetPtr->pictureNumber == 0)) {
+                ((PictureParentControlSet_t *)pictureControlSetWrapperPtr->objectPtr)->endOfSequenceFlag = endOfSequenceFlag;
+                outputResultsPtr->pictureControlSetWrapperPtr = pictureControlSetWrapperPtr;
+            } else
+                outputResultsPtr->pictureControlSetWrapperPtr = prevPictureControlSetWrapperPtr;
 
-			// Post the finished Results Object
-			EbPostFullObject(outputWrapperPtr);
-		}
+            // Post the finished Results Object
+            EbPostFullObject(outputWrapperPtr);
+        }
 
-		prevPictureControlSetWrapperPtr = pictureControlSetWrapperPtr;
+        prevPictureControlSetWrapperPtr = pictureControlSetWrapperPtr;
 
 
 


### PR DESCRIPTION
When the application send fake frames (such as with EOS flag), the
encoder should make each frame go through the whole encoding kernel
stages (from ResourceCoordination to Packetization), otherwise
EbH265GetPacket() would be blocked in waiting for the buffer posted
by Packetization.

Signed-off-by: Austin Hu <austin.hu@intel.com>

Fixes #367 .