### PR TITLE
Removed the redundant LcuParamsCtor() calling.

### DIFF
--- a/Source/Lib/Codec/EbSequenceControlSet.c
+++ b/Source/Lib/Codec/EbSequenceControlSet.c
@@ -167,10 +167,6 @@ EB_ERRORTYPE EbSequenceControlSetCtor(
     EbUnRegUserDataSEICtor(
         &sequenceControlSetPtr->unRegUserDataSeiPtr);
 
-    // Initialize LCU params
-    LcuParamsCtor(
-        sequenceControlSetPtr);
-
     sequenceControlSetPtr->maxDpbSize	= 0;
     
     return EB_ErrorNone;
@@ -230,17 +226,6 @@ EB_ERRORTYPE EbSequenceControlSetInstanceCtor(
         
     return EB_ErrorNone;
 }    
-       
-
-extern EB_ERRORTYPE LcuParamsCtor(
-	SequenceControlSet_t *sequenceControlSetPtr) {
-
-	EB_ERRORTYPE return_error = EB_ErrorNone;
-
-	EB_MALLOC(LcuParams_t*, sequenceControlSetPtr->lcuParamsArray, sizeof(LcuParams_t) * ((MAX_PICTURE_WIDTH_SIZE + sequenceControlSetPtr->lcuSize - 1) / sequenceControlSetPtr->lcuSize) * ((MAX_PICTURE_HEIGHT_SIZE + sequenceControlSetPtr->lcuSize - 1) / sequenceControlSetPtr->lcuSize), EB_N_PTR);
-	return return_error;
-}
-
 
 extern EB_ERRORTYPE LcuParamsInit(
 	SequenceControlSet_t *sequenceControlSetPtr) {

--- a/Source/Lib/Codec/EbSequenceControlSet.h
+++ b/Source/Lib/Codec/EbSequenceControlSet.h
@@ -230,11 +230,6 @@ extern EB_ERRORTYPE CopySequenceControlSet(
         
 extern EB_ERRORTYPE EbSequenceControlSetInstanceCtor(
     EbSequenceControlSetInstance_t **objectDblPtr);
-    
-
-
-extern EB_ERRORTYPE LcuParamsCtor(
-    SequenceControlSet_t *sequenceControlSetPtr);
 
 extern EB_ERRORTYPE LcuParamsInit(
     SequenceControlSet_t *sequenceControlSetPtr);


### PR DESCRIPTION
Because the lcuParamsArray of an SCS object will be allocated through
ResourceCoordinationKernel()->LcuParamsInit() later. With it removed,
about 4.5MB memory ((EB_SequenceControlSetPoolInitCount + 1) *
sizeof(LcuParams_t) * 146 * 80) can be saved.

Signed-off-by: Austin Hu <austin.hu@intel.com>

Fixes #416 .