### PR TITLE
Fix condition to prevent encoding two AUD in one IDR frame.

### DIFF
--- a/Source/Lib/Codec/EbPacketizationProcess.c
+++ b/Source/Lib/Codec/EbPacketizationProcess.c
@@ -570,8 +570,7 @@ void* PacketizationKernel(void *inputPtr)
         packetizationQp = pictureControlSetPtr->pictureQp;
 
         // Note: If AUD is inserted with headers, avoid insertion again for smaller bitstream.
-        if (sequenceControlSetPtr->staticConfig.accessUnitDelimiter && pictureControlSetPtr->pictureNumber > 0
-                && !toInsertHeaders)
+        if (sequenceControlSetPtr->staticConfig.accessUnitDelimiter && !toInsertHeaders)
         {
             EncodeAUD(
                 pictureControlSetPtr->bitstreamPtr,

--- a/Source/Lib/Codec/EbPacketizationProcess.c
+++ b/Source/Lib/Codec/EbPacketizationProcess.c
@@ -568,8 +568,10 @@ void* PacketizationKernel(void *inputPtr)
 
         // Encode slice header and write it into the bitstream.
         packetizationQp = pictureControlSetPtr->pictureQp;
-     
-        if (sequenceControlSetPtr->staticConfig.accessUnitDelimiter && !(sequenceControlSetPtr->staticConfig.codeVpsSpsPps && toInsertHeaders))
+
+        // Note: If AUD is inserted with headers, avoid insertion again for smaller bitstream.
+        if (sequenceControlSetPtr->staticConfig.accessUnitDelimiter && pictureControlSetPtr->pictureNumber > 0
+                && !toInsertHeaders)
         {
             EncodeAUD(
                 pictureControlSetPtr->bitstreamPtr,

--- a/Source/Lib/Codec/EbPacketizationProcess.c
+++ b/Source/Lib/Codec/EbPacketizationProcess.c
@@ -569,7 +569,7 @@ void* PacketizationKernel(void *inputPtr)
         // Encode slice header and write it into the bitstream.
         packetizationQp = pictureControlSetPtr->pictureQp;
      
-        if(sequenceControlSetPtr->staticConfig.accessUnitDelimiter && (pictureControlSetPtr->pictureNumber > 0)) 
+        if (sequenceControlSetPtr->staticConfig.accessUnitDelimiter && !(sequenceControlSetPtr->staticConfig.codeVpsSpsPps && toInsertHeaders))
         {
             EncodeAUD(
                 pictureControlSetPtr->bitstreamPtr,


### PR DESCRIPTION
The first AUD is inserted here:
```c
        if (sequenceControlSetPtr->staticConfig.codeVpsSpsPps && toInsertHeaders) {
            // Reset the bitstream before writing to it
            ResetBitstream(
                pictureControlSetPtr->bitstreamPtr->outputBitstreamPtr);

            if (sequenceControlSetPtr->staticConfig.accessUnitDelimiter) {

                EncodeAUD(
                    pictureControlSetPtr->bitstreamPtr,
                    pictureControlSetPtr->sliceType,
                    pictureControlSetPtr->temporalId);
            }
```
So the second AUD now checks if the first one was not inserted.