### PR TITLE
Decimal value of level

### DIFF
--- a/Source/Lib/Codec/EbEncHandle.c
+++ b/Source/Lib/Codec/EbEncHandle.c
@@ -3360,7 +3360,7 @@ static void PrintLibParams(
         SVT_LOG("\nSVT [config]: MainEXT Profile\t");
 
     if (config->tier != 0 && config->level !=0)
-        SVT_LOG("Tier %d\tLevel %.1f\t", config->tier, (float)(config->level / 10));
+        SVT_LOG("Tier %d\tLevel %.1f\t", config->tier, (float)(config->level) / 10);
     else {
         if (config->tier == 0 )
             SVT_LOG("Tier (auto)\t");
@@ -3370,7 +3370,7 @@ static void PrintLibParams(
         if (config->level == 0 )
             SVT_LOG("Level (auto)\t");
         else
-            SVT_LOG("Level %.1f\t", (float)(config->level / 10));
+            SVT_LOG("Level %.1f\t", (float)(config->level) / 10);
 
 
     }


### PR DESCRIPTION
Changed the log for the level value so that the decimal value
(e.g. 6.2 vs 6.0) is correctly shown.  Float cast is now
done on the pre-decimated value rather than the
post-decimated value where the decimal value was
already lost.

Signed-off-by: Mark Feldman <mark.feldman@intel.com>