### PR TITLE
Fixed the IDR insertion failure regression.

### DIFF
--- a/Source/Lib/Codec/EbPictureDecisionProcess.c
+++ b/Source/Lib/Codec/EbPictureDecisionProcess.c
@@ -738,9 +738,6 @@ void* PictureDecisionKernel(void *inputPtr)
            ReleasePrevPictureFromReorderQueue(
                encodeContextPtr);
 
-            pictureControlSetPtr->craFlag = EB_FALSE;
-            pictureControlSetPtr->idrFlag = EB_FALSE;
-
             // If the Intra period length is 0, then introduce an intra for every picture
             if ((sequenceControlSetPtr->intraPeriodLength == 0) || (pictureControlSetPtr->pictureNumber == 0)) {
                 if (sequenceControlSetPtr->intraRefreshType == CRA_REFRESH)


### PR DESCRIPTION
The regression was caused by PR #250. So fixed it by rolling back to
the original logic to set IDR (and CRA) flag.

Signed-off-by: Austin Hu <austin.hu@intel.com>

Fixes #423 .