### PR TITLE
Fix pAppPrivate not propagating to the output.

### DIFF
--- a/Source/Lib/Codec/EbEncHandle.c
+++ b/Source/Lib/Codec/EbEncHandle.c
@@ -3971,14 +3971,15 @@ static EB_ERRORTYPE  CopyInputBuffer(
     EB_ERRORTYPE return_error = EB_ErrorNone;
 
     // Copy the higher level structure
-    dst->nAllocLen  = src->nAllocLen;
-    dst->nFilledLen = src->nFilledLen;
-    dst->nFlags     = src->nFlags;
-    dst->pts        = src->pts;
-    dst->nTickCount = src->nTickCount;
-    dst->nSize      = src->nSize;
-    dst->qpValue    = src->qpValue;
-    dst->sliceType  = src->sliceType;
+    dst->nAllocLen   = src->nAllocLen;
+    dst->nFilledLen  = src->nFilledLen;
+    dst->pAppPrivate = src->pAppPrivate;
+    dst->nFlags      = src->nFlags;
+    dst->pts         = src->pts;
+    dst->nTickCount  = src->nTickCount;
+    dst->nSize       = src->nSize;
+    dst->qpValue     = src->qpValue;
+    dst->sliceType   = src->sliceType;
 
     // Copy the picture buffer
     if(src->pBuffer != NULL)


### PR DESCRIPTION
There's a comment in [gstsvthevcenc.c](https://github.com/OpenVisualCloud/SVT-HEVC/blob/1ec6f6d6b9fbbd4f0a2d1e36a493dba12d7dfbae/gstreamer-plugin/gstsvthevcenc.c#L993-L997) that should be checked with this fix (I didn't test GStreamer):
```c
      /* if pAppPrivate is indeed propagated, get the frame through it
       * it's not currently the case with SVT-HEVC 1.3.0
       * so we fallback on using its PTS to find it back */
      if (output_buf->pAppPrivate) {
        frame = (GstVideoCodecFrame *) output_buf->pAppPrivate;
      } else {
```