### PR TITLE
Fixed the core dump issue with only 1 frame input.

### DIFF
--- a/Source/Lib/Codec/EbEncHandle.c
+++ b/Source/Lib/Codec/EbEncHandle.c
@@ -1970,7 +1970,6 @@ EB_API EB_ERRORTYPE EbDeinitEncoder(EB_COMPONENTTYPE *h265EncComponent)
                 switch (memoryEntry->ptrType) {
                 case EB_N_PTR:
                     free(memoryEntry->ptr);
-                    //memoryEntry->ptr = EB_NULL;
                     break;
                 case EB_A_PTR:
 #ifdef _WIN32


### PR DESCRIPTION
(When receiving only 1 frame input, )SvtHevcEncApp or any application
may invokes EbDeinitEncoder() ahead of all the kernel threads complete
processing. And EbDeinitEncoder() would free all the recorded memory
objects which may be still used by some threads, so that race condition
happens.

So fixed (worked around) this issue by terminating the kernel threads
before freeing memories. Ideally, there should be some object reference
and unreference mechanism to make the objects access safe.

Note:
  1. EbObjectIncLiveCount() couldn't be helpful to address such race
     condition, because it just avoids that an EbObjectWrapper_t object
     wouldn't be returned back to an empty queue prematurely;
  2. EB_SEND_END_OBJ() plus EB_CHECK_END_OBJ() (induced in PR #270) could
     not avoid such race condition, either. Because the objects can be
     freed at any moment when a kernel thread is running and needs to
     access to it.

Signed-off-by: Austin Hu <austin.hu@intel.com>

Fixes #413  .