### PR TITLE
Unbreak build on FreeBSD

### DIFF
--- a/Source/Lib/Codec/EbEncHandle.c
+++ b/Source/Lib/Codec/EbEncHandle.c
@@ -135,7 +135,7 @@ typedef void(*constraint_handler_t) (const char * /* msg */,
 
 static constraint_handler_t str_handler = NULL;
 
-static void ignore_handler_s(const char *msg, void *ptr, errno_t error)
+static void eb_ignore_handler_s(const char *msg, void *ptr, errno_t error)
 {
     (void)msg;
     (void)ptr;
@@ -154,7 +154,7 @@ invoke_safe_str_constraint_handler(const char *msg,
        str_handler(msg, ptr, error);
     }
     else {
-        ignore_handler_s(msg, ptr, error);
+        eb_ignore_handler_s(msg, ptr, error);
     }
 }
 


### PR DESCRIPTION
https://github.com/freebsd/freebsd/commit/4774ca6be082 and https://github.com/dragonflybsd/dragonflybsd/commit/086b156cdf18 declare `ignore_handler_s` in `<stdlib.h>` but SVT-HEVC includes it in the same file where a `static` copy is defined, causing a conflict. See [error log](https://github.com/OpenVisualCloud/SVT-HEVC/files/3832441/svt-hevc-1.4.1.34.log).
https://github.com/OpenVisualCloud/SVT-HEVC/blob/8382e4fd31c676c673920e476f329d59f9ee2f33/Source/Lib/Codec/EbEncHandle.c#L13
https://github.com/OpenVisualCloud/SVT-HEVC/blob/8382e4fd31c676c673920e476f329d59f9ee2f33/Source/Lib/Codec/EbEncHandle.c#L138-L146

Other BSD fixes are in #135.
