### PR TITLE
Fixed the memory map management issue with multi-instance.

### DIFF
--- a/Source/Lib/Codec/EbBitstreamUnit.c
+++ b/Source/Lib/Codec/EbBitstreamUnit.c
@@ -13,14 +13,15 @@
  **********************************/
 EB_ERRORTYPE OutputBitstreamUnitCtor(
     OutputBitstreamUnit_t   *bitstreamPtr,
-    EB_U32                   bufferSize )
+    EB_U32                   bufferSize,
+    EB_PTR                   encHandle)
 {
 
     EB_U32       sliceIndex;
 
     if(bufferSize) {
         bitstreamPtr->size             = bufferSize / sizeof(unsigned int);
-        EB_MALLOC(EB_U32*, bitstreamPtr->bufferBegin, sizeof(EB_U32) * bitstreamPtr->size, EB_N_PTR);
+        EB_MALLOC(EB_U32*, bitstreamPtr->bufferBegin, sizeof(EB_U32) * bitstreamPtr->size, EB_N_PTR, encHandle);
         bitstreamPtr->buffer           = bitstreamPtr->bufferBegin;
     }
     else {

--- a/Source/Lib/Codec/EbBitstreamUnit.h
+++ b/Source/Lib/Codec/EbBitstreamUnit.h
@@ -36,7 +36,8 @@ typedef struct OutputBitstreamUnit_s {
  **********************************/
 extern EB_ERRORTYPE OutputBitstreamUnitCtor(
     OutputBitstreamUnit_t   *bitstreamPtr,
-    EB_U32                   bufferSize );
+    EB_U32                   bufferSize,
+    EB_PTR                   encHandle);
 
 
 extern EB_ERRORTYPE OutputBitstreamReset(OutputBitstreamUnit_t *bitstreamPtr);

--- a/Source/Lib/Codec/EbCodingUnit.c
+++ b/Source/Lib/Codec/EbCodingUnit.c
@@ -27,7 +27,8 @@ EB_ERRORTYPE LargestCodingUnitCtor(
     EB_U16                       lcuOriginX,
     EB_U16                       lcuOriginY,
     EB_U16                       lcuIndex,
-    struct PictureControlSet_s  *pictureControlSet)
+    struct PictureControlSet_s  *pictureControlSet,
+    EB_HANDLE                    encHandle)
 
 {
     EB_ERRORTYPE return_error = EB_ErrorNone;
@@ -37,7 +38,7 @@ EB_ERRORTYPE LargestCodingUnitCtor(
     EbPictureBufferDescInitData_t coeffInitData;
     
     LargestCodingUnit_t *largestCodingUnitPtr;
-    EB_MALLOC(LargestCodingUnit_t*, largestCodingUnitPtr, sizeof(LargestCodingUnit_t), EB_N_PTR);
+    EB_MALLOC(LargestCodingUnit_t*, largestCodingUnitPtr, sizeof(LargestCodingUnit_t), EB_N_PTR, encHandle);
 
     *largetCodingUnitDblPtr = largestCodingUnitPtr;
     
@@ -65,9 +66,9 @@ EB_ERRORTYPE LargestCodingUnitCtor(
     
     largestCodingUnitPtr->index                         = lcuIndex; 
 
-    EB_MALLOC(CodingUnit_t**, largestCodingUnitPtr->codedLeafArrayPtr, sizeof(CodingUnit_t*) * CU_MAX_COUNT, EB_N_PTR);
+    EB_MALLOC(CodingUnit_t**, largestCodingUnitPtr->codedLeafArrayPtr, sizeof(CodingUnit_t*) * CU_MAX_COUNT, EB_N_PTR, encHandle);
     for(codedLeafIndex=0; codedLeafIndex < CU_MAX_COUNT; ++codedLeafIndex) {
-        EB_MALLOC(CodingUnit_t*, largestCodingUnitPtr->codedLeafArrayPtr[codedLeafIndex], sizeof(CodingUnit_t) , EB_N_PTR);
+        EB_MALLOC(CodingUnit_t*, largestCodingUnitPtr->codedLeafArrayPtr[codedLeafIndex], sizeof(CodingUnit_t) , EB_N_PTR, encHandle);
         for(tuIndex = 0; tuIndex < TRANSFORM_UNIT_MAX_COUNT; ++tuIndex){
             largestCodingUnitPtr->codedLeafArrayPtr[codedLeafIndex]->transformUnitArray[tuIndex].tuIndex = tuIndex;
         }
@@ -90,7 +91,8 @@ EB_ERRORTYPE LargestCodingUnitCtor(
 
     return_error = EbPictureBufferDescCtor(
         (EB_PTR*) &(largestCodingUnitPtr->quantizedCoeff),
-        (EB_PTR)  &coeffInitData);
+        (EB_PTR)  &coeffInitData,
+        encHandle);
 	if (return_error == EB_ErrorInsufficientResources){
         return EB_ErrorInsufficientResources;
     }

--- a/Source/Lib/Codec/EbCodingUnit.h
+++ b/Source/Lib/Codec/EbCodingUnit.h
@@ -233,7 +233,8 @@ extern EB_ERRORTYPE LargestCodingUnitCtor(
     EB_U16                       lcuOriginX,
     EB_U16                       lcuOriginY,
     EB_U16                       lcuIndex,
-    struct PictureControlSet_s  *pictureControlSet);
+    struct PictureControlSet_s  *pictureControlSet,
+    EB_HANDLE                    encHandle);
 
 #ifdef __cplusplus
 }

--- a/Source/Lib/Codec/EbEncDecProcess.h
+++ b/Source/Lib/Codec/EbEncDecProcess.h
@@ -161,7 +161,8 @@ extern EB_ERRORTYPE EncDecContextCtor(
     EbFifo_t                *feedbackFifoPtr,
     EbFifo_t                *pictureDemuxFifoPtr,
     EB_BOOL                  is16bit,
-    EB_COLOR_FORMAT          colorFormat);
+    EB_COLOR_FORMAT          colorFormat,
+    EB_HANDLE                encHandle);
 
 
     

--- a/Source/Lib/Codec/EbEncDecResults.c
+++ b/Source/Lib/Codec/EbEncDecResults.c
@@ -9,10 +9,11 @@
 
 EB_ERRORTYPE EncDecResultsCtor(
     EB_PTR *objectDblPtr,
-    EB_PTR objectInitDataPtr)
+    EB_PTR objectInitDataPtr,
+    EB_HANDLE encHandle)
 {
     EncDecResults_t *contextPtr;
-    EB_MALLOC(EncDecResults_t*, contextPtr, sizeof(EncDecResults_t), EB_N_PTR);
+    EB_MALLOC(EncDecResults_t*, contextPtr, sizeof(EncDecResults_t), EB_N_PTR, encHandle);
     
     *objectDblPtr = (EB_PTR) contextPtr;
 

--- a/Source/Lib/Codec/EbEncDecResults.h
+++ b/Source/Lib/Codec/EbEncDecResults.h
@@ -33,7 +33,8 @@ typedef struct EncDecResultsInitData_s
  **************************************/
 extern EB_ERRORTYPE EncDecResultsCtor(
     EB_PTR *objectDblPtr, 
-    EB_PTR objectInitDataPtr);
+    EB_PTR objectInitDataPtr,
+    EB_HANDLE encHandle);
 
 
 #ifdef __cplusplus

--- a/Source/Lib/Codec/EbEncDecSegments.c
+++ b/Source/Lib/Codec/EbEncDecSegments.c
@@ -13,11 +13,12 @@
 EB_ERRORTYPE EncDecSegmentsCtor(
     EncDecSegments_t **segmentsDblPtr,
     EB_U32             segmentColCount,
-    EB_U32             segmentRowCount)
+    EB_U32             segmentRowCount,
+    EB_HANDLE          encHandle)
 {
     EB_U32 rowIndex;
     EncDecSegments_t *segmentsPtr;
-    EB_MALLOC(EncDecSegments_t*, segmentsPtr, sizeof(EncDecSegments_t), EB_N_PTR);
+    EB_MALLOC(EncDecSegments_t*, segmentsPtr, sizeof(EncDecSegments_t), EB_N_PTR, encHandle);
     
     *segmentsDblPtr = segmentsPtr;
 
@@ -26,22 +27,22 @@ EB_ERRORTYPE EncDecSegmentsCtor(
     segmentsPtr->segmentMaxTotalCount = segmentsPtr->segmentMaxRowCount * segmentsPtr->segmentMaxBandCount;
 
     // Start Arrays
-    EB_MALLOC(EB_U16*, segmentsPtr->xStartArray, sizeof(EB_U16) * segmentsPtr->segmentMaxTotalCount, EB_N_PTR);
+    EB_MALLOC(EB_U16*, segmentsPtr->xStartArray, sizeof(EB_U16) * segmentsPtr->segmentMaxTotalCount, EB_N_PTR, encHandle);
 
-    EB_MALLOC(EB_U16*, segmentsPtr->yStartArray, sizeof(EB_U16) * segmentsPtr->segmentMaxTotalCount, EB_N_PTR);
+    EB_MALLOC(EB_U16*, segmentsPtr->yStartArray, sizeof(EB_U16) * segmentsPtr->segmentMaxTotalCount, EB_N_PTR, encHandle);
     
-    EB_MALLOC(EB_U16*, segmentsPtr->validLcuCountArray, sizeof(EB_U16) * segmentsPtr->segmentMaxTotalCount, EB_N_PTR);
+    EB_MALLOC(EB_U16*, segmentsPtr->validLcuCountArray, sizeof(EB_U16) * segmentsPtr->segmentMaxTotalCount, EB_N_PTR, encHandle);
     
     // Dependency map
-    EB_MALLOC(EB_U8*, segmentsPtr->depMap.dependencyMap, sizeof(EB_U8) * segmentsPtr->segmentMaxTotalCount, EB_N_PTR);
+    EB_MALLOC(EB_U8*, segmentsPtr->depMap.dependencyMap, sizeof(EB_U8) * segmentsPtr->segmentMaxTotalCount, EB_N_PTR, encHandle);
     
-    EB_CREATEMUTEX(EB_HANDLE, segmentsPtr->depMap.updateMutex, sizeof(EB_HANDLE), EB_MUTEX);
+    EB_CREATEMUTEX(EB_HANDLE, segmentsPtr->depMap.updateMutex, sizeof(EB_HANDLE), EB_MUTEX, encHandle);
     
     // Segment rows
-    EB_MALLOC(EncDecSegSegmentRow_t*, segmentsPtr->rowArray, sizeof(EncDecSegSegmentRow_t) * segmentsPtr->segmentMaxRowCount, EB_N_PTR)
+    EB_MALLOC(EncDecSegSegmentRow_t*, segmentsPtr->rowArray, sizeof(EncDecSegSegmentRow_t) * segmentsPtr->segmentMaxRowCount, EB_N_PTR, encHandle);
     
     for(rowIndex=0; rowIndex < segmentsPtr->segmentMaxRowCount; ++rowIndex) {
-        EB_CREATEMUTEX(EB_HANDLE, segmentsPtr->rowArray[rowIndex].assignmentMutex, sizeof(EB_HANDLE), EB_MUTEX);
+        EB_CREATEMUTEX(EB_HANDLE, segmentsPtr->rowArray[rowIndex].assignmentMutex, sizeof(EB_HANDLE), EB_MUTEX, encHandle);
     }
 
     return EB_ErrorNone;

--- a/Source/Lib/Codec/EbEncDecSegments.h
+++ b/Source/Lib/Codec/EbEncDecSegments.h
@@ -77,7 +77,8 @@ typedef struct
 extern EB_ERRORTYPE EncDecSegmentsCtor(
     EncDecSegments_t **segmentsDblPtr,
     EB_U32             segmentColCount,
-    EB_U32             segmentRowCount);
+    EB_U32             segmentRowCount,
+    EB_HANDLE          encHandle);
 
 
 extern void EncDecSegmentsInit(

--- a/Source/Lib/Codec/EbEncDecTasks.c
+++ b/Source/Lib/Codec/EbEncDecTasks.c
@@ -10,10 +10,11 @@
 
 EB_ERRORTYPE EncDecTasksCtor(
     EB_PTR *objectDblPtr,
-    EB_PTR objectInitDataPtr)
+    EB_PTR objectInitDataPtr,
+    EB_HANDLE encHandle)
 {
     EncDecTasks_t *contextPtr;
-    EB_MALLOC(EncDecTasks_t*, contextPtr, sizeof(EncDecTasks_t), EB_N_PTR);
+    EB_MALLOC(EncDecTasks_t*, contextPtr, sizeof(EncDecTasks_t), EB_N_PTR, encHandle);
     
     *objectDblPtr = (EB_PTR) contextPtr;
 

--- a/Source/Lib/Codec/EbEncDecTasks.h
+++ b/Source/Lib/Codec/EbEncDecTasks.h
@@ -37,7 +37,8 @@ typedef struct EncDecTasksInitData_s
  **************************************/
 extern EB_ERRORTYPE EncDecTasksCtor(
     EB_PTR *objectDblPtr, 
-    EB_PTR objectInitDataPtr);
+    EB_PTR objectInitDataPtr,
+    EB_HANDLE encHandle);
 
 
 #ifdef __cplusplus

--- a/Source/Lib/Codec/EbEncHandle.h
+++ b/Source/Lib/Codec/EbEncHandle.h
@@ -153,9 +153,6 @@ typedef struct EbEncHandle_s
     // *Note - Recon Video buffers will have distortion data appended to 
     // the end of the buffer.  This distortion data aids in the calculation
     // of PSNR.
-    // Memory Map
-    EbMemoryMapEntry                       *memoryMap; 
-    EB_U32                                  memoryMapIndex;
     EB_U64                                  totalLibMemory;
 
 } EbEncHandle_t;
@@ -165,15 +162,18 @@ typedef struct EbEncHandle_s
  **************************************/  
 extern EB_ERRORTYPE EbInputBufferHeaderCtor(
     EB_PTR *objectDblPtr, 
-    EB_PTR objectInitDataPtr);
+    EB_PTR objectInitDataPtr,
+    EB_HANDLE encHandle);
 
 extern EB_ERRORTYPE EbOutputBufferHeaderCtor(
     EB_PTR *objectDblPtr,
-    EB_PTR objectInitDataPtr);
+    EB_PTR objectInitDataPtr,
+    EB_HANDLE encHandle);
 
 extern EB_ERRORTYPE EbOutputReconBufferHeaderCtor(
     EB_PTR *objectDblPtr,
-    EB_PTR objectInitDataPtr);
+    EB_PTR objectInitDataPtr,
+    EB_HANDLE encHandle);
 
 #ifdef __cplusplus
 }

--- a/Source/Lib/Codec/EbEncodeContext.c
+++ b/Source/Lib/Codec/EbEncodeContext.c
@@ -14,13 +14,14 @@
 
 EB_ERRORTYPE EncodeContextCtor(
     EB_PTR *objectDblPtr, 
-    EB_PTR objectInitDataPtr)
+    EB_PTR objectInitDataPtr,
+    EB_HANDLE encHandle)
 {
     EB_U32 pictureIndex;
     EB_ERRORTYPE return_error = EB_ErrorNone;
     
     EncodeContext_t *encodeContextPtr;
-    EB_MALLOC(EncodeContext_t*, encodeContextPtr, sizeof(EncodeContext_t), EB_N_PTR);
+    EB_MALLOC(EncodeContext_t*, encodeContextPtr, sizeof(EncodeContext_t), EB_N_PTR, encHandle);
     *objectDblPtr = (EB_PTR) encodeContextPtr;
     
     objectInitDataPtr = 0;
@@ -33,7 +34,7 @@ EB_ERRORTYPE EncodeContextCtor(
     encodeContextPtr->appCallbackPtr                                    = (EbCallback_t*) EB_NULL;
     
     // Port Active State
-    EB_CREATEMUTEX(EB_HANDLE, encodeContextPtr->terminatingConditionsMutex, sizeof(EB_HANDLE), EB_MUTEX);
+    EB_CREATEMUTEX(EB_HANDLE, encodeContextPtr->terminatingConditionsMutex, sizeof(EB_HANDLE), EB_MUTEX, encHandle);
 
     encodeContextPtr->totalNumberOfReconFrames                          = 0;
 	
@@ -48,12 +49,13 @@ EB_ERRORTYPE EncodeContextCtor(
     
     // Picture Decision Reordering Queue
     encodeContextPtr->pictureDecisionReorderQueueHeadIndex                 = 0;
-    EB_MALLOC(PictureDecisionReorderEntry_t**, encodeContextPtr->pictureDecisionReorderQueue, sizeof(PictureDecisionReorderEntry_t*) * PICTURE_DECISION_REORDER_QUEUE_MAX_DEPTH, EB_N_PTR);
+    EB_MALLOC(PictureDecisionReorderEntry_t**, encodeContextPtr->pictureDecisionReorderQueue, sizeof(PictureDecisionReorderEntry_t*) * PICTURE_DECISION_REORDER_QUEUE_MAX_DEPTH, EB_N_PTR, encHandle);
         
     for(pictureIndex=0; pictureIndex < PICTURE_DECISION_REORDER_QUEUE_MAX_DEPTH; ++pictureIndex) {
 		return_error = PictureDecisionReorderEntryCtor(
             &(encodeContextPtr->pictureDecisionReorderQueue[pictureIndex]),
-            pictureIndex);
+            pictureIndex,
+            encHandle);
         if (return_error == EB_ErrorInsufficientResources){
             return EB_ErrorInsufficientResources;
         }
@@ -61,12 +63,13 @@ EB_ERRORTYPE EncodeContextCtor(
     
 	// Picture Manager Reordering Queue
 	encodeContextPtr->pictureManagerReorderQueueHeadIndex = 0;
-	EB_MALLOC(PictureManagerReorderEntry_t**, encodeContextPtr->pictureManagerReorderQueue, sizeof(PictureManagerReorderEntry_t*) * PICTURE_MANAGER_REORDER_QUEUE_MAX_DEPTH, EB_N_PTR);
+	EB_MALLOC(PictureManagerReorderEntry_t**, encodeContextPtr->pictureManagerReorderQueue, sizeof(PictureManagerReorderEntry_t*) * PICTURE_MANAGER_REORDER_QUEUE_MAX_DEPTH, EB_N_PTR, encHandle);
 
 	for (pictureIndex = 0; pictureIndex < PICTURE_MANAGER_REORDER_QUEUE_MAX_DEPTH; ++pictureIndex) {
 		return_error = PictureManagerReorderEntryCtor(
 			&(encodeContextPtr->pictureManagerReorderQueue[pictureIndex]),
-			pictureIndex);
+			pictureIndex,
+            encHandle);
 		if (return_error == EB_ErrorInsufficientResources){
 			return EB_ErrorInsufficientResources;
 		}
@@ -84,7 +87,7 @@ EB_ERRORTYPE EncodeContextCtor(
     encodeContextPtr->preAssignmentBufferCount                          = 0;
     encodeContextPtr->numberOfActivePictures                            = 0;
 
-    EB_MALLOC(EbObjectWrapper_t**, encodeContextPtr->preAssignmentBuffer, sizeof(EbObjectWrapper_t*) * PRE_ASSIGNMENT_MAX_DEPTH, EB_N_PTR);
+    EB_MALLOC(EbObjectWrapper_t**, encodeContextPtr->preAssignmentBuffer, sizeof(EbObjectWrapper_t*) * PRE_ASSIGNMENT_MAX_DEPTH, EB_N_PTR, encHandle);
     
     for(pictureIndex=0; pictureIndex < PRE_ASSIGNMENT_MAX_DEPTH; ++pictureIndex) {
         encodeContextPtr->preAssignmentBuffer[pictureIndex] = (EbObjectWrapper_t*) EB_NULL;
@@ -93,11 +96,12 @@ EB_ERRORTYPE EncodeContextCtor(
     // Picture Manager Input Queue
     encodeContextPtr->inputPictureQueueHeadIndex                        = 0;
     encodeContextPtr->inputPictureQueueTailIndex                        = 0;
-    EB_MALLOC(InputQueueEntry_t**, encodeContextPtr->inputPictureQueue, sizeof(InputQueueEntry_t*) * INPUT_QUEUE_MAX_DEPTH, EB_N_PTR);
+    EB_MALLOC(InputQueueEntry_t**, encodeContextPtr->inputPictureQueue, sizeof(InputQueueEntry_t*) * INPUT_QUEUE_MAX_DEPTH, EB_N_PTR, encHandle);
 
     for(pictureIndex=0; pictureIndex < INPUT_QUEUE_MAX_DEPTH; ++pictureIndex) {
         return_error = InputQueueEntryCtor(
-            &(encodeContextPtr->inputPictureQueue[pictureIndex]));
+            &(encodeContextPtr->inputPictureQueue[pictureIndex]),
+            encHandle);
         if (return_error == EB_ErrorInsufficientResources){
             return EB_ErrorInsufficientResources;
         }
@@ -106,11 +110,12 @@ EB_ERRORTYPE EncodeContextCtor(
     // Picture Manager Reference Queue
     encodeContextPtr->referencePictureQueueHeadIndex                    = 0;
     encodeContextPtr->referencePictureQueueTailIndex                    = 0;
-    EB_MALLOC(ReferenceQueueEntry_t**, encodeContextPtr->referencePictureQueue, sizeof(ReferenceQueueEntry_t*) * REFERENCE_QUEUE_MAX_DEPTH, EB_N_PTR);
+    EB_MALLOC(ReferenceQueueEntry_t**, encodeContextPtr->referencePictureQueue, sizeof(ReferenceQueueEntry_t*) * REFERENCE_QUEUE_MAX_DEPTH, EB_N_PTR, encHandle);
     
     for(pictureIndex=0; pictureIndex < REFERENCE_QUEUE_MAX_DEPTH; ++pictureIndex) {
         return_error = ReferenceQueueEntryCtor(
-            &(encodeContextPtr->referencePictureQueue[pictureIndex]));
+            &(encodeContextPtr->referencePictureQueue[pictureIndex]),
+            encHandle);
         if (return_error == EB_ErrorInsufficientResources){
             return EB_ErrorInsufficientResources;
         }
@@ -119,11 +124,12 @@ EB_ERRORTYPE EncodeContextCtor(
     // Picture Decision PA Reference Queue
     encodeContextPtr->pictureDecisionPaReferenceQueueHeadIndex                     = 0;
     encodeContextPtr->pictureDecisionPaReferenceQueueTailIndex                     = 0;
-    EB_MALLOC(PaReferenceQueueEntry_t**, encodeContextPtr->pictureDecisionPaReferenceQueue, sizeof(PaReferenceQueueEntry_t*) * PICTURE_DECISION_PA_REFERENCE_QUEUE_MAX_DEPTH, EB_N_PTR);
+    EB_MALLOC(PaReferenceQueueEntry_t**, encodeContextPtr->pictureDecisionPaReferenceQueue, sizeof(PaReferenceQueueEntry_t*) * PICTURE_DECISION_PA_REFERENCE_QUEUE_MAX_DEPTH, EB_N_PTR, encHandle);
 
     for(pictureIndex=0; pictureIndex < PICTURE_DECISION_PA_REFERENCE_QUEUE_MAX_DEPTH; ++pictureIndex) {
 		return_error = PaReferenceQueueEntryCtor(
-            &(encodeContextPtr->pictureDecisionPaReferenceQueue[pictureIndex]));
+            &(encodeContextPtr->pictureDecisionPaReferenceQueue[pictureIndex]),
+            encHandle);
         if (return_error == EB_ErrorInsufficientResources){
             return EB_ErrorInsufficientResources;
         }
@@ -131,12 +137,13 @@ EB_ERRORTYPE EncodeContextCtor(
     
     // Initial Rate Control Reordering Queue
     encodeContextPtr->initialRateControlReorderQueueHeadIndex                 = 0;
-    EB_MALLOC(InitialRateControlReorderEntry_t**, encodeContextPtr->initialRateControlReorderQueue, sizeof(InitialRateControlReorderEntry_t*) * INITIAL_RATE_CONTROL_REORDER_QUEUE_MAX_DEPTH, EB_N_PTR);
+    EB_MALLOC(InitialRateControlReorderEntry_t**, encodeContextPtr->initialRateControlReorderQueue, sizeof(InitialRateControlReorderEntry_t*) * INITIAL_RATE_CONTROL_REORDER_QUEUE_MAX_DEPTH, EB_N_PTR, encHandle);
 
 	for(pictureIndex=0; pictureIndex < INITIAL_RATE_CONTROL_REORDER_QUEUE_MAX_DEPTH; ++pictureIndex) {
         return_error = InitialRateControlReorderEntryCtor(
             &(encodeContextPtr->initialRateControlReorderQueue[pictureIndex]),
-            pictureIndex);
+            pictureIndex,
+            encHandle);
         if (return_error == EB_ErrorInsufficientResources){
             return EB_ErrorInsufficientResources;
         }
@@ -145,27 +152,29 @@ EB_ERRORTYPE EncodeContextCtor(
     // High level Rate Control histogram Queue
     encodeContextPtr->hlRateControlHistorgramQueueHeadIndex                 = 0;
     
-    EB_CALLOC(HlRateControlHistogramEntry_t**, encodeContextPtr->hlRateControlHistorgramQueue, sizeof(HlRateControlHistogramEntry_t*) * HIGH_LEVEL_RATE_CONTROL_HISTOGRAM_QUEUE_MAX_DEPTH, 1, EB_N_PTR);
+    EB_CALLOC(HlRateControlHistogramEntry_t**, encodeContextPtr->hlRateControlHistorgramQueue, sizeof(HlRateControlHistogramEntry_t*) * HIGH_LEVEL_RATE_CONTROL_HISTOGRAM_QUEUE_MAX_DEPTH, 1, EB_N_PTR, encHandle);
 
     for(pictureIndex=0; pictureIndex < HIGH_LEVEL_RATE_CONTROL_HISTOGRAM_QUEUE_MAX_DEPTH; ++pictureIndex) {
         return_error = HlRateControlHistogramEntryCtor(
             &(encodeContextPtr->hlRateControlHistorgramQueue[pictureIndex]),
-            pictureIndex);
+            pictureIndex,
+            encHandle);
         if (return_error == EB_ErrorInsufficientResources){
             return EB_ErrorInsufficientResources;
         }
     }
     // HLRateControl Historgram Queue Mutex
-    EB_CREATEMUTEX(EB_HANDLE, encodeContextPtr->hlRateControlHistorgramQueueMutex, sizeof(EB_HANDLE), EB_MUTEX);
+    EB_CREATEMUTEX(EB_HANDLE, encodeContextPtr->hlRateControlHistorgramQueueMutex, sizeof(EB_HANDLE), EB_MUTEX, encHandle);
 
     // Packetization Reordering Queue
     encodeContextPtr->packetizationReorderQueueHeadIndex                 = 0;
-    EB_MALLOC(PacketizationReorderEntry_t**, encodeContextPtr->packetizationReorderQueue, sizeof(PacketizationReorderEntry_t*) * PACKETIZATION_REORDER_QUEUE_MAX_DEPTH, EB_N_PTR);
+    EB_MALLOC(PacketizationReorderEntry_t**, encodeContextPtr->packetizationReorderQueue, sizeof(PacketizationReorderEntry_t*) * PACKETIZATION_REORDER_QUEUE_MAX_DEPTH, EB_N_PTR, encHandle);
     
     for(pictureIndex=0; pictureIndex < PACKETIZATION_REORDER_QUEUE_MAX_DEPTH; ++pictureIndex) {
         return_error = PacketizationReorderEntryCtor(
             &(encodeContextPtr->packetizationReorderQueue[pictureIndex]),
-            pictureIndex);
+            pictureIndex,
+            encHandle);
         if (return_error == EB_ErrorInsufficientResources){
             return EB_ErrorInsufficientResources;
         }
@@ -187,7 +196,7 @@ EB_ERRORTYPE EncodeContextCtor(
     encodeContextPtr->predictionStructureGroupPtr                       = (PredictionStructureGroup_t*) EB_NULL;
 
     // Cabac Context Model Array
-    EB_MALLOC(ContextModelEncContext_t*, encodeContextPtr->cabacContextModelArray, sizeof(ContextModelEncContext_t) * TOTAL_NUMBER_OF_CABAC_CONTEXT_MODEL_BUFFERS, EB_N_PTR);
+    EB_MALLOC(ContextModelEncContext_t*, encodeContextPtr->cabacContextModelArray, sizeof(ContextModelEncContext_t) * TOTAL_NUMBER_OF_CABAC_CONTEXT_MODEL_BUFFERS, EB_N_PTR, encHandle);
 
     return_error = EncodeCabacContextModelCtor(encodeContextPtr->cabacContextModelArray);
     if (return_error == EB_ErrorInsufficientResources){
@@ -195,9 +204,9 @@ EB_ERRORTYPE EncodeContextCtor(
     }
 
     // MD Rate Estimation Array
-    EB_MALLOC(MdRateEstimationContext_t*, encodeContextPtr->mdRateEstimationArray, sizeof(MdRateEstimationContext_t) * TOTAL_NUMBER_OF_MD_RATE_ESTIMATION_CASE_BUFFERS, EB_N_PTR);
+    EB_MALLOC(MdRateEstimationContext_t*, encodeContextPtr->mdRateEstimationArray, sizeof(MdRateEstimationContext_t) * TOTAL_NUMBER_OF_MD_RATE_ESTIMATION_CASE_BUFFERS, EB_N_PTR, encHandle);
 
-    return_error = MdRateEstimationContextCtor(encodeContextPtr->mdRateEstimationArray, encodeContextPtr->cabacContextModelArray);
+    return_error = MdRateEstimationContextCtor(encodeContextPtr->mdRateEstimationArray, encodeContextPtr->cabacContextModelArray, encHandle);
     if (return_error == EB_ErrorInsufficientResources){
         return EB_ErrorInsufficientResources;
     }
@@ -211,37 +220,29 @@ EB_ERRORTYPE EncodeContextCtor(
     encodeContextPtr->fillerBitError                                    = 0;
 
     // Rate Control Bit Tables
-    EB_MALLOC(RateControlTables_t*, encodeContextPtr->rateControlTablesArray, sizeof(RateControlTables_t) * TOTAL_NUMBER_OF_INITIAL_RC_TABLES_ENTRY, EB_N_PTR);
+    EB_MALLOC(RateControlTables_t*, encodeContextPtr->rateControlTablesArray, sizeof(RateControlTables_t) * TOTAL_NUMBER_OF_INITIAL_RC_TABLES_ENTRY, EB_N_PTR, encHandle);
 
     return_error = RateControlTablesCtor(encodeContextPtr->rateControlTablesArray);
     if (return_error == EB_ErrorInsufficientResources){
         return EB_ErrorInsufficientResources;
     }
     // RC Rate Table Update Mutex
-    EB_CREATEMUTEX(EB_HANDLE, encodeContextPtr->rateTableUpdateMutex, sizeof(EB_HANDLE), EB_MUTEX);
+    EB_CREATEMUTEX(EB_HANDLE, encodeContextPtr->rateTableUpdateMutex, sizeof(EB_HANDLE), EB_MUTEX, encHandle);
 
     encodeContextPtr->rateControlTablesArrayUpdated = EB_FALSE;
 
-    EB_CREATEMUTEX(EB_HANDLE, encodeContextPtr->scBufferMutex, sizeof(EB_HANDLE), EB_MUTEX);
+    EB_CREATEMUTEX(EB_HANDLE, encodeContextPtr->scBufferMutex, sizeof(EB_HANDLE), EB_MUTEX, encHandle);
     encodeContextPtr->scBuffer      = 0;
     encodeContextPtr->scFrameIn     = 0;
     encodeContextPtr->scFrameOut    = 0;
     encodeContextPtr->encMode = SPEED_CONTROL_INIT_MOD;
 
-    EB_CREATEMUTEX(EB_HANDLE, encodeContextPtr->bufferFillMutex, sizeof(EB_HANDLE), EB_MUTEX);
+    EB_CREATEMUTEX(EB_HANDLE, encodeContextPtr->bufferFillMutex, sizeof(EB_HANDLE), EB_MUTEX, encHandle);
     encodeContextPtr->previousSelectedRefQp = 32;
     encodeContextPtr->maxCodedPoc = 0;
     encodeContextPtr->maxCodedPocSelectedRefQp = 32;
 
-     encodeContextPtr->sharedReferenceMutex = EbCreateMutex();
-	if (encodeContextPtr->sharedReferenceMutex  == (EB_HANDLE) EB_NULL){
-        return EB_ErrorInsufficientResources;
-    }else {
-        memoryMap[*(memoryMapIndex)].ptrType          = EB_MUTEX;
-        memoryMap[(*(memoryMapIndex))++].ptr          = encodeContextPtr->sharedReferenceMutex ;
-        *totalLibMemory                              += (sizeof(EB_HANDLE));    
-    }
-
+    EB_CREATEMUTEX(EB_HANDLE, encodeContextPtr->sharedReferenceMutex, sizeof(EB_HANDLE), EB_MUTEX, encHandle);
 
     return EB_ErrorNone;
 }

--- a/Source/Lib/Codec/EbEncodeContext.h
+++ b/Source/Lib/Codec/EbEncodeContext.h
@@ -175,7 +175,8 @@ typedef struct EncodeContextInitData_s {
  **************************************/
 extern EB_ERRORTYPE EncodeContextCtor(
     EB_PTR *objectDblPtr, 
-    EB_PTR objectInitDataPtr);
+    EB_PTR objectInitDataPtr,
+    EB_HANDLE encHandle);
     
 #ifdef __cplusplus
 }

--- a/Source/Lib/Codec/EbEntropyCoding.c
+++ b/Source/Lib/Codec/EbEntropyCoding.c
@@ -9280,16 +9280,17 @@ EB_ERRORTYPE CopyRbspBitstreamToPayload(
 
 EB_ERRORTYPE BitstreamCtor(
 	Bitstream_t **bitstreamDblPtr,
-	EB_U32 bufferSize)
+	EB_U32 bufferSize,
+    EB_HANDLE encHandle)
 {
     EB_ERRORTYPE return_error = EB_ErrorNone;
-    EB_MALLOC(Bitstream_t*, *bitstreamDblPtr, sizeof(Bitstream_t), EB_N_PTR);
+    EB_MALLOC(Bitstream_t*, *bitstreamDblPtr, sizeof(Bitstream_t), EB_N_PTR, encHandle);
 
-    EB_MALLOC(EB_PTR, (*bitstreamDblPtr)->outputBitstreamPtr, sizeof(OutputBitstreamUnit_t), EB_N_PTR);
+    EB_MALLOC(EB_PTR, (*bitstreamDblPtr)->outputBitstreamPtr, sizeof(OutputBitstreamUnit_t), EB_N_PTR, encHandle);
 
     return_error = OutputBitstreamUnitCtor(
 		(OutputBitstreamUnit_t *)(*bitstreamDblPtr)->outputBitstreamPtr,
-		bufferSize);
+		bufferSize, encHandle);
 
     return return_error;
 }
@@ -9299,12 +9300,13 @@ EB_ERRORTYPE BitstreamCtor(
 
 EB_ERRORTYPE EntropyCoderCtor(
 	EntropyCoder_t **entropyCoderDblPtr,
-	EB_U32 bufferSize)
+	EB_U32 bufferSize,
+    EB_HANDLE encHandle)
 {
     EB_ERRORTYPE return_error = EB_ErrorNone;
-    EB_MALLOC(EntropyCoder_t*, *entropyCoderDblPtr, sizeof(EntropyCoder_t), EB_N_PTR);
+    EB_MALLOC(EntropyCoder_t*, *entropyCoderDblPtr, sizeof(EntropyCoder_t), EB_N_PTR, encHandle);
 
-    EB_MALLOC(EB_PTR, (*entropyCoderDblPtr)->cabacEncodeContextPtr, sizeof(CabacEncodeContext_t), EB_N_PTR);
+    EB_MALLOC(EB_PTR, (*entropyCoderDblPtr)->cabacEncodeContextPtr, sizeof(CabacEncodeContext_t), EB_N_PTR, encHandle);
 
 	EbHevcCabacCtor(
 		(CabacEncodeContext_t *)(*entropyCoderDblPtr)->cabacEncodeContextPtr);
@@ -9312,7 +9314,7 @@ EB_ERRORTYPE EntropyCoderCtor(
 
     return_error = OutputBitstreamUnitCtor(
 		&((((CabacEncodeContext_t*)(*entropyCoderDblPtr)->cabacEncodeContextPtr)->bacEncContext).m_pcTComBitIf),
-		bufferSize);
+		bufferSize, encHandle);
 
     return return_error;
 }

--- a/Source/Lib/Codec/EbEntropyCodingObject.h
+++ b/Source/Lib/Codec/EbEntropyCodingObject.h
@@ -21,12 +21,14 @@ typedef struct EntropyCoder_s {
 
 extern EB_ERRORTYPE BitstreamCtor(
     Bitstream_t **bitstreamDblPtr,
-    EB_U32 bufferSize);
+    EB_U32 bufferSize,
+    EB_HANDLE encHandle);
 
 
 extern EB_ERRORTYPE EntropyCoderCtor(
     EntropyCoder_t **entropyCoderDblPtr,
-    EB_U32 bufferSize);
+    EB_U32 bufferSize,
+    EB_HANDLE encHandle);
 
 
 

--- a/Source/Lib/Codec/EbEntropyCodingProcess.c
+++ b/Source/Lib/Codec/EbEntropyCodingProcess.c
@@ -18,10 +18,11 @@ EB_ERRORTYPE EntropyCodingContextCtor(
     EbFifo_t                *encDecInputFifoPtr,
     EbFifo_t                *packetizationOutputFifoPtr,
     EbFifo_t                *rateControlOutputFifoPtr,
-    EB_BOOL                  is16bit)
+    EB_BOOL                  is16bit,
+    EB_HANDLE                encHandle)
 {
     EntropyCodingContext_t *contextPtr;
-    EB_MALLOC(EntropyCodingContext_t*, contextPtr, sizeof(EntropyCodingContext_t), EB_N_PTR);
+    EB_MALLOC(EntropyCodingContext_t*, contextPtr, sizeof(EntropyCodingContext_t), EB_N_PTR, encHandle);
     *contextDblPtr = contextPtr;
 
     contextPtr->is16bit = is16bit;

--- a/Source/Lib/Codec/EbEntropyCodingProcess.h
+++ b/Source/Lib/Codec/EbEntropyCodingProcess.h
@@ -82,7 +82,6 @@ typedef struct EntropyCodingContext_s
     
     // MCP Context
     EB_BOOL                         is16bit; //enable 10 bit encode in CL
-
 } EntropyCodingContext_t;
 
 /**************************************
@@ -93,7 +92,8 @@ extern EB_ERRORTYPE EntropyCodingContextCtor(
     EbFifo_t                *encDecInputFifoPtr,
     EbFifo_t                *packetizationOutputFifoPtr,
     EbFifo_t                *rateControlOutputFifoPtr,
-    EB_BOOL                  is16bit);
+    EB_BOOL                  is16bit,
+    EB_HANDLE                encHandle);
     
 extern void* EntropyCodingKernel(void *inputPtr);
 

--- a/Source/Lib/Codec/EbEntropyCodingResults.c
+++ b/Source/Lib/Codec/EbEntropyCodingResults.c
@@ -10,10 +10,11 @@
 
 EB_ERRORTYPE EntropyCodingResultsCtor(
     EB_PTR *objectDblPtr,
-    EB_PTR objectInitDataPtr)
+    EB_PTR objectInitDataPtr,
+    EB_HANDLE encHandle)
 {
     EntropyCodingResults_t *contextPtr;
-    EB_MALLOC(EntropyCodingResults_t*, contextPtr, sizeof(EntropyCodingResults_t), EB_N_PTR);
+    EB_MALLOC(EntropyCodingResults_t*, contextPtr, sizeof(EntropyCodingResults_t), EB_N_PTR, encHandle);
 
     *objectDblPtr = (EB_PTR) contextPtr;
 

--- a/Source/Lib/Codec/EbEntropyCodingResults.h
+++ b/Source/Lib/Codec/EbEntropyCodingResults.h
@@ -30,7 +30,8 @@ typedef struct
  **************************************/
 extern EB_ERRORTYPE EntropyCodingResultsCtor(
     EB_PTR *objectDblPtr, 
-    EB_PTR objectInitDataPtr);
+    EB_PTR objectInitDataPtr,
+    EB_HANDLE encHandle);
 
 
 #ifdef __cplusplus

--- a/Source/Lib/Codec/EbInitialRateControlProcess.c
+++ b/Source/Lib/Codec/EbInitialRateControlProcess.c
@@ -359,10 +359,11 @@ void EbHevcDetectGlobalMotion(
 EB_ERRORTYPE InitialRateControlContextCtor(
 	InitialRateControlContext_t **contextDblPtr,
 	EbFifo_t                     *motionEstimationResultsInputFifoPtr,
-	EbFifo_t                     *initialrateControlResultsOutputFifoPtr)
+	EbFifo_t                     *initialrateControlResultsOutputFifoPtr,
+    EB_HANDLE                     encHandle)
 {
 	InitialRateControlContext_t *contextPtr;
-	EB_MALLOC(InitialRateControlContext_t*, contextPtr, sizeof(InitialRateControlContext_t), EB_N_PTR);
+	EB_MALLOC(InitialRateControlContext_t*, contextPtr, sizeof(InitialRateControlContext_t), EB_N_PTR, encHandle);
 	*contextDblPtr = contextPtr;
 	contextPtr->motionEstimationResultsInputFifoPtr = motionEstimationResultsInputFifoPtr;
 	contextPtr->initialrateControlResultsOutputFifoPtr = initialrateControlResultsOutputFifoPtr;

--- a/Source/Lib/Codec/EbInitialRateControlProcess.h
+++ b/Source/Lib/Codec/EbInitialRateControlProcess.h
@@ -21,7 +21,6 @@ typedef struct InitialRateControlContext_s
 {
     EbFifo_t                    *motionEstimationResultsInputFifoPtr;
 	EbFifo_t                    *initialrateControlResultsOutputFifoPtr;
-
 } InitialRateControlContext_t;
 
 /***************************************
@@ -30,7 +29,8 @@ typedef struct InitialRateControlContext_s
 extern EB_ERRORTYPE InitialRateControlContextCtor(
     InitialRateControlContext_t **contextDblPtr,
     EbFifo_t                     *motionEstimationResultsInputFifoPtr,
-    EbFifo_t                     *pictureDemuxResultsOutputFifoPtr);
+    EbFifo_t                     *pictureDemuxResultsOutputFifoPtr,
+    EB_HANDLE                     encHandle);
 
 extern void* InitialRateControlKernel(void *inputPtr);
 

--- a/Source/Lib/Codec/EbInitialRateControlReorderQueue.c
+++ b/Source/Lib/Codec/EbInitialRateControlReorderQueue.c
@@ -8,9 +8,10 @@
 
 EB_ERRORTYPE InitialRateControlReorderEntryCtor(   
     InitialRateControlReorderEntry_t   **entryDblPtr,
-    EB_U32                          pictureNumber)
+    EB_U32                          pictureNumber,
+    EB_HANDLE                            encHandle)
 {
-    EB_MALLOC(InitialRateControlReorderEntry_t*, *entryDblPtr, sizeof(InitialRateControlReorderEntry_t), EB_N_PTR);
+    EB_MALLOC(InitialRateControlReorderEntry_t*, *entryDblPtr, sizeof(InitialRateControlReorderEntry_t), EB_N_PTR, encHandle);
 
     (*entryDblPtr)->pictureNumber       = pictureNumber;
     (*entryDblPtr)->parentPcsWrapperPtr = (EbObjectWrapper_t *)EB_NULL;
@@ -21,9 +22,10 @@ EB_ERRORTYPE InitialRateControlReorderEntryCtor(
 
 EB_ERRORTYPE HlRateControlHistogramEntryCtor(   
     HlRateControlHistogramEntry_t   **entryDblPtr,
-    EB_U32                          pictureNumber)
+    EB_U32                            pictureNumber,
+    EB_HANDLE                         encHandle)
 {
-    EB_CALLOC(HlRateControlHistogramEntry_t*, *entryDblPtr, sizeof(HlRateControlHistogramEntry_t), 1, EB_N_PTR);
+    EB_CALLOC(HlRateControlHistogramEntry_t*, *entryDblPtr, sizeof(HlRateControlHistogramEntry_t), 1, EB_N_PTR, encHandle);
 
     (*entryDblPtr)->pictureNumber       = pictureNumber;
     (*entryDblPtr)->lifeCount           = 0;
@@ -31,9 +33,9 @@ EB_ERRORTYPE HlRateControlHistogramEntryCtor(
     (*entryDblPtr)->parentPcsWrapperPtr = (EbObjectWrapper_t *)EB_NULL;
 
 	// ME and OIS Distortion Histograms
-    EB_MALLOC(EB_U16*, (*entryDblPtr)->meDistortionHistogram, sizeof(EB_U16) * NUMBER_OF_SAD_INTERVALS, EB_N_PTR);
+    EB_MALLOC(EB_U16*, (*entryDblPtr)->meDistortionHistogram, sizeof(EB_U16) * NUMBER_OF_SAD_INTERVALS, EB_N_PTR, encHandle);
 
-    EB_MALLOC(EB_U16*, (*entryDblPtr)->oisDistortionHistogram, sizeof(EB_U16) * NUMBER_OF_INTRA_SAD_INTERVALS, EB_N_PTR);
+    EB_MALLOC(EB_U16*, (*entryDblPtr)->oisDistortionHistogram, sizeof(EB_U16) * NUMBER_OF_INTRA_SAD_INTERVALS, EB_N_PTR, encHandle);
 
     return EB_ErrorNone;
 }

--- a/Source/Lib/Codec/EbInitialRateControlReorderQueue.h
+++ b/Source/Lib/Codec/EbInitialRateControlReorderQueue.h
@@ -23,7 +23,8 @@ typedef struct InitialRateControlReorderEntry_s {
 
 extern EB_ERRORTYPE InitialRateControlReorderEntryCtor(   
     InitialRateControlReorderEntry_t   **entryDblPtr,
-    EB_U32                               pictureNumber);
+    EB_U32                               pictureNumber,
+    EB_HANDLE                            encHandle);
 
 
 /************************************************
@@ -50,7 +51,8 @@ typedef struct HlRateControlHistogramEntry_s {
 
 extern EB_ERRORTYPE HlRateControlHistogramEntryCtor(   
     HlRateControlHistogramEntry_t   **entryDblPtr,
-    EB_U32                            pictureNumber);
+    EB_U32                            pictureNumber,
+    EB_HANDLE                         encHandle);
 
 #ifdef __cplusplus
 }

--- a/Source/Lib/Codec/EbInitialRateControlResults.c
+++ b/Source/Lib/Codec/EbInitialRateControlResults.c
@@ -9,10 +9,11 @@
 
 EB_ERRORTYPE InitialRateControlResultsCtor(
     EB_PTR *objectDblPtr, 
-    EB_PTR objectInitDataPtr)
+    EB_PTR objectInitDataPtr,
+    EB_HANDLE encHandle)
 {
     InitialRateControlResults_t *objectPtr;
-    EB_MALLOC(InitialRateControlResults_t *, objectPtr, sizeof(InitialRateControlResults_t), EB_N_PTR);
+    EB_MALLOC(InitialRateControlResults_t *, objectPtr, sizeof(InitialRateControlResults_t), EB_N_PTR, encHandle);
 
     *objectDblPtr = (EB_PTR) objectPtr;
     objectInitDataPtr = 0;

--- a/Source/Lib/Codec/EbInitialRateControlResults.h
+++ b/Source/Lib/Codec/EbInitialRateControlResults.h
@@ -29,7 +29,8 @@ typedef struct InitialRateControlResultInitData_s
  **************************************/
 extern EB_ERRORTYPE InitialRateControlResultsCtor(
     EB_PTR *objectDblPtr, 
-    EB_PTR objectInitDataPtr);
+    EB_PTR objectInitDataPtr,
+    EB_HANDLE encHandle);
 
    
 #ifdef __cplusplus

--- a/Source/Lib/Codec/EbInterPrediction.c
+++ b/Source/Lib/Codec/EbInterPrediction.c
@@ -22,12 +22,13 @@ EB_ERRORTYPE InterPredictionContextCtor(
     InterPredictionContext_t **interPredictionContext,
 	EB_U16                     maxCUWidth,
     EB_U16                     maxCUHeight,
-    EB_BOOL                    is16bit)
+    EB_BOOL                    is16bit,
+    EB_HANDLE                  encHandle)
 
 {
     EB_ERRORTYPE              return_error = EB_ErrorNone;
     InterPredictionContext_t *contextPtr;
-    EB_MALLOC(InterPredictionContext_t*, contextPtr, sizeof(InterPredictionContext_t), EB_N_PTR);
+    EB_MALLOC(InterPredictionContext_t*, contextPtr, sizeof(InterPredictionContext_t), EB_N_PTR, encHandle);
 
     (*interPredictionContext) = contextPtr;
 
@@ -35,7 +36,8 @@ EB_ERRORTYPE InterPredictionContextCtor(
         &contextPtr->mcpContext,
         maxCUWidth,
         maxCUHeight,
-        is16bit);
+        is16bit,
+        encHandle);
 
     if (return_error == EB_ErrorInsufficientResources){
         return EB_ErrorInsufficientResources;

--- a/Source/Lib/Codec/EbInterPrediction.h
+++ b/Source/Lib/Codec/EbInterPrediction.h
@@ -43,7 +43,8 @@ extern EB_ERRORTYPE InterPredictionContextCtor(
 	InterPredictionContext_t **interPredictionContext,
 	EB_U16                     maxCUWidth,
     EB_U16                     maxCUHeight,
-    EB_BOOL                    is16bit);
+    EB_BOOL                    is16bit,
+    EB_HANDLE                  encHandle);
 
 
 extern EB_ERRORTYPE InterPredictionContextDtor(

--- a/Source/Lib/Codec/EbIntraPrediction.c
+++ b/Source/Lib/Codec/EbIntraPrediction.c
@@ -73,27 +73,27 @@ static const EB_S32 intraLumaFilterTable[] = {
 /**********************************************
  * Intra Reference Samples Ctor
  **********************************************/
-EB_ERRORTYPE IntraReferenceSamplesCtor(IntraReferenceSamples_t **contextDblPtr, EB_COLOR_FORMAT colorFormat)
+EB_ERRORTYPE IntraReferenceSamplesCtor(IntraReferenceSamples_t **contextDblPtr, EB_COLOR_FORMAT colorFormat, EB_HANDLE encHandle)
 {
     IntraReferenceSamples_t *contextPtr;
-    EB_MALLOC(IntraReferenceSamples_t*, contextPtr, sizeof(IntraReferenceSamples_t), EB_N_PTR);
+    EB_MALLOC(IntraReferenceSamples_t*, contextPtr, sizeof(IntraReferenceSamples_t), EB_N_PTR, encHandle);
     *contextDblPtr = contextPtr;
 
-    EB_MALLOC(EB_U8*, contextPtr->yIntraReferenceArray, sizeof(EB_U8) * (4 * MAX_LCU_SIZE + 1), EB_N_PTR);
+    EB_MALLOC(EB_U8*, contextPtr->yIntraReferenceArray, sizeof(EB_U8) * (4 * MAX_LCU_SIZE + 1), EB_N_PTR, encHandle);
 
-    EB_MALLOC(EB_U8*, contextPtr->cbIntraReferenceArray, sizeof(EB_U8) * (4 * MAX_LCU_SIZE + 1), EB_N_PTR);
+    EB_MALLOC(EB_U8*, contextPtr->cbIntraReferenceArray, sizeof(EB_U8) * (4 * MAX_LCU_SIZE + 1), EB_N_PTR, encHandle);
 
-    EB_MALLOC(EB_U8*, contextPtr->crIntraReferenceArray, sizeof(EB_U8) * (4 * MAX_LCU_SIZE + 1), EB_N_PTR);
+    EB_MALLOC(EB_U8*, contextPtr->crIntraReferenceArray, sizeof(EB_U8) * (4 * MAX_LCU_SIZE + 1), EB_N_PTR, encHandle);
 
-    EB_MALLOC(EB_U8*, contextPtr->yIntraFilteredReferenceArray, sizeof(EB_U8) * (4 * MAX_LCU_SIZE + 1), EB_N_PTR);
+    EB_MALLOC(EB_U8*, contextPtr->yIntraFilteredReferenceArray, sizeof(EB_U8) * (4 * MAX_LCU_SIZE + 1), EB_N_PTR, encHandle);
 
-    EB_MALLOC(EB_U8*, contextPtr->yIntraReferenceArrayReverse, sizeof(EB_U8) * (4 * MAX_LCU_SIZE + 2), EB_N_PTR);
+    EB_MALLOC(EB_U8*, contextPtr->yIntraReferenceArrayReverse, sizeof(EB_U8) * (4 * MAX_LCU_SIZE + 2), EB_N_PTR, encHandle);
 
-    EB_MALLOC(EB_U8*, contextPtr->yIntraFilteredReferenceArrayReverse, sizeof(EB_U8) * (4 * MAX_LCU_SIZE + 2), EB_N_PTR);
+    EB_MALLOC(EB_U8*, contextPtr->yIntraFilteredReferenceArrayReverse, sizeof(EB_U8) * (4 * MAX_LCU_SIZE + 2), EB_N_PTR, encHandle);
 
-    EB_MALLOC(EB_U8*, contextPtr->cbIntraReferenceArrayReverse, sizeof(EB_U8) * (4 * MAX_LCU_SIZE + 2), EB_N_PTR);
+    EB_MALLOC(EB_U8*, contextPtr->cbIntraReferenceArrayReverse, sizeof(EB_U8) * (4 * MAX_LCU_SIZE + 2), EB_N_PTR, encHandle);
 
-    EB_MALLOC(EB_U8*, contextPtr->crIntraReferenceArrayReverse, sizeof(EB_U8) * (4 * MAX_LCU_SIZE + 2), EB_N_PTR);
+    EB_MALLOC(EB_U8*, contextPtr->crIntraReferenceArrayReverse, sizeof(EB_U8) * (4 * MAX_LCU_SIZE + 2), EB_N_PTR, encHandle);
 
     contextPtr->yIntraReferenceArrayReverse++; //Jing: mem leak? bad here
     contextPtr->yIntraFilteredReferenceArrayReverse++;
@@ -101,10 +101,10 @@ EB_ERRORTYPE IntraReferenceSamplesCtor(IntraReferenceSamples_t **contextDblPtr, 
     contextPtr->crIntraReferenceArrayReverse++;
 
     if (colorFormat == EB_YUV444) {
-        EB_MALLOC(EB_U8*, contextPtr->cbIntraFilteredReferenceArray, sizeof(EB_U8) * (4 * MAX_LCU_SIZE + 1), EB_N_PTR);
-        EB_MALLOC(EB_U8*, contextPtr->crIntraFilteredReferenceArray, sizeof(EB_U8) * (4 * MAX_LCU_SIZE + 1), EB_N_PTR);
-        EB_MALLOC(EB_U8*, contextPtr->cbIntraFilteredReferenceArrayReverse, sizeof(EB_U8) * (4 * MAX_LCU_SIZE + 2), EB_N_PTR);
-        EB_MALLOC(EB_U8*, contextPtr->crIntraFilteredReferenceArrayReverse, sizeof(EB_U8) * (4 * MAX_LCU_SIZE + 2), EB_N_PTR);
+        EB_MALLOC(EB_U8*, contextPtr->cbIntraFilteredReferenceArray, sizeof(EB_U8) * (4 * MAX_LCU_SIZE + 1), EB_N_PTR, encHandle);
+        EB_MALLOC(EB_U8*, contextPtr->crIntraFilteredReferenceArray, sizeof(EB_U8) * (4 * MAX_LCU_SIZE + 1), EB_N_PTR, encHandle);
+        EB_MALLOC(EB_U8*, contextPtr->cbIntraFilteredReferenceArrayReverse, sizeof(EB_U8) * (4 * MAX_LCU_SIZE + 2), EB_N_PTR, encHandle);
+        EB_MALLOC(EB_U8*, contextPtr->crIntraFilteredReferenceArrayReverse, sizeof(EB_U8) * (4 * MAX_LCU_SIZE + 2), EB_N_PTR, encHandle);
         contextPtr->cbIntraFilteredReferenceArrayReverse++;
         contextPtr->crIntraFilteredReferenceArrayReverse++;
     } else {
@@ -122,27 +122,28 @@ EB_ERRORTYPE IntraReferenceSamplesCtor(IntraReferenceSamples_t **contextDblPtr, 
  **********************************************/
 EB_ERRORTYPE IntraReference16bitSamplesCtor(
     IntraReference16bitSamples_t **contextDblPtr,
-    EB_COLOR_FORMAT colorFormat)
+    EB_COLOR_FORMAT colorFormat,
+    EB_HANDLE encHandle)
 {
     IntraReference16bitSamples_t *contextPtr;
-    EB_MALLOC(IntraReference16bitSamples_t*, contextPtr, sizeof(IntraReference16bitSamples_t), EB_N_PTR);
+    EB_MALLOC(IntraReference16bitSamples_t*, contextPtr, sizeof(IntraReference16bitSamples_t), EB_N_PTR, encHandle);
     *contextDblPtr = contextPtr;
 
-    EB_MALLOC(EB_U16*, contextPtr->yIntraReferenceArray, sizeof(EB_U16) * (4 * MAX_LCU_SIZE + 1), EB_N_PTR);
+    EB_MALLOC(EB_U16*, contextPtr->yIntraReferenceArray, sizeof(EB_U16) * (4 * MAX_LCU_SIZE + 1), EB_N_PTR, encHandle);
 
-    EB_MALLOC(EB_U16*, contextPtr->cbIntraReferenceArray, sizeof(EB_U16) * (4 * MAX_LCU_SIZE + 1), EB_N_PTR);
+    EB_MALLOC(EB_U16*, contextPtr->cbIntraReferenceArray, sizeof(EB_U16) * (4 * MAX_LCU_SIZE + 1), EB_N_PTR, encHandle);
 
-    EB_MALLOC(EB_U16*, contextPtr->crIntraReferenceArray, sizeof(EB_U16) * (4 * MAX_LCU_SIZE + 1), EB_N_PTR);
+    EB_MALLOC(EB_U16*, contextPtr->crIntraReferenceArray, sizeof(EB_U16) * (4 * MAX_LCU_SIZE + 1), EB_N_PTR, encHandle);
 
-    EB_MALLOC(EB_U16*, contextPtr->yIntraFilteredReferenceArray, sizeof(EB_U16) * (4 * MAX_LCU_SIZE + 1), EB_N_PTR);
+    EB_MALLOC(EB_U16*, contextPtr->yIntraFilteredReferenceArray, sizeof(EB_U16) * (4 * MAX_LCU_SIZE + 1), EB_N_PTR, encHandle);
 
-    EB_MALLOC(EB_U16*, contextPtr->yIntraReferenceArrayReverse, sizeof(EB_U16) * (4 * MAX_LCU_SIZE + 2), EB_N_PTR);
+    EB_MALLOC(EB_U16*, contextPtr->yIntraReferenceArrayReverse, sizeof(EB_U16) * (4 * MAX_LCU_SIZE + 2), EB_N_PTR, encHandle);
 
-    EB_MALLOC(EB_U16*, contextPtr->yIntraFilteredReferenceArrayReverse, sizeof(EB_U16) * (4 * MAX_LCU_SIZE + 2), EB_N_PTR);
+    EB_MALLOC(EB_U16*, contextPtr->yIntraFilteredReferenceArrayReverse, sizeof(EB_U16) * (4 * MAX_LCU_SIZE + 2), EB_N_PTR, encHandle);
 
-    EB_MALLOC(EB_U16*, contextPtr->cbIntraReferenceArrayReverse, sizeof(EB_U16) * (4 * MAX_LCU_SIZE + 2), EB_N_PTR);
+    EB_MALLOC(EB_U16*, contextPtr->cbIntraReferenceArrayReverse, sizeof(EB_U16) * (4 * MAX_LCU_SIZE + 2), EB_N_PTR, encHandle);
 
-    EB_MALLOC(EB_U16*, contextPtr->crIntraReferenceArrayReverse, sizeof(EB_U16) * (4 * MAX_LCU_SIZE + 2), EB_N_PTR);
+    EB_MALLOC(EB_U16*, contextPtr->crIntraReferenceArrayReverse, sizeof(EB_U16) * (4 * MAX_LCU_SIZE + 2), EB_N_PTR, encHandle);
 
     contextPtr->yIntraReferenceArrayReverse++;
     contextPtr->yIntraFilteredReferenceArrayReverse++;
@@ -150,10 +151,10 @@ EB_ERRORTYPE IntraReference16bitSamplesCtor(
     contextPtr->crIntraReferenceArrayReverse++;
 
     if (colorFormat == EB_YUV444) {
-        EB_MALLOC(EB_U16*, contextPtr->cbIntraFilteredReferenceArray, sizeof(EB_U16) * (4 * MAX_LCU_SIZE + 1), EB_N_PTR);
-        EB_MALLOC(EB_U16*, contextPtr->crIntraFilteredReferenceArray, sizeof(EB_U16) * (4 * MAX_LCU_SIZE + 1), EB_N_PTR);
-        EB_MALLOC(EB_U16*, contextPtr->cbIntraFilteredReferenceArrayReverse, sizeof(EB_U16) * (4 * MAX_LCU_SIZE + 2), EB_N_PTR);
-        EB_MALLOC(EB_U16*, contextPtr->crIntraFilteredReferenceArrayReverse, sizeof(EB_U16) * (4 * MAX_LCU_SIZE + 2), EB_N_PTR);
+        EB_MALLOC(EB_U16*, contextPtr->cbIntraFilteredReferenceArray, sizeof(EB_U16) * (4 * MAX_LCU_SIZE + 1), EB_N_PTR, encHandle);
+        EB_MALLOC(EB_U16*, contextPtr->crIntraFilteredReferenceArray, sizeof(EB_U16) * (4 * MAX_LCU_SIZE + 1), EB_N_PTR, encHandle);
+        EB_MALLOC(EB_U16*, contextPtr->cbIntraFilteredReferenceArrayReverse, sizeof(EB_U16) * (4 * MAX_LCU_SIZE + 2), EB_N_PTR, encHandle);
+        EB_MALLOC(EB_U16*, contextPtr->crIntraFilteredReferenceArrayReverse, sizeof(EB_U16) * (4 * MAX_LCU_SIZE + 2), EB_N_PTR, encHandle);
         contextPtr->cbIntraFilteredReferenceArrayReverse++;
         contextPtr->crIntraFilteredReferenceArrayReverse++;
     } else {
@@ -4891,16 +4892,17 @@ EB_ERRORTYPE EncodePassIntraPrediction16bit(
  * Intra Reference Samples Ctor
  **********************************************/
 EB_ERRORTYPE IntraOpenLoopReferenceSamplesCtor(
-    IntraReferenceSamplesOpenLoop_t **contextDblPtr)
+    IntraReferenceSamplesOpenLoop_t **contextDblPtr,
+    EB_HANDLE encHandle)
 {
     IntraReferenceSamplesOpenLoop_t *contextPtr;
-    EB_MALLOC(IntraReferenceSamplesOpenLoop_t*, contextPtr, sizeof(IntraReferenceSamplesOpenLoop_t), EB_N_PTR);
+    EB_MALLOC(IntraReferenceSamplesOpenLoop_t*, contextPtr, sizeof(IntraReferenceSamplesOpenLoop_t), EB_N_PTR, encHandle);
 
     *contextDblPtr = contextPtr;
 
-    EB_MALLOC(EB_U8*, contextPtr->yIntraReferenceArray, sizeof(EB_U8) * (4 * MAX_LCU_SIZE + 1), EB_N_PTR);
+    EB_MALLOC(EB_U8*, contextPtr->yIntraReferenceArray, sizeof(EB_U8) * (4 * MAX_LCU_SIZE + 1), EB_N_PTR, encHandle);
 
-    EB_MALLOC(EB_U8*, contextPtr->yIntraReferenceArrayReverse, sizeof(EB_U8) * (4 * MAX_LCU_SIZE + 2), EB_N_PTR);
+    EB_MALLOC(EB_U8*, contextPtr->yIntraReferenceArrayReverse, sizeof(EB_U8) * (4 * MAX_LCU_SIZE + 2), EB_N_PTR, encHandle);
 
     contextPtr->yIntraReferenceArrayReverse++;
 

--- a/Source/Lib/Codec/EbIntraPrediction.h
+++ b/Source/Lib/Codec/EbIntraPrediction.h
@@ -99,13 +99,15 @@ typedef struct IntraReference16bitSamples_s {
 
 extern EB_ERRORTYPE IntraReferenceSamplesCtor(
         IntraReferenceSamples_t **contextDblPtr,
-        EB_COLOR_FORMAT colorFormat);
+        EB_COLOR_FORMAT colorFormat,
+        EB_HANDLE encHandle);
 
 
 
 extern EB_ERRORTYPE IntraReference16bitSamplesCtor(
     IntraReference16bitSamples_t **contextDblPtr,
-    EB_COLOR_FORMAT colorFormat);
+    EB_COLOR_FORMAT colorFormat,
+    EB_HANDLE encHandle);
 
 
 
@@ -377,7 +379,8 @@ extern EB_ERRORTYPE UpdateChromaNeighborSamplesArrayOL(
     LargestCodingUnit_t             *lcuPtr);
 
 extern EB_ERRORTYPE IntraOpenLoopReferenceSamplesCtor(
-    IntraReferenceSamplesOpenLoop_t **contextDblPtr);
+    IntraReferenceSamplesOpenLoop_t **contextDblPtr,
+    EB_HANDLE encHandle);
 extern void IntraOpenLoopReferenceSamplesDtor(
     IntraReferenceSamplesOpenLoop_t  *contextPtr);
 

--- a/Source/Lib/Codec/EbMcp.c
+++ b/Source/Lib/Codec/EbMcp.c
@@ -27,27 +27,29 @@ EB_ERRORTYPE MotionCompensationPredictionContextCtor(
     MotionCompensationPredictionContext_t **contextDblPtr,
 	EB_U16                                  maxCUWidth,
     EB_U16                                  maxCUHeight,
-    EB_BOOL                                 is16bit)
+    EB_BOOL                                 is16bit,
+    EB_HANDLE                               encHandle)
 
 {
     EB_ERRORTYPE return_error = EB_ErrorNone;
     MotionCompensationPredictionContext_t *contextPtr;
-    EB_MALLOC(MotionCompensationPredictionContext_t *, contextPtr, sizeof(MotionCompensationPredictionContext_t), EB_N_PTR);
+
+    EB_MALLOC(MotionCompensationPredictionContext_t *, contextPtr, sizeof(MotionCompensationPredictionContext_t), EB_N_PTR, encHandle);
     *(contextDblPtr) = contextPtr;
 
     // Jing: increase the size for 422/444
-    EB_MALLOC(EB_S16*, contextPtr->motionCompensationIntermediateResultBuf0, sizeof(EB_S16)*(maxCUWidth*maxCUHeight * 3 + 8), EB_N_PTR);        //Y + U + V
+    EB_MALLOC(EB_S16*, contextPtr->motionCompensationIntermediateResultBuf0, sizeof(EB_S16)*(maxCUWidth*maxCUHeight * 3 + 8), EB_N_PTR, encHandle);        //Y + U + V
 
-    EB_MALLOC(EB_S16*, contextPtr->motionCompensationIntermediateResultBuf1, sizeof(EB_S16)*(maxCUWidth*maxCUHeight * 3 + 8), EB_N_PTR);        //Y + U + V
+    EB_MALLOC(EB_S16*, contextPtr->motionCompensationIntermediateResultBuf1, sizeof(EB_S16)*(maxCUWidth*maxCUHeight * 3 + 8), EB_N_PTR, encHandle);        //Y + U + V
 
-    EB_MALLOC(EB_BYTE, contextPtr->avcStyleMcpIntermediateResultBuf0, sizeof(EB_U8)*maxCUWidth*maxCUHeight * 6 * 3 + 16, EB_N_PTR);        //Y + U + V;
+    EB_MALLOC(EB_BYTE, contextPtr->avcStyleMcpIntermediateResultBuf0, sizeof(EB_U8)*maxCUWidth*maxCUHeight * 6 * 3 + 16, EB_N_PTR, encHandle);        //Y + U + V;
 
-    EB_MALLOC(EB_BYTE, contextPtr->avcStyleMcpIntermediateResultBuf1, sizeof(EB_U8)*maxCUWidth*maxCUHeight * 6 * 3 + 16, EB_N_PTR);        //Y + U + V;
+    EB_MALLOC(EB_BYTE, contextPtr->avcStyleMcpIntermediateResultBuf1, sizeof(EB_U8)*maxCUWidth*maxCUHeight * 6 * 3 + 16, EB_N_PTR, encHandle);        //Y + U + V;
 
 #if !USE_PRE_COMPUTE
-    EB_MALLOC(EB_S16*, contextPtr->TwoDInterpolationFirstPassFilterResultBuf, sizeof(EB_S16)*(maxCUWidth + MaxHorizontalLumaFliterTag - 1)*(maxCUHeight + MaxVerticalLumaFliterTag - 1), EB_N_PTR);   // to be modified
+    EB_MALLOC(EB_S16*, contextPtr->TwoDInterpolationFirstPassFilterResultBuf, sizeof(EB_S16)*(maxCUWidth + MaxHorizontalLumaFliterTag - 1)*(maxCUHeight + MaxVerticalLumaFliterTag - 1), EB_N_PTR, encHandle);   // to be modified
 
-    EB_MALLOC(EB_BYTE, contextPtr->avcStyleMcpTwoDInterpolationFirstPassFilterResultBuf, sizeof(EB_U8)*(6 * maxCUWidth + MaxHorizontalLumaFliterTag - 1)*(maxCUHeight + MaxVerticalLumaFliterTag - 1), EB_N_PTR);
+    EB_MALLOC(EB_BYTE, contextPtr->avcStyleMcpTwoDInterpolationFirstPassFilterResultBuf, sizeof(EB_U8)*(6 * maxCUWidth + MaxHorizontalLumaFliterTag - 1)*(maxCUHeight + MaxVerticalLumaFliterTag - 1), EB_N_PTR, encHandle);
 
 #endif
 
@@ -69,24 +71,26 @@ EB_ERRORTYPE MotionCompensationPredictionContextCtor(
 
         return_error = EbPictureBufferDescCtor(
             (EB_PTR*)&contextPtr->localReferenceBlockL0,
-            (EB_PTR)&initData);
+            (EB_PTR)&initData,
+            encHandle);
         if (return_error == EB_ErrorInsufficientResources){
             return EB_ErrorInsufficientResources;
         }
         return_error = EbPictureBufferDescCtor(
             (EB_PTR*)&contextPtr->localReferenceBlockL1,
-            (EB_PTR)&initData);
+            (EB_PTR)&initData,
+            encHandle);
         if (return_error == EB_ErrorInsufficientResources){
             return EB_ErrorInsufficientResources;
         }
 
         initData.bitDepth = EB_8BIT;
 
-        return_error = EbPictureBufferDescCtor( (EB_PTR*)&contextPtr->localReferenceBlock8BITL0,  (EB_PTR)&initData);
+        return_error = EbPictureBufferDescCtor( (EB_PTR*)&contextPtr->localReferenceBlock8BITL0,  (EB_PTR)&initData, encHandle);
         if (return_error == EB_ErrorInsufficientResources){
             return EB_ErrorInsufficientResources;
         }
-        return_error = EbPictureBufferDescCtor( (EB_PTR*)&contextPtr->localReferenceBlock8BITL1,  (EB_PTR)&initData);
+        return_error = EbPictureBufferDescCtor( (EB_PTR*)&contextPtr->localReferenceBlock8BITL1,  (EB_PTR)&initData, encHandle);
         if (return_error == EB_ErrorInsufficientResources){
             return EB_ErrorInsufficientResources;
         }

--- a/Source/Lib/Codec/EbMcp.h
+++ b/Source/Lib/Codec/EbMcp.h
@@ -262,7 +262,8 @@ extern EB_ERRORTYPE MotionCompensationPredictionContextCtor(
 	MotionCompensationPredictionContext_t **contextDblPtr,
 	EB_U16                                  maxCUWidth,
     EB_U16                                  maxCUHeight,
-    EB_BOOL                                 is16bit);
+    EB_BOOL                                 is16bit,
+    EB_HANDLE                               encHandle);
 
 extern void UniPredHevcInterpolationMd(
 	EbPictureBufferDesc_t *refPic,

--- a/Source/Lib/Codec/EbMdRateEstimation.c
+++ b/Source/Lib/Codec/EbMdRateEstimation.c
@@ -294,7 +294,8 @@ EB_ERRORTYPE GetSaoOffsetsFractionBits(
 }
 
 EB_ERRORTYPE MdRateEstimationContextCtor(MdRateEstimationContext_t *mdRateEstimationArray,
-                                 ContextModelEncContext_t  *cabacContextModelArray)
+                                 ContextModelEncContext_t  *cabacContextModelArray,
+                                 EB_HANDLE                  encHandle)
 {
     EB_U32                      caseIndex1;
     EB_U32                      caseIndex2;
@@ -306,7 +307,7 @@ EB_ERRORTYPE MdRateEstimationContextCtor(MdRateEstimationContext_t *mdRateEstima
     EB_U32                      cabacContextModelArrayOffset2;
     ContextModelEncContext_t   *cabacContextModelPtr;
     EB_ContextModel            *contextModelPtr;
-    EB_MALLOC(EB_ContextModel*, contextModelPtr, sizeof(EB_ContextModel), EB_N_PTR);
+    EB_MALLOC(EB_ContextModel*, contextModelPtr, sizeof(EB_ContextModel), EB_N_PTR, encHandle);
 
     // Loop over all slice types
     for(sliceIndex = 0; sliceIndex < TOTAL_NUMBER_OF_SLICE_TYPES; sliceIndex++) {

--- a/Source/Lib/Codec/EbMdRateEstimation.h
+++ b/Source/Lib/Codec/EbMdRateEstimation.h
@@ -179,7 +179,8 @@ typedef struct MdRateEstimationContext_s {
  * Extern Function Declarations
  **************************************/
 extern EB_ERRORTYPE MdRateEstimationContextCtor(MdRateEstimationContext_t *mdRateEstimationArray,
-                                        ContextModelEncContext_t  *cabacContextModelArray);
+                                        ContextModelEncContext_t  *cabacContextModelArray,
+                                        EB_HANDLE                  encHandle);
 
 extern EB_ERRORTYPE EbHevcGetMvdFractionBits(
     EB_S32                      mvdX,

--- a/Source/Lib/Codec/EbModeDecision.c
+++ b/Source/Lib/Codec/EbModeDecision.c
@@ -130,14 +130,15 @@ EB_ERRORTYPE ModeDecisionCandidateBufferCtor(
 	EB_U64                         *fastCostPtr,
 	EB_U64                         *fullCostPtr,
 	EB_U64                         *fullCostSkipPtr,
-	EB_U64                         *fullCostMergePtr)
+	EB_U64                         *fullCostMergePtr,
+    EB_HANDLE                       encHandle)
 {
 	EbPictureBufferDescInitData_t pictureBufferDescInitData;
 	EbPictureBufferDescInitData_t doubleWidthPictureBufferDescInitData;
 	EB_ERRORTYPE return_error = EB_ErrorNone;
 	// Allocate Buffer
 	ModeDecisionCandidateBuffer_t *bufferPtr;
-	EB_MALLOC(ModeDecisionCandidateBuffer_t*, bufferPtr, sizeof(ModeDecisionCandidateBuffer_t), EB_N_PTR);
+	EB_MALLOC(ModeDecisionCandidateBuffer_t*, bufferPtr, sizeof(ModeDecisionCandidateBuffer_t), EB_N_PTR, encHandle);
 	*bufferDblPtr = bufferPtr;
 
 	// Init Picture Data
@@ -169,14 +170,16 @@ EB_ERRORTYPE ModeDecisionCandidateBufferCtor(
 	// Video Buffers
 	return_error = EbPictureBufferDescCtor(
 		(EB_PTR*)&(bufferPtr->predictionPtr),
-		(EB_PTR)&pictureBufferDescInitData);
+		(EB_PTR)&pictureBufferDescInitData,
+        encHandle);
 
 	if (return_error == EB_ErrorInsufficientResources){
 		return EB_ErrorInsufficientResources;
 	}
 	return_error = EbPictureBufferDescCtor(
 		(EB_PTR*)&(bufferPtr->residualQuantCoeffPtr),
-		(EB_PTR)&doubleWidthPictureBufferDescInitData);
+		(EB_PTR)&doubleWidthPictureBufferDescInitData,
+        encHandle);
 
 	if (return_error == EB_ErrorInsufficientResources){
 		return EB_ErrorInsufficientResources;
@@ -184,14 +187,16 @@ EB_ERRORTYPE ModeDecisionCandidateBufferCtor(
 
 	return_error = EbPictureBufferDescCtor(
 		(EB_PTR*)&(bufferPtr->reconCoeffPtr),
-		(EB_PTR)&doubleWidthPictureBufferDescInitData);
+		(EB_PTR)&doubleWidthPictureBufferDescInitData,
+        encHandle);
 
 	if (return_error == EB_ErrorInsufficientResources){
 		return EB_ErrorInsufficientResources;
 	}
 	return_error = EbPictureBufferDescCtor(
 		(EB_PTR*)&(bufferPtr->reconPtr),
-		(EB_PTR)&pictureBufferDescInitData);
+		(EB_PTR)&pictureBufferDescInitData,
+        encHandle);
 
 	if (return_error == EB_ErrorInsufficientResources){
 		return EB_ErrorInsufficientResources;

--- a/Source/Lib/Codec/EbModeDecision.h
+++ b/Source/Lib/Codec/EbModeDecision.h
@@ -231,7 +231,8 @@ extern EB_ERRORTYPE ModeDecisionCandidateBufferCtor(
 		EB_U64                         *fastCostPtr,
 		EB_U64                         *fullCostPtr,
 		EB_U64                         *fullCostSkipPtr,
-		EB_U64                         *fullCostMergePtr);
+		EB_U64                         *fullCostMergePtr,
+        EB_HANDLE                     encHandle);
 
 
     EB_ERRORTYPE ProductGenerateAmvpMergeInterIntraMdCandidatesCU(

--- a/Source/Lib/Codec/EbModeDecisionConfigurationProcess.c
+++ b/Source/Lib/Codec/EbModeDecisionConfigurationProcess.c
@@ -259,11 +259,12 @@ EB_ERRORTYPE ModeDecisionConfigurationContextCtor(
     EbFifo_t                            *rateControlInputFifoPtr,
 
     EbFifo_t                            *modeDecisionConfigurationOutputFifoPtr,
-    EB_U16						         lcuTotalCount)
+    EB_U16						         lcuTotalCount,
+    EB_HANDLE                            encHandle)
 {
     ModeDecisionConfigurationContext_t *contextPtr;
 
-    EB_MALLOC(ModeDecisionConfigurationContext_t*, contextPtr, sizeof(ModeDecisionConfigurationContext_t), EB_N_PTR);
+    EB_MALLOC(ModeDecisionConfigurationContext_t*, contextPtr, sizeof(ModeDecisionConfigurationContext_t), EB_N_PTR, encHandle);
 
     *contextDblPtr = contextPtr;
 
@@ -271,12 +272,12 @@ EB_ERRORTYPE ModeDecisionConfigurationContextCtor(
     contextPtr->rateControlInputFifoPtr                      = rateControlInputFifoPtr;
     contextPtr->modeDecisionConfigurationOutputFifoPtr       = modeDecisionConfigurationOutputFifoPtr;
     // Rate estimation
-    EB_MALLOC(MdRateEstimationContext_t*, contextPtr->mdRateEstimationPtr, sizeof(MdRateEstimationContext_t), EB_N_PTR);
+    EB_MALLOC(MdRateEstimationContext_t*, contextPtr->mdRateEstimationPtr, sizeof(MdRateEstimationContext_t), EB_N_PTR, encHandle);
 
 
     // Budgeting
-    EB_MALLOC(EB_U32*,contextPtr->lcuScoreArray,sizeof(EB_U32) * lcuTotalCount, EB_N_PTR);
-    EB_MALLOC(EB_U8 *,contextPtr->lcuCostArray ,sizeof(EB_U8 ) * lcuTotalCount, EB_N_PTR);
+    EB_MALLOC(EB_U32*,contextPtr->lcuScoreArray,sizeof(EB_U32) * lcuTotalCount, EB_N_PTR, encHandle);
+    EB_MALLOC(EB_U8 *,contextPtr->lcuCostArray ,sizeof(EB_U8 ) * lcuTotalCount, EB_N_PTR, encHandle);
 
 
     return EB_ErrorNone;

--- a/Source/Lib/Codec/EbModeDecisionConfigurationProcess.h
+++ b/Source/Lib/Codec/EbModeDecisionConfigurationProcess.h
@@ -72,7 +72,6 @@ typedef struct ModeDecisionConfigurationContext_s
     // Multi - Mode signal(s)
     EB_U8                               adpLevel;
     EB_U8                               chromaQpOffsetLevel;
-
 } ModeDecisionConfigurationContext_t;
 
 
@@ -85,7 +84,8 @@ extern EB_ERRORTYPE ModeDecisionConfigurationContextCtor(
     EbFifo_t                            *rateControlInputFifoPtr,
 
     EbFifo_t                            *modeDecisionConfigurationOutputFifoPtr,
-    EB_U16						         lcuTotalCount);
+    EB_U16						         lcuTotalCount,
+    EB_HANDLE                            encHandle);
 
    
 extern void* ModeDecisionConfigurationKernel(void *inputPtr);

--- a/Source/Lib/Codec/EbModeDecisionProcess.h
+++ b/Source/Lib/Codec/EbModeDecisionProcess.h
@@ -290,7 +290,8 @@ extern EB_ERRORTYPE ModeDecisionContextCtor(
     ModeDecisionContext_t  **contextDblPtr,
     EbFifo_t                *modeDecisionConfigurationInputFifoPtr,
     EbFifo_t                *modeDecisionOutputFifoPtr,
-    EB_BOOL                  is16bit);
+    EB_BOOL                  is16bit,
+    EB_HANDLE                encHandle);
 
 
 //extern void ResetModeDecisionNeighborArrays(

--- a/Source/Lib/Codec/EbMotionEstimationContext.c
+++ b/Source/Lib/Codec/EbMotionEstimationContext.c
@@ -26,14 +26,15 @@ void EbHevcMotionEstimetionPredUnitCtor(
 
 
 EB_ERRORTYPE MeContextCtor(
-    MeContext_t     **objectDblPtr)
+    MeContext_t     **objectDblPtr,
+    EB_HANDLE         encHandle)
 {
     EB_U32                   listIndex;
     EB_U32                   refPicIndex;
     EB_U32                   puIndex;
     EB_U32                   meCandidateIndex;
 
-    EB_MALLOC(MeContext_t*, *objectDblPtr, sizeof(MeContext_t), EB_N_PTR);
+    EB_MALLOC(MeContext_t*, *objectDblPtr, sizeof(MeContext_t), EB_N_PTR, encHandle);
 
     (*objectDblPtr)->updateHmeSearchCenter = EB_FALSE;
     (*objectDblPtr)->xMvOffset = 0;
@@ -41,25 +42,25 @@ EB_ERRORTYPE MeContextCtor(
 
     // Intermediate LCU-sized buffer to retain the input samples
     (*objectDblPtr)->lcuBufferStride                = MAX_LCU_SIZE;
-    EB_ALLIGN_MALLOC(EB_U8 *, (*objectDblPtr)->lcuBuffer, sizeof(EB_U8) * MAX_LCU_SIZE * (*objectDblPtr)->lcuBufferStride, EB_A_PTR);
+    EB_ALLIGN_MALLOC(EB_U8 *, (*objectDblPtr)->lcuBuffer, sizeof(EB_U8) * MAX_LCU_SIZE * (*objectDblPtr)->lcuBufferStride, EB_A_PTR, encHandle);
 
     (*objectDblPtr)->hmeLcuBufferStride             = (MAX_LCU_SIZE + HME_DECIM_FILTER_TAP - 1);
-    EB_MALLOC(EB_U8 *, (*objectDblPtr)->hmeLcuBuffer, sizeof(EB_U8) * (MAX_LCU_SIZE + HME_DECIM_FILTER_TAP - 1) * (*objectDblPtr)->hmeLcuBufferStride, EB_N_PTR);
+    EB_MALLOC(EB_U8 *, (*objectDblPtr)->hmeLcuBuffer, sizeof(EB_U8) * (MAX_LCU_SIZE + HME_DECIM_FILTER_TAP - 1) * (*objectDblPtr)->hmeLcuBufferStride, EB_N_PTR, encHandle);
 
     (*objectDblPtr)->quarterLcuBufferStride         = (MAX_LCU_SIZE >> 1);
-    EB_MALLOC(EB_U8 *, (*objectDblPtr)->quarterLcuBuffer, sizeof(EB_U8) * (MAX_LCU_SIZE >> 1) * (*objectDblPtr)->quarterLcuBufferStride, EB_N_PTR);
+    EB_MALLOC(EB_U8 *, (*objectDblPtr)->quarterLcuBuffer, sizeof(EB_U8) * (MAX_LCU_SIZE >> 1) * (*objectDblPtr)->quarterLcuBufferStride, EB_N_PTR, encHandle);
 
     (*objectDblPtr)->sixteenthLcuBufferStride       = (MAX_LCU_SIZE >> 2);
-    EB_ALLIGN_MALLOC(EB_U8 *, (*objectDblPtr)->sixteenthLcuBuffer, sizeof(EB_U8) * (MAX_LCU_SIZE >> 2) * (*objectDblPtr)->sixteenthLcuBufferStride, EB_A_PTR);
+    EB_ALLIGN_MALLOC(EB_U8 *, (*objectDblPtr)->sixteenthLcuBuffer, sizeof(EB_U8) * (MAX_LCU_SIZE >> 2) * (*objectDblPtr)->sixteenthLcuBufferStride, EB_A_PTR, encHandle);
 
     (*objectDblPtr)->interpolatedStride             = MAX_SEARCH_AREA_WIDTH;
-    EB_MALLOC(EB_U8 *, (*objectDblPtr)->hmeBuffer, sizeof(EB_U8) * (*objectDblPtr)->interpolatedStride * MAX_SEARCH_AREA_HEIGHT, EB_N_PTR);
+    EB_MALLOC(EB_U8 *, (*objectDblPtr)->hmeBuffer, sizeof(EB_U8) * (*objectDblPtr)->interpolatedStride * MAX_SEARCH_AREA_HEIGHT, EB_N_PTR, encHandle);
 
     (*objectDblPtr)->hmeBufferStride                = MAX_SEARCH_AREA_WIDTH;
 
     EB_MEMSET((*objectDblPtr)->lcuBuffer, 0 , sizeof(EB_U8) * MAX_LCU_SIZE * (*objectDblPtr)->lcuBufferStride);
     EB_MEMSET((*objectDblPtr)->hmeLcuBuffer, 0 ,sizeof(EB_U8) * (MAX_LCU_SIZE + HME_DECIM_FILTER_TAP - 1) * (*objectDblPtr)->hmeLcuBufferStride);
-	EB_MALLOC(EB_BitFraction *, (*objectDblPtr)->mvdBitsArray, sizeof(EB_BitFraction) * NUMBER_OF_MVD_CASES, EB_N_PTR);
+	EB_MALLOC(EB_BitFraction *, (*objectDblPtr)->mvdBitsArray, sizeof(EB_BitFraction) * NUMBER_OF_MVD_CASES, EB_N_PTR, encHandle);
     // 15 intermediate buffers to retain the interpolated reference samples
 
     //      0    1    2    3
@@ -105,21 +106,21 @@ EB_ERRORTYPE MeContextCtor(
 
         for( refPicIndex = 0; refPicIndex < MAX_REF_IDX; refPicIndex++) {
 
-            EB_MALLOC(EB_U8 *, (*objectDblPtr)->integerBuffer[listIndex][refPicIndex], sizeof(EB_U8) * (*objectDblPtr)->interpolatedStride * MAX_SEARCH_AREA_HEIGHT, EB_N_PTR);
+            EB_MALLOC(EB_U8 *, (*objectDblPtr)->integerBuffer[listIndex][refPicIndex], sizeof(EB_U8) * (*objectDblPtr)->interpolatedStride * MAX_SEARCH_AREA_HEIGHT, EB_N_PTR, encHandle);
 
-            EB_MALLOC(EB_U8 *, (*objectDblPtr)->posbBuffer[listIndex][refPicIndex], sizeof(EB_U8) * (*objectDblPtr)->interpolatedStride * MAX_SEARCH_AREA_HEIGHT, EB_N_PTR);
+            EB_MALLOC(EB_U8 *, (*objectDblPtr)->posbBuffer[listIndex][refPicIndex], sizeof(EB_U8) * (*objectDblPtr)->interpolatedStride * MAX_SEARCH_AREA_HEIGHT, EB_N_PTR, encHandle);
 
-            EB_MALLOC(EB_U8 *, (*objectDblPtr)->poshBuffer[listIndex][refPicIndex], sizeof(EB_U8) * (*objectDblPtr)->interpolatedStride * MAX_SEARCH_AREA_HEIGHT, EB_N_PTR);
+            EB_MALLOC(EB_U8 *, (*objectDblPtr)->poshBuffer[listIndex][refPicIndex], sizeof(EB_U8) * (*objectDblPtr)->interpolatedStride * MAX_SEARCH_AREA_HEIGHT, EB_N_PTR, encHandle);
 
-            EB_MALLOC(EB_U8 *, (*objectDblPtr)->posjBuffer[listIndex][refPicIndex], sizeof(EB_U8) * (*objectDblPtr)->interpolatedStride * MAX_SEARCH_AREA_HEIGHT, EB_N_PTR);
+            EB_MALLOC(EB_U8 *, (*objectDblPtr)->posjBuffer[listIndex][refPicIndex], sizeof(EB_U8) * (*objectDblPtr)->interpolatedStride * MAX_SEARCH_AREA_HEIGHT, EB_N_PTR, encHandle);
 
         }
 
     }
 
-    EB_MALLOC(EB_BYTE, (*objectDblPtr)->oneDIntermediateResultsBuf0, sizeof(EB_U8)*MAX_LCU_SIZE*MAX_LCU_SIZE, EB_N_PTR);
+    EB_MALLOC(EB_BYTE, (*objectDblPtr)->oneDIntermediateResultsBuf0, sizeof(EB_U8)*MAX_LCU_SIZE*MAX_LCU_SIZE, EB_N_PTR, encHandle);
 
-    EB_MALLOC(EB_BYTE, (*objectDblPtr)->oneDIntermediateResultsBuf1, sizeof(EB_U8)*MAX_LCU_SIZE*MAX_LCU_SIZE, EB_N_PTR);
+    EB_MALLOC(EB_BYTE, (*objectDblPtr)->oneDIntermediateResultsBuf1, sizeof(EB_U8)*MAX_LCU_SIZE*MAX_LCU_SIZE, EB_N_PTR, encHandle);
 
     for(puIndex= 0; puIndex < MAX_ME_PU_COUNT; puIndex++) {
         for( meCandidateIndex = 0; meCandidateIndex < MAX_ME_CANDIDATE_PER_PU; meCandidateIndex++) {
@@ -127,9 +128,9 @@ EB_ERRORTYPE MeContextCtor(
         }
     }
 
-    EB_MALLOC(EB_U8 *, (*objectDblPtr)->avctempBuffer, sizeof(EB_U8) * (*objectDblPtr)->interpolatedStride * MAX_SEARCH_AREA_HEIGHT, EB_N_PTR);
+    EB_MALLOC(EB_U8 *, (*objectDblPtr)->avctempBuffer, sizeof(EB_U8) * (*objectDblPtr)->interpolatedStride * MAX_SEARCH_AREA_HEIGHT, EB_N_PTR, encHandle);
 
-    EB_MALLOC(EB_U16 *, (*objectDblPtr)->pEightPosSad16x16, sizeof(EB_U16) * 8 * 16, EB_N_PTR);//16= 16 16x16 blocks in a LCU.       8=8search points
+    EB_MALLOC(EB_U16 *, (*objectDblPtr)->pEightPosSad16x16, sizeof(EB_U16) * 8 * 16, EB_N_PTR, encHandle);//16= 16 16x16 blocks in a LCU.       8=8search points
 
     return EB_ErrorNone;
 }

--- a/Source/Lib/Codec/EbMotionEstimationContext.h
+++ b/Source/Lib/Codec/EbMotionEstimationContext.h
@@ -466,7 +466,8 @@ typedef struct MeContext_s {
 } MeContext_t;
 
 extern EB_ERRORTYPE MeContextCtor(
-    MeContext_t     **objectDblPtr);
+    MeContext_t     **objectDblPtr,
+    EB_HANDLE         encHandle);
     
 #ifdef __cplusplus
 }

--- a/Source/Lib/Codec/EbMotionEstimationProcess.c
+++ b/Source/Lib/Codec/EbMotionEstimationProcess.c
@@ -145,21 +145,22 @@ static void SetMeHmeParamsFromConfig(
 EB_ERRORTYPE MotionEstimationContextCtor(
 	MotionEstimationContext_t   **contextDblPtr,
 	EbFifo_t                     *pictureDecisionResultsInputFifoPtr,
-	EbFifo_t                     *motionEstimationResultsOutputFifoPtr) {
+	EbFifo_t                     *motionEstimationResultsOutputFifoPtr,
+    EB_HANDLE                     encHandle) {
 
 	EB_ERRORTYPE return_error = EB_ErrorNone;
 	MotionEstimationContext_t *contextPtr;
-	EB_MALLOC(MotionEstimationContext_t*, contextPtr, sizeof(MotionEstimationContext_t), EB_N_PTR);
+	EB_MALLOC(MotionEstimationContext_t*, contextPtr, sizeof(MotionEstimationContext_t), EB_N_PTR, encHandle);
 
 	*contextDblPtr = contextPtr;
 
 	contextPtr->pictureDecisionResultsInputFifoPtr = pictureDecisionResultsInputFifoPtr;
 	contextPtr->motionEstimationResultsOutputFifoPtr = motionEstimationResultsOutputFifoPtr;
-	return_error = IntraOpenLoopReferenceSamplesCtor(&contextPtr->intraRefPtr);
+	return_error = IntraOpenLoopReferenceSamplesCtor(&contextPtr->intraRefPtr, encHandle);
 	if (return_error == EB_ErrorInsufficientResources){
 		return EB_ErrorInsufficientResources;
 	}
-	return_error = MeContextCtor(&(contextPtr->meContextPtr));
+	return_error = MeContextCtor(&(contextPtr->meContextPtr), encHandle);
 	if (return_error == EB_ErrorInsufficientResources){
 		return EB_ErrorInsufficientResources;
 	}

--- a/Source/Lib/Codec/EbMotionEstimationProcess.h
+++ b/Source/Lib/Codec/EbMotionEstimationProcess.h
@@ -31,7 +31,6 @@ typedef struct MotionEstimationContext_s
     EB_BOOL                          oisKernelLevel;                // used by P/B Slices
     EB_U8                            oisThSet;                      // used by P/B Slices
     EB_BOOL                          setBestOisDistortionToValid;   // used by I/P/B Slices
-
 } MotionEstimationContext_t;
 
 /***************************************
@@ -40,7 +39,8 @@ typedef struct MotionEstimationContext_s
 extern EB_ERRORTYPE MotionEstimationContextCtor(
 	MotionEstimationContext_t   **contextDblPtr,
 	EbFifo_t                     *pictureDecisionResultsInputFifoPtr,
-	EbFifo_t                     *motionEstimationResultsOutputFifoPtr);
+	EbFifo_t                     *motionEstimationResultsOutputFifoPtr,
+    EB_HANDLE                     encHandle);
 
 
 extern void* MotionEstimationKernel(void *inputPtr);  

--- a/Source/Lib/Codec/EbMotionEstimationResults.c
+++ b/Source/Lib/Codec/EbMotionEstimationResults.c
@@ -10,10 +10,11 @@
 
 EB_ERRORTYPE MotionEstimationResultsCtor(
     EB_PTR *objectDblPtr,
-    EB_PTR objectInitDataPtr)
+    EB_PTR objectInitDataPtr,
+    EB_HANDLE encHandle)
 {
     MotionEstimationResults_t *contextPtr;
-    EB_MALLOC(MotionEstimationResults_t*, contextPtr, sizeof(MotionEstimationResults_t), EB_N_PTR);
+    EB_MALLOC(MotionEstimationResults_t*, contextPtr, sizeof(MotionEstimationResults_t), EB_N_PTR, encHandle);
     
     *objectDblPtr = (EB_PTR) contextPtr;
     objectInitDataPtr = 0;

--- a/Source/Lib/Codec/EbMotionEstimationResults.h
+++ b/Source/Lib/Codec/EbMotionEstimationResults.h
@@ -30,7 +30,8 @@ typedef struct MotionEstimationResultsInitData_s
  **************************************/
 extern EB_ERRORTYPE MotionEstimationResultsCtor(
     EB_PTR *objectDblPtr, 
-    EB_PTR objectInitDataPtr);
+    EB_PTR objectInitDataPtr,
+    EB_HANDLE encHandle);
 
 
 #ifdef __cplusplus

--- a/Source/Lib/Codec/EbNeighborArrays.c
+++ b/Source/Lib/Codec/EbNeighborArrays.c
@@ -19,10 +19,12 @@ EB_ERRORTYPE NeighborArrayUnitCtor(
     EB_U32   unitSize,
     EB_U32   granularityNormal,
     EB_U32   granularityTopLeft,
-    EB_U32   typeMask)
+    EB_U32   typeMask,
+    EB_HANDLE encHandle)
 {
     NeighborArrayUnit_t *naUnitPtr;
-    EB_MALLOC(NeighborArrayUnit_t*, naUnitPtr, sizeof(NeighborArrayUnit_t), EB_N_PTR);
+
+    EB_MALLOC(NeighborArrayUnit_t*, naUnitPtr, sizeof(NeighborArrayUnit_t), EB_N_PTR, encHandle);
     
     *naUnitDblPtr = naUnitPtr;
     naUnitPtr->unitSize                 = (EB_U8)(unitSize);
@@ -35,21 +37,21 @@ EB_ERRORTYPE NeighborArrayUnitCtor(
     naUnitPtr->topLeftArraySize         = (EB_U16)((typeMask & NEIGHBOR_ARRAY_UNIT_TOPLEFT_MASK) ? (maxPictureWidth + maxPictureHeight) >> naUnitPtr->granularityTopLeftLog2 : 0);
 
     if(naUnitPtr->leftArraySize) {
-        EB_MALLOC(EB_U8*, naUnitPtr->leftArray, naUnitPtr->unitSize * naUnitPtr->leftArraySize, EB_N_PTR);
+        EB_MALLOC(EB_U8*, naUnitPtr->leftArray, naUnitPtr->unitSize * naUnitPtr->leftArraySize, EB_N_PTR, encHandle);
     }
     else {
         naUnitPtr->leftArray = (EB_U8*) EB_NULL;
     }
 
     if(naUnitPtr->topArraySize) {
-        EB_MALLOC(EB_U8*, naUnitPtr->topArray, naUnitPtr->unitSize * naUnitPtr->topArraySize, EB_N_PTR);
+        EB_MALLOC(EB_U8*, naUnitPtr->topArray, naUnitPtr->unitSize * naUnitPtr->topArraySize, EB_N_PTR, encHandle);
     }
     else {
         naUnitPtr->topArray = (EB_U8*) EB_NULL;
     }
 
     if(naUnitPtr->topLeftArraySize) {
-        EB_MALLOC(EB_U8*, naUnitPtr->topLeftArray, naUnitPtr->unitSize * naUnitPtr->topLeftArraySize, EB_N_PTR);
+        EB_MALLOC(EB_U8*, naUnitPtr->topLeftArray, naUnitPtr->unitSize * naUnitPtr->topLeftArraySize, EB_N_PTR, encHandle);
     }
     else {
         naUnitPtr->topLeftArray = (EB_U8*) EB_NULL;

--- a/Source/Lib/Codec/EbNeighborArrays.h
+++ b/Source/Lib/Codec/EbNeighborArrays.h
@@ -57,7 +57,8 @@ extern EB_ERRORTYPE NeighborArrayUnitCtor(
     EB_U32   unitSize,          
     EB_U32   granularityNormal,
     EB_U32   granularityTopLeft,
-    EB_U32   typeMask);
+    EB_U32   typeMask,
+    EB_HANDLE encHandle);
 
 extern void NeighborArrayUnitDtor(NeighborArrayUnit_t  *naUnitPtr);
 

--- a/Source/Lib/Codec/EbPacketizationProcess.c
+++ b/Source/Lib/Codec/EbPacketizationProcess.c
@@ -97,18 +97,19 @@ EB_ERRORTYPE PacketizationContextCtor(
     PacketizationContext_t **contextDblPtr,
     EbFifo_t                *entropyCodingInputFifoPtr,
     EbFifo_t                *rateControlTasksOutputFifoPtr,
-    EbFifo_t                *pictureManagerOutputFifoPtr
+    EbFifo_t                *pictureManagerOutputFifoPtr,
+    EB_HANDLE                encHandle
 )
 {
     PacketizationContext_t *contextPtr;
-    EB_MALLOC(PacketizationContext_t*, contextPtr, sizeof(PacketizationContext_t), EB_N_PTR);
+    EB_MALLOC(PacketizationContext_t*, contextPtr, sizeof(PacketizationContext_t), EB_N_PTR, encHandle);
     *contextDblPtr = contextPtr;
 
     contextPtr->entropyCodingInputFifoPtr      = entropyCodingInputFifoPtr;
     contextPtr->rateControlTasksOutputFifoPtr  = rateControlTasksOutputFifoPtr;
     contextPtr->pictureManagerOutputFifoPtr    = pictureManagerOutputFifoPtr;
 
-    EB_MALLOC(EbPPSConfig_t*, contextPtr->ppsConfig, sizeof(EbPPSConfig_t), EB_N_PTR);
+    EB_MALLOC(EbPPSConfig_t*, contextPtr->ppsConfig, sizeof(EbPPSConfig_t), EB_N_PTR, encHandle);
 
 	return EB_ErrorNone;
 }

--- a/Source/Lib/Codec/EbPacketizationProcess.h
+++ b/Source/Lib/Codec/EbPacketizationProcess.h
@@ -31,7 +31,6 @@ typedef struct PacketizationContext_s
     EbFifo_t                *rateControlTasksOutputFifoPtr;
     EbPPSConfig_t           *ppsConfig;
     EbFifo_t                *pictureManagerOutputFifoPtr;   // to picture-manager
-    
 } PacketizationContext_t;
 
 /**************************************
@@ -41,7 +40,8 @@ extern EB_ERRORTYPE PacketizationContextCtor(
     PacketizationContext_t **contextDblPtr,
     EbFifo_t                *entropyCodingInputFifoPtr,
     EbFifo_t                *rateControlTasksOutputFifoPtr,
-    EbFifo_t                *pictureManagerOutputFifoPtr
+    EbFifo_t                *pictureManagerOutputFifoPtr,
+    EB_HANDLE                encHandle
 );
     
     

--- a/Source/Lib/Codec/EbPacketizationReorderQueue.c
+++ b/Source/Lib/Codec/EbPacketizationReorderQueue.c
@@ -8,9 +8,10 @@
 #include "EbPictureControlSet.h"
 
 EB_ERRORTYPE PicTimingCtor(
-    PicTimingEntry_t*   *entryPtr)
+    PicTimingEntry_t*   *entryPtr,
+    EB_HANDLE            encHandle)
 {
-    EB_MALLOC(PicTimingEntry_t*, *entryPtr, sizeof(PicTimingEntry_t), EB_N_PTR);
+    EB_MALLOC(PicTimingEntry_t*, *entryPtr, sizeof(PicTimingEntry_t), EB_N_PTR, encHandle);
     (*entryPtr)->picStruct = 0;
     (*entryPtr)->temporalId = 0;
     (*entryPtr)->decodeOrder = 0;
@@ -18,15 +19,18 @@ EB_ERRORTYPE PicTimingCtor(
 }
 EB_ERRORTYPE PacketizationReorderEntryCtor(
     PacketizationReorderEntry_t   **entryDblPtr,
-    EB_U32                          pictureNumber)
+    EB_U32                          pictureNumber,
+    EB_HANDLE                       encHandle)
 {
     EB_ERRORTYPE return_error = EB_ErrorNone;
-    EB_MALLOC(PacketizationReorderEntry_t*, *entryDblPtr, sizeof(PacketizationReorderEntry_t), EB_N_PTR);
+    EB_MALLOC(PacketizationReorderEntry_t*, *entryDblPtr, sizeof(PacketizationReorderEntry_t), EB_N_PTR, encHandle);
     return_error = PicTimingCtor(
-        &(*entryDblPtr)->picTimingEntry);
+        &(*entryDblPtr)->picTimingEntry,
+        encHandle);
     return_error = BitstreamCtor(
         &(*entryDblPtr)->bitStreamPtr2,
-        PACKETIZATION_PROCESS_BUFFER_SIZE);
+        PACKETIZATION_PROCESS_BUFFER_SIZE,
+        encHandle);
     (*entryDblPtr)->pictureNumber                   = pictureNumber;
     (*entryDblPtr)->outputStreamWrapperPtr          = (EbObjectWrapper_t *)EB_NULL;
     (*entryDblPtr)->startSplicing = 0;

--- a/Source/Lib/Codec/EbPacketizationReorderQueue.h
+++ b/Source/Lib/Codec/EbPacketizationReorderQueue.h
@@ -41,7 +41,8 @@ typedef struct PacketizationReorderEntry_s {
 
 extern EB_ERRORTYPE PacketizationReorderEntryCtor(   
     PacketizationReorderEntry_t   **entryDblPtr,
-    EB_U32                          pictureNumber);
+    EB_U32                          pictureNumber,
+    EB_HANDLE                       encHandle);
 
   
 #ifdef __cplusplus

--- a/Source/Lib/Codec/EbPictureAnalysisProcess.c
+++ b/Source/Lib/Codec/EbPictureAnalysisProcess.c
@@ -48,10 +48,12 @@ EB_ERRORTYPE PictureAnalysisContextCtor(
     PictureAnalysisContext_t      **contextDblPtr,
     EbFifo_t                       *resourceCoordinationResultsInputFifoPtr,
     EbFifo_t                       *pictureAnalysisResultsOutputFifoPtr,
-    EB_U16						    lcuTotalCount)
+    EB_U16						    lcuTotalCount,
+    EB_HANDLE                       encHandle)
 {
 	PictureAnalysisContext_t *contextPtr;
-	EB_MALLOC(PictureAnalysisContext_t*, contextPtr, sizeof(PictureAnalysisContext_t), EB_N_PTR);
+
+	EB_MALLOC(PictureAnalysisContext_t*, contextPtr, sizeof(PictureAnalysisContext_t), EB_N_PTR, encHandle);
 	*contextDblPtr = contextPtr;
 
 	contextPtr->resourceCoordinationResultsInputFifoPtr = resourceCoordinationResultsInputFifoPtr;
@@ -72,7 +74,8 @@ EB_ERRORTYPE PictureAnalysisContextCtor(
 
 		return_error = EbPictureBufferDescCtor(
 			(EB_PTR*)&(contextPtr->denoisedPicturePtr),
-			(EB_PTR)inputPictureBufferDescInitData);
+			(EB_PTR)inputPictureBufferDescInitData,
+            encHandle);
 
 		if (return_error == EB_ErrorInsufficientResources){
 			return EB_ErrorInsufficientResources;
@@ -91,16 +94,17 @@ EB_ERRORTYPE PictureAnalysisContextCtor(
 
 		return_error = EbPictureBufferDescCtor(
 			(EB_PTR*)&(contextPtr->noisePicturePtr),
-			(EB_PTR)inputPictureBufferDescInitData);
+			(EB_PTR)inputPictureBufferDescInitData,
+            encHandle);
 
 		if (return_error == EB_ErrorInsufficientResources){
 			return EB_ErrorInsufficientResources;
 		}
 	}
 
-    EB_MALLOC(EB_U16**, contextPtr->grad, sizeof(EB_U16*) * lcuTotalCount, EB_N_PTR);
+    EB_MALLOC(EB_U16**, contextPtr->grad, sizeof(EB_U16*) * lcuTotalCount, EB_N_PTR, encHandle);
     for (EB_U16 lcuIndex = 0; lcuIndex < lcuTotalCount; ++lcuIndex) {
-        EB_MALLOC(EB_U16*, contextPtr->grad[lcuIndex], sizeof(EB_U16) * CU_MAX_COUNT, EB_N_PTR);
+        EB_MALLOC(EB_U16*, contextPtr->grad[lcuIndex], sizeof(EB_U16) * CU_MAX_COUNT, EB_N_PTR, encHandle);
     }
 
 

--- a/Source/Lib/Codec/EbPictureAnalysisProcess.h
+++ b/Source/Lib/Codec/EbPictureAnalysisProcess.h
@@ -36,7 +36,8 @@ extern EB_ERRORTYPE PictureAnalysisContextCtor(
     PictureAnalysisContext_t      **contextDblPtr,
     EbFifo_t                       *resourceCoordinationResultsInputFifoPtr,
     EbFifo_t                       *pictureAnalysisResultsOutputFifoPtr,
-    EB_U16						    lcuTotalCount);
+    EB_U16						    lcuTotalCount,
+    EB_HANDLE                       encHandle);
     
 extern void* PictureAnalysisKernel(void *inputPtr);
 

--- a/Source/Lib/Codec/EbPictureAnalysisResults.c
+++ b/Source/Lib/Codec/EbPictureAnalysisResults.c
@@ -9,10 +9,11 @@
 
 EB_ERRORTYPE PictureAnalysisResultCtor(
     EB_PTR *objectDblPtr, 
-    EB_PTR objectInitDataPtr)
+    EB_PTR objectInitDataPtr,
+    EB_HANDLE encHandle)
 {
     PictureAnalysisResults_t *objectPtr;
-    EB_MALLOC(PictureAnalysisResults_t *, objectPtr, sizeof(PictureAnalysisResults_t), EB_N_PTR);
+    EB_MALLOC(PictureAnalysisResults_t *, objectPtr, sizeof(PictureAnalysisResults_t), EB_N_PTR, encHandle);
 
     *objectDblPtr = (EB_PTR) objectPtr;
     objectInitDataPtr = 0;

--- a/Source/Lib/Codec/EbPictureAnalysisResults.h
+++ b/Source/Lib/Codec/EbPictureAnalysisResults.h
@@ -30,7 +30,8 @@ typedef struct PictureAnalysisResultInitData_s
  **************************************/
 extern EB_ERRORTYPE PictureAnalysisResultCtor(
     EB_PTR *objectDblPtr, 
-    EB_PTR objectInitDataPtr);
+    EB_PTR objectInitDataPtr,
+    EB_HANDLE encHandle);
 
    
 #ifdef __cplusplus

--- a/Source/Lib/Codec/EbPictureBufferDesc.c
+++ b/Source/Lib/Codec/EbPictureBufferDesc.c
@@ -15,14 +15,15 @@
  *****************************************/
 EB_ERRORTYPE EbPictureBufferDescCtor(
     EB_PTR  *objectDblPtr,
-    EB_PTR   objectInitDataPtr)
+    EB_PTR   objectInitDataPtr,
+    EB_HANDLE encHandle)
 {
     EbPictureBufferDesc_t          *pictureBufferDescPtr;
     EbPictureBufferDescInitData_t  *pictureBufferDescInitDataPtr = (EbPictureBufferDescInitData_t*) objectInitDataPtr;
 
     EB_U32 bytesPerPixel = (pictureBufferDescInitDataPtr->bitDepth == EB_8BIT) ? 1 : 2;
     
-    EB_MALLOC(EbPictureBufferDesc_t*, pictureBufferDescPtr, sizeof(EbPictureBufferDesc_t), EB_N_PTR);
+    EB_MALLOC(EbPictureBufferDesc_t*, pictureBufferDescPtr, sizeof(EbPictureBufferDesc_t), EB_N_PTR, encHandle);
 
     // Allocate the PictureBufferDesc Object
     *objectDblPtr       = (EB_PTR) pictureBufferDescPtr;
@@ -61,11 +62,11 @@ EB_ERRORTYPE EbPictureBufferDescCtor(
 
     // Allocate the Picture Buffers (luma & chroma)
     if(pictureBufferDescInitDataPtr->bufferEnableMask & PICTURE_BUFFER_DESC_Y_FLAG) {
-        EB_ALLIGN_MALLOC(EB_BYTE, pictureBufferDescPtr->bufferY, pictureBufferDescPtr->lumaSize      * bytesPerPixel * sizeof(EB_U8), EB_A_PTR);
+        EB_ALLIGN_MALLOC(EB_BYTE, pictureBufferDescPtr->bufferY, pictureBufferDescPtr->lumaSize      * bytesPerPixel * sizeof(EB_U8), EB_A_PTR, encHandle);
         //pictureBufferDescPtr->bufferY = (EB_BYTE) EB_aligned_malloc( pictureBufferDescPtr->lumaSize      * bytesPerPixel * sizeof(EB_U8),ALVALUE);
         pictureBufferDescPtr->bufferBitIncY = 0;
         if(pictureBufferDescInitDataPtr->splitMode == EB_TRUE ) {
-            EB_ALLIGN_MALLOC(EB_BYTE, pictureBufferDescPtr->bufferBitIncY, pictureBufferDescPtr->lumaSize      * bytesPerPixel * sizeof(EB_U8), EB_A_PTR);
+            EB_ALLIGN_MALLOC(EB_BYTE, pictureBufferDescPtr->bufferBitIncY, pictureBufferDescPtr->lumaSize      * bytesPerPixel * sizeof(EB_U8), EB_A_PTR, encHandle);
             //pictureBufferDescPtr->bufferBitIncY = (EB_BYTE) EB_aligned_malloc( pictureBufferDescPtr->lumaSize      * bytesPerPixel * sizeof(EB_U8),ALVALUE);
         }
     }
@@ -75,11 +76,11 @@ EB_ERRORTYPE EbPictureBufferDescCtor(
     }
 
     if(pictureBufferDescInitDataPtr->bufferEnableMask & PICTURE_BUFFER_DESC_Cb_FLAG) {
-        EB_ALLIGN_MALLOC(EB_BYTE, pictureBufferDescPtr->bufferCb, pictureBufferDescPtr->chromaSize    * bytesPerPixel * sizeof(EB_U8), EB_A_PTR);
+        EB_ALLIGN_MALLOC(EB_BYTE, pictureBufferDescPtr->bufferCb, pictureBufferDescPtr->chromaSize    * bytesPerPixel * sizeof(EB_U8), EB_A_PTR, encHandle);
         //pictureBufferDescPtr->bufferCb = (EB_BYTE) EB_aligned_malloc(pictureBufferDescPtr->chromaSize    * bytesPerPixel * sizeof(EB_U8),ALVALUE);
         pictureBufferDescPtr->bufferBitIncCb = 0;
         if(pictureBufferDescInitDataPtr->splitMode == EB_TRUE ) {
-            EB_ALLIGN_MALLOC(EB_BYTE, pictureBufferDescPtr->bufferBitIncCb, pictureBufferDescPtr->chromaSize      * bytesPerPixel * sizeof(EB_U8), EB_A_PTR);
+            EB_ALLIGN_MALLOC(EB_BYTE, pictureBufferDescPtr->bufferBitIncCb, pictureBufferDescPtr->chromaSize      * bytesPerPixel * sizeof(EB_U8), EB_A_PTR, encHandle);
             //pictureBufferDescPtr->bufferBitIncCb = (EB_BYTE) EB_aligned_malloc(pictureBufferDescPtr->chromaSize    * bytesPerPixel * sizeof(EB_U8),ALVALUE);
         }
     }
@@ -89,11 +90,11 @@ EB_ERRORTYPE EbPictureBufferDescCtor(
     }
 
     if(pictureBufferDescInitDataPtr->bufferEnableMask & PICTURE_BUFFER_DESC_Cr_FLAG) {
-        EB_ALLIGN_MALLOC(EB_BYTE, pictureBufferDescPtr->bufferCr, pictureBufferDescPtr->chromaSize    * bytesPerPixel * sizeof(EB_U8), EB_A_PTR);
+        EB_ALLIGN_MALLOC(EB_BYTE, pictureBufferDescPtr->bufferCr, pictureBufferDescPtr->chromaSize    * bytesPerPixel * sizeof(EB_U8), EB_A_PTR, encHandle);
         //pictureBufferDescPtr->bufferCr = (EB_BYTE) EB_aligned_malloc(pictureBufferDescPtr->chromaSize    * bytesPerPixel * sizeof(EB_U8),ALVALUE);
         pictureBufferDescPtr->bufferBitIncCr = 0;
         if(pictureBufferDescInitDataPtr->splitMode == EB_TRUE ) {
-            EB_ALLIGN_MALLOC(EB_BYTE, pictureBufferDescPtr->bufferBitIncCr, pictureBufferDescPtr->chromaSize      * bytesPerPixel * sizeof(EB_U8), EB_A_PTR);
+            EB_ALLIGN_MALLOC(EB_BYTE, pictureBufferDescPtr->bufferBitIncCr, pictureBufferDescPtr->chromaSize      * bytesPerPixel * sizeof(EB_U8), EB_A_PTR, encHandle);
             //pictureBufferDescPtr->bufferBitIncCr = (EB_BYTE) EB_aligned_malloc(pictureBufferDescPtr->chromaSize    * bytesPerPixel * sizeof(EB_U8),ALVALUE);
         }
     }
@@ -114,14 +115,15 @@ EB_ERRORTYPE EbPictureBufferDescCtor(
  *****************************************/
 EB_ERRORTYPE EbReconPictureBufferDescCtor(
     EB_PTR  *objectDblPtr,
-    EB_PTR   objectInitDataPtr)
+    EB_PTR   objectInitDataPtr,
+    EB_HANDLE encHandle)
 {
     EbPictureBufferDesc_t          *pictureBufferDescPtr;
     EbPictureBufferDescInitData_t  *pictureBufferDescInitDataPtr = (EbPictureBufferDescInitData_t*) objectInitDataPtr;
 
     EB_U32 bytesPerPixel = (pictureBufferDescInitDataPtr->bitDepth == EB_8BIT) ? 1 : 2;
 
-    EB_MALLOC(EbPictureBufferDesc_t*, pictureBufferDescPtr, sizeof(EbPictureBufferDesc_t), EB_N_PTR);
+    EB_MALLOC(EbPictureBufferDesc_t*, pictureBufferDescPtr, sizeof(EbPictureBufferDesc_t), EB_N_PTR, encHandle);
 
     // Allocate the PictureBufferDesc Object
     *objectDblPtr       = (EB_PTR) pictureBufferDescPtr;
@@ -150,7 +152,7 @@ EB_ERRORTYPE EbReconPictureBufferDescCtor(
 
     // Allocate the Picture Buffers (luma & chroma)
     if(pictureBufferDescInitDataPtr->bufferEnableMask & PICTURE_BUFFER_DESC_Y_FLAG) {
-        EB_CALLOC(EB_BYTE, pictureBufferDescPtr->bufferY, pictureBufferDescPtr->lumaSize      * bytesPerPixel * sizeof(EB_U8) + (pictureBufferDescPtr->width + 1) * 2 * bytesPerPixel*sizeof(EB_U8), 1, EB_N_PTR);
+        EB_CALLOC(EB_BYTE, pictureBufferDescPtr->bufferY, pictureBufferDescPtr->lumaSize      * bytesPerPixel * sizeof(EB_U8) + (pictureBufferDescPtr->width + 1) * 2 * bytesPerPixel*sizeof(EB_U8), 1, EB_N_PTR, encHandle);
         pictureBufferDescPtr->bufferY += (pictureBufferDescPtr->width+1) * bytesPerPixel;
     }
     else {
@@ -158,7 +160,7 @@ EB_ERRORTYPE EbReconPictureBufferDescCtor(
     }
 
     if(pictureBufferDescInitDataPtr->bufferEnableMask & PICTURE_BUFFER_DESC_Cb_FLAG) {
-        EB_CALLOC(EB_BYTE, pictureBufferDescPtr->bufferCb, pictureBufferDescPtr->chromaSize    * bytesPerPixel * sizeof(EB_U8) + ((pictureBufferDescPtr->width >> 1) + 1) * 2 * bytesPerPixel*sizeof(EB_U8), 1, EB_N_PTR);
+        EB_CALLOC(EB_BYTE, pictureBufferDescPtr->bufferCb, pictureBufferDescPtr->chromaSize    * bytesPerPixel * sizeof(EB_U8) + ((pictureBufferDescPtr->width >> 1) + 1) * 2 * bytesPerPixel*sizeof(EB_U8), 1, EB_N_PTR, encHandle);
         pictureBufferDescPtr->bufferCb += ((pictureBufferDescPtr->width >> 1) +1) * bytesPerPixel;
     }
     else {
@@ -166,7 +168,7 @@ EB_ERRORTYPE EbReconPictureBufferDescCtor(
     }
 
     if(pictureBufferDescInitDataPtr->bufferEnableMask & PICTURE_BUFFER_DESC_Cr_FLAG) {
-        EB_CALLOC(EB_BYTE, pictureBufferDescPtr->bufferCr, pictureBufferDescPtr->chromaSize    * bytesPerPixel * sizeof(EB_U8) + ((pictureBufferDescPtr->width >> 1) + 1) * 2 * bytesPerPixel*sizeof(EB_U8), 1, EB_N_PTR);
+        EB_CALLOC(EB_BYTE, pictureBufferDescPtr->bufferCr, pictureBufferDescPtr->chromaSize    * bytesPerPixel * sizeof(EB_U8) + ((pictureBufferDescPtr->width >> 1) + 1) * 2 * bytesPerPixel*sizeof(EB_U8), 1, EB_N_PTR, encHandle);
         pictureBufferDescPtr->bufferCr += ((pictureBufferDescPtr->width >> 1)+1) * bytesPerPixel;
     }
     else {

--- a/Source/Lib/Codec/EbPictureBufferDesc.h
+++ b/Source/Lib/Codec/EbPictureBufferDesc.h
@@ -10,7 +10,6 @@
 
 #include "EbDefinitions.h"
 
-
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -86,11 +85,13 @@ typedef struct EbPictureBufferDescInitData_s
  **************************************/
 extern EB_ERRORTYPE EbPictureBufferDescCtor(
     EB_PTR *objectDblPtr, 
-    EB_PTR objectInitDataPtr);
+    EB_PTR objectInitDataPtr,
+    EB_HANDLE encHandle);
 
 extern EB_ERRORTYPE EbReconPictureBufferDescCtor(
     EB_PTR *objectDblPtr, 
-    EB_PTR objectInitDataPtr);
+    EB_PTR objectInitDataPtr,
+    EB_HANDLE encHandle);
 
 #ifdef __cplusplus
 }

--- a/Source/Lib/Codec/EbPictureControlSet.h
+++ b/Source/Lib/Codec/EbPictureControlSet.h
@@ -643,11 +643,13 @@ typedef struct PictureControlSetInitData_s
  **************************************/
 extern EB_ERRORTYPE PictureControlSetCtor(
     EB_PTR *objectDblPtr, 
-    EB_PTR objectInitDataPtr);
+    EB_PTR objectInitDataPtr,
+    EB_HANDLE encHandle);
 
 extern EB_ERRORTYPE PictureParentControlSetCtor(
     EB_PTR *objectDblPtr, 
-    EB_PTR objectInitDataPtr);
+    EB_PTR objectInitDataPtr,
+    EB_HANDLE encHandle);
 
 #ifdef __cplusplus
 }

--- a/Source/Lib/Codec/EbPictureDecisionProcess.c
+++ b/Source/Lib/Codec/EbPictureDecisionProcess.c
@@ -43,30 +43,31 @@
 EB_ERRORTYPE PictureDecisionContextCtor(
     PictureDecisionContext_t **contextDblPtr,
     EbFifo_t *pictureAnalysisResultsInputFifoPtr,
-    EbFifo_t *pictureDecisionResultsOutputFifoPtr)
+    EbFifo_t *pictureDecisionResultsOutputFifoPtr,
+    EB_HANDLE encHandle)
 {
     PictureDecisionContext_t *contextPtr;
     EB_U32 arrayIndex;
     EB_U32 arrayRow , arrowColumn;
-    EB_MALLOC(PictureDecisionContext_t*, contextPtr, sizeof(PictureDecisionContext_t), EB_N_PTR);
+    EB_MALLOC(PictureDecisionContext_t*, contextPtr, sizeof(PictureDecisionContext_t), EB_N_PTR, encHandle);
     *contextDblPtr = contextPtr;
 
     contextPtr->pictureAnalysisResultsInputFifoPtr  = pictureAnalysisResultsInputFifoPtr;
     contextPtr->pictureDecisionResultsOutputFifoPtr = pictureDecisionResultsOutputFifoPtr;
 
-	EB_MALLOC(EB_U32**, contextPtr->ahdRunningAvgCb, sizeof(EB_U32*) * MAX_NUMBER_OF_REGIONS_IN_WIDTH, EB_N_PTR);
+	EB_MALLOC(EB_U32**, contextPtr->ahdRunningAvgCb, sizeof(EB_U32*) * MAX_NUMBER_OF_REGIONS_IN_WIDTH, EB_N_PTR, encHandle);
 
-	EB_MALLOC(EB_U32**, contextPtr->ahdRunningAvgCr, sizeof(EB_U32*) * MAX_NUMBER_OF_REGIONS_IN_WIDTH, EB_N_PTR);
+	EB_MALLOC(EB_U32**, contextPtr->ahdRunningAvgCr, sizeof(EB_U32*) * MAX_NUMBER_OF_REGIONS_IN_WIDTH, EB_N_PTR, encHandle);
 
-	EB_MALLOC(EB_U32**, contextPtr->ahdRunningAvg, sizeof(EB_U32*) * MAX_NUMBER_OF_REGIONS_IN_WIDTH, EB_N_PTR);
+	EB_MALLOC(EB_U32**, contextPtr->ahdRunningAvg, sizeof(EB_U32*) * MAX_NUMBER_OF_REGIONS_IN_WIDTH, EB_N_PTR, encHandle);
 
 	for (arrayIndex = 0; arrayIndex < MAX_NUMBER_OF_REGIONS_IN_WIDTH; arrayIndex++)
 	{
-		EB_MALLOC(EB_U32*, contextPtr->ahdRunningAvgCb[arrayIndex], sizeof(EB_U32) * MAX_NUMBER_OF_REGIONS_IN_HEIGHT, EB_N_PTR);
+		EB_MALLOC(EB_U32*, contextPtr->ahdRunningAvgCb[arrayIndex], sizeof(EB_U32) * MAX_NUMBER_OF_REGIONS_IN_HEIGHT, EB_N_PTR, encHandle);
 
-		EB_MALLOC(EB_U32*, contextPtr->ahdRunningAvgCr[arrayIndex], sizeof(EB_U32) * MAX_NUMBER_OF_REGIONS_IN_HEIGHT, EB_N_PTR);
+		EB_MALLOC(EB_U32*, contextPtr->ahdRunningAvgCr[arrayIndex], sizeof(EB_U32) * MAX_NUMBER_OF_REGIONS_IN_HEIGHT, EB_N_PTR, encHandle);
 
-		EB_MALLOC(EB_U32*, contextPtr->ahdRunningAvg[arrayIndex], sizeof(EB_U32) * MAX_NUMBER_OF_REGIONS_IN_HEIGHT, EB_N_PTR);
+		EB_MALLOC(EB_U32*, contextPtr->ahdRunningAvg[arrayIndex], sizeof(EB_U32) * MAX_NUMBER_OF_REGIONS_IN_HEIGHT, EB_N_PTR, encHandle);
 	}
 
 	for (arrayRow = 0; arrayRow < MAX_NUMBER_OF_REGIONS_IN_HEIGHT; arrayRow++)

--- a/Source/Lib/Codec/EbPictureDecisionProcess.h
+++ b/Source/Lib/Codec/EbPictureDecisionProcess.h
@@ -55,7 +55,8 @@ typedef struct PictureDecisionContext_s
 extern EB_ERRORTYPE PictureDecisionContextCtor(
     PictureDecisionContext_t    **contextDblPtr,
     EbFifo_t                     *pictureAnalysisResultsInputFifoPtr,
-    EbFifo_t                     *pictureDecisionResultsOutputFifoPtr);
+    EbFifo_t                     *pictureDecisionResultsOutputFifoPtr,
+    EB_HANDLE                     encHandle);
     
 
 extern void* PictureDecisionKernel(void *inputPtr);

--- a/Source/Lib/Codec/EbPictureDecisionQueue.c
+++ b/Source/Lib/Codec/EbPictureDecisionQueue.c
@@ -8,10 +8,12 @@
 
 
 EB_ERRORTYPE PaReferenceQueueEntryCtor(   
-    PaReferenceQueueEntry_t   **entryDblPtr)
+    PaReferenceQueueEntry_t   **entryDblPtr,
+    EB_HANDLE encHandle)
 {
     PaReferenceQueueEntry_t *entryPtr;
-    EB_MALLOC(PaReferenceQueueEntry_t*, entryPtr, sizeof(PaReferenceQueueEntry_t), EB_N_PTR);
+
+    EB_MALLOC(PaReferenceQueueEntry_t*, entryPtr, sizeof(PaReferenceQueueEntry_t), EB_N_PTR, encHandle);
     *entryDblPtr = entryPtr;
 
     entryPtr->inputObjectPtr        = (EbObjectWrapper_t*) EB_NULL;
@@ -20,9 +22,9 @@ EB_ERRORTYPE PaReferenceQueueEntryCtor(
     entryPtr->dependentCount        = 0;
     entryPtr->list0Ptr              = (ReferenceList_t*) EB_NULL;
     entryPtr->list1Ptr              = (ReferenceList_t*) EB_NULL;
-    EB_MALLOC(EB_S32*, entryPtr->list0.list, sizeof(EB_S32) * (1 << MAX_TEMPORAL_LAYERS) , EB_N_PTR);
+    EB_MALLOC(EB_S32*, entryPtr->list0.list, sizeof(EB_S32) * (1 << MAX_TEMPORAL_LAYERS) , EB_N_PTR, encHandle);
     
-    EB_MALLOC(EB_S32*, entryPtr->list1.list, sizeof(EB_S32) * (1 << MAX_TEMPORAL_LAYERS) , EB_N_PTR);
+    EB_MALLOC(EB_S32*, entryPtr->list1.list, sizeof(EB_S32) * (1 << MAX_TEMPORAL_LAYERS) , EB_N_PTR, encHandle);
 
     return EB_ErrorNone;
 }

--- a/Source/Lib/Codec/EbPictureDecisionQueue.h
+++ b/Source/Lib/Codec/EbPictureDecisionQueue.h
@@ -34,7 +34,8 @@ typedef struct PaReferenceQueueEntry_s {
 } PaReferenceQueueEntry_t;
 
 extern EB_ERRORTYPE PaReferenceQueueEntryCtor(   
-    PaReferenceQueueEntry_t  **entryDblPtr);
+    PaReferenceQueueEntry_t  **entryDblPtr,
+    EB_HANDLE encHandle);
 
 #ifdef __cplusplus
 }

--- a/Source/Lib/Codec/EbPictureDecisionReorderQueue.c
+++ b/Source/Lib/Codec/EbPictureDecisionReorderQueue.c
@@ -8,9 +8,10 @@
 
 EB_ERRORTYPE PictureManagerReorderEntryCtor(   
     PictureManagerReorderEntry_t   **entryDblPtr,
-    EB_U32                           pictureNumber)
+    EB_U32                           pictureNumber,
+    EB_HANDLE                        encHandle)
 {
-    EB_MALLOC(PictureManagerReorderEntry_t*, *entryDblPtr, sizeof(PictureManagerReorderEntry_t), EB_N_PTR);
+    EB_MALLOC(PictureManagerReorderEntry_t*, *entryDblPtr, sizeof(PictureManagerReorderEntry_t), EB_N_PTR, encHandle);
 
     (*entryDblPtr)->pictureNumber       = pictureNumber;
     (*entryDblPtr)->parentPcsWrapperPtr = (EbObjectWrapper_t *)EB_NULL;

--- a/Source/Lib/Codec/EbPictureDecisionReorderQueue.h
+++ b/Source/Lib/Codec/EbPictureDecisionReorderQueue.h
@@ -22,7 +22,8 @@ typedef struct PictureDecisionReorderEntry_s {
 
 extern EB_ERRORTYPE PictureDecisionReorderEntryCtor(   
     PictureDecisionReorderEntry_t       **entryDblPtr,
-    EB_U32                                pictureNumber);
+    EB_U32                                pictureNumber,
+    EB_HANDLE                             encHandle);
 
 #ifdef __cplusplus
 }

--- a/Source/Lib/Codec/EbPictureDecisionResults.c
+++ b/Source/Lib/Codec/EbPictureDecisionResults.c
@@ -9,10 +9,11 @@
 
 EB_ERRORTYPE PictureDecisionResultCtor(
     EB_PTR *objectDblPtr, 
-    EB_PTR objectInitDataPtr)
+    EB_PTR objectInitDataPtr,
+    EB_HANDLE encHandle)
 {
     PictureDecisionResults_t *objectPtr;
-    EB_MALLOC(PictureDecisionResults_t *, objectPtr, sizeof(PictureDecisionResults_t), EB_N_PTR);
+    EB_MALLOC(PictureDecisionResults_t *, objectPtr, sizeof(PictureDecisionResults_t), EB_N_PTR, encHandle);
 
     *objectDblPtr = (EB_PTR) objectPtr;
     objectInitDataPtr = 0;

--- a/Source/Lib/Codec/EbPictureDecisionResults.h
+++ b/Source/Lib/Codec/EbPictureDecisionResults.h
@@ -31,7 +31,8 @@ typedef struct PictureDecisionResultInitData_s
  **************************************/
 extern EB_ERRORTYPE PictureDecisionResultCtor(
     EB_PTR *objectDblPtr, 
-    EB_PTR objectInitDataPtr);
+    EB_PTR objectInitDataPtr,
+    EB_HANDLE encHandle);
 
 #ifdef __cplusplus
 }

--- a/Source/Lib/Codec/EbPictureDemuxResults.c
+++ b/Source/Lib/Codec/EbPictureDemuxResults.c
@@ -8,10 +8,11 @@
 
 EB_ERRORTYPE PictureResultsCtor(
     EB_PTR *objectDblPtr, 
-    EB_PTR objectInitDataPtr)
+    EB_PTR objectInitDataPtr,
+    EB_HANDLE encHandle)
 {
     PictureDemuxResults_t *objectPtr;
-    EB_MALLOC(PictureDemuxResults_t*, objectPtr, sizeof(PictureDemuxResults_t), EB_N_PTR);
+    EB_MALLOC(PictureDemuxResults_t*, objectPtr, sizeof(PictureDemuxResults_t), EB_N_PTR, encHandle);
 
     *objectDblPtr                    = objectPtr;
     

--- a/Source/Lib/Codec/EbPictureDemuxResults.h
+++ b/Source/Lib/Codec/EbPictureDemuxResults.h
@@ -48,7 +48,8 @@ typedef struct PictureResultInitData_s
  **************************************/
 extern EB_ERRORTYPE PictureResultsCtor(
     EB_PTR *objectDblPtr, 
-    EB_PTR objectInitDataPtr);
+    EB_PTR objectInitDataPtr,
+    EB_HANDLE encHandle);
 
 #ifdef __cplusplus
 }

--- a/Source/Lib/Codec/EbPictureManagerProcess.c
+++ b/Source/Lib/Codec/EbPictureManagerProcess.c
@@ -35,10 +35,11 @@ EB_ERRORTYPE PictureManagerContextCtor(
     PictureManagerContext_t **contextDblPtr,
     EbFifo_t                 *pictureInputFifoPtr,
     EbFifo_t                 *pictureManagerOutputFifoPtr,
-    EbFifo_t                **pictureControlSetFifoPtrArray)
+    EbFifo_t                **pictureControlSetFifoPtrArray,
+    EB_HANDLE                 encHandle)
 {
     PictureManagerContext_t *contextPtr;
-    EB_MALLOC(PictureManagerContext_t*, contextPtr, sizeof(PictureManagerContext_t), EB_N_PTR);
+    EB_MALLOC(PictureManagerContext_t*, contextPtr, sizeof(PictureManagerContext_t), EB_N_PTR, encHandle);
 
     *contextDblPtr = contextPtr;
 

--- a/Source/Lib/Codec/EbPictureManagerProcess.h
+++ b/Source/Lib/Codec/EbPictureManagerProcess.h
@@ -19,7 +19,6 @@ typedef struct PictureManagerContext_s
     EbFifo_t                 *pictureInputFifoPtr;
     EbFifo_t                 *pictureManagerOutputFifoPtr;
     EbFifo_t                **pictureControlSetFifoPtrArray;
-     
 } PictureManagerContext_t;
 
 /***************************************
@@ -29,7 +28,8 @@ extern EB_ERRORTYPE PictureManagerContextCtor(
     PictureManagerContext_t **contextDblPtr,
     EbFifo_t                 *pictureInputFifoPtr,
     EbFifo_t                 *pictureManagerOutputFifoPtr,   
-    EbFifo_t                **pictureControlSetFifoPtrArray);
+    EbFifo_t                **pictureControlSetFifoPtrArray,
+    EB_HANDLE                 encHandle);
     
    
 

--- a/Source/Lib/Codec/EbPictureManagerQueue.c
+++ b/Source/Lib/Codec/EbPictureManagerQueue.c
@@ -7,10 +7,11 @@
 #include "EbPictureManagerQueue.h"
 
 EB_ERRORTYPE InputQueueEntryCtor(
-    InputQueueEntry_t      **entryDblPtr)
+    InputQueueEntry_t      **entryDblPtr,
+    EB_HANDLE                encHandle)
 {
     InputQueueEntry_t *entryPtr;
-    EB_MALLOC(InputQueueEntry_t*, entryPtr, sizeof(InputQueueEntry_t), EB_N_PTR);
+    EB_MALLOC(InputQueueEntry_t*, entryPtr, sizeof(InputQueueEntry_t), EB_N_PTR, encHandle);
     *entryDblPtr = entryPtr;
 
     entryPtr->inputObjectPtr      = (EbObjectWrapper_t*) EB_NULL;
@@ -26,10 +27,12 @@ EB_ERRORTYPE InputQueueEntryCtor(
 
 
 EB_ERRORTYPE ReferenceQueueEntryCtor(   
-    ReferenceQueueEntry_t  **entryDblPtr)
+    ReferenceQueueEntry_t  **entryDblPtr,
+    EB_HANDLE                encHandle)
 {
     ReferenceQueueEntry_t *entryPtr;
-    EB_MALLOC(ReferenceQueueEntry_t*, entryPtr, sizeof(ReferenceQueueEntry_t), EB_N_PTR);
+
+    EB_MALLOC(ReferenceQueueEntry_t*, entryPtr, sizeof(ReferenceQueueEntry_t), EB_N_PTR, encHandle);
     *entryDblPtr = entryPtr;
 
     entryPtr->referenceObjectPtr  = (EbObjectWrapper_t*) EB_NULL;
@@ -37,9 +40,9 @@ EB_ERRORTYPE ReferenceQueueEntryCtor(
     entryPtr->dependentCount      = 0;
     entryPtr->referenceAvailable  = EB_FALSE;
 
-    EB_MALLOC(EB_S32*, entryPtr->list0.list, sizeof(EB_S32) * (1 << MAX_TEMPORAL_LAYERS) , EB_N_PTR);
+    EB_MALLOC(EB_S32*, entryPtr->list0.list, sizeof(EB_S32) * (1 << MAX_TEMPORAL_LAYERS) , EB_N_PTR, encHandle);
 
-    EB_MALLOC(EB_S32*, entryPtr->list1.list, sizeof(EB_S32) * (1 << MAX_TEMPORAL_LAYERS) , EB_N_PTR);
+    EB_MALLOC(EB_S32*, entryPtr->list1.list, sizeof(EB_S32) * (1 << MAX_TEMPORAL_LAYERS) , EB_N_PTR, encHandle);
 
     return EB_ErrorNone;
 }

--- a/Source/Lib/Codec/EbPictureManagerQueue.h
+++ b/Source/Lib/Codec/EbPictureManagerQueue.h
@@ -90,12 +90,14 @@ typedef struct RcFeedbackQueueEntry_s {
 } RcFeedbackQueueEntry_t;   
 
 extern EB_ERRORTYPE InputQueueEntryCtor(   
-    InputQueueEntry_t      **entryDblPtr);
+    InputQueueEntry_t      **entryDblPtr,
+    EB_HANDLE                encHandle);
 
    
 
 extern EB_ERRORTYPE ReferenceQueueEntryCtor(   
-    ReferenceQueueEntry_t  **entryDblPtr);
+    ReferenceQueueEntry_t  **entryDblPtr,
+    EB_HANDLE                encHandle);
 
 
 #ifdef __cplusplus

--- a/Source/Lib/Codec/EbPictureManagerReorderQueue.c
+++ b/Source/Lib/Codec/EbPictureManagerReorderQueue.c
@@ -8,9 +8,10 @@
 
 EB_ERRORTYPE PictureDecisionReorderEntryCtor(   
     PictureDecisionReorderEntry_t   **entryDblPtr,
-    EB_U32                            pictureNumber)
+    EB_U32                            pictureNumber,
+    EB_HANDLE                         encHandle)
 {
-    EB_MALLOC(PictureDecisionReorderEntry_t*, *entryDblPtr, sizeof(PictureDecisionReorderEntry_t), EB_N_PTR);
+    EB_MALLOC(PictureDecisionReorderEntry_t*, *entryDblPtr, sizeof(PictureDecisionReorderEntry_t), EB_N_PTR, encHandle);
 
     (*entryDblPtr)->pictureNumber       = pictureNumber;
     (*entryDblPtr)->parentPcsWrapperPtr = (EbObjectWrapper_t *)EB_NULL;

--- a/Source/Lib/Codec/EbPictureManagerReorderQueue.h
+++ b/Source/Lib/Codec/EbPictureManagerReorderQueue.h
@@ -22,7 +22,8 @@ typedef struct PictureManagerReorderEntry_s {
 
 extern EB_ERRORTYPE PictureManagerReorderEntryCtor(   
     PictureManagerReorderEntry_t       **entryDblPtr,
-    EB_U32                                pictureNumber);
+    EB_U32                                pictureNumber,
+    EB_HANDLE                             encHandle);
 
 #ifdef __cplusplus
 }

--- a/Source/Lib/Codec/EbPredictionStructure.c
+++ b/Source/Lib/Codec/EbPredictionStructure.c
@@ -848,7 +848,8 @@ static EB_ERRORTYPE PredictionStructureCtor(
     PredictionStructure_t       **predictionStructureDblPtr,
     const PredictionStructureConfig_t  *predictionStructureConfigPtr,
     EB_PRED                       predType,
-    EB_U32                        numberOfReferences)
+    EB_U32                        numberOfReferences,
+    EB_HANDLE                     encHandle)
 {
     EB_U32                  entryIndex;
     EB_U32                  configEntryIndex;
@@ -860,7 +861,8 @@ static EB_ERRORTYPE PredictionStructureCtor(
     EB_U32                  steadyStatePicCount;
 
     PredictionStructure_t  *predictionStructurePtr;
-    EB_MALLOC(PredictionStructure_t*, predictionStructurePtr, sizeof(PredictionStructure_t), EB_N_PTR);
+
+    EB_MALLOC(PredictionStructure_t*, predictionStructurePtr, sizeof(PredictionStructure_t), EB_N_PTR, encHandle);
     *predictionStructureDblPtr = predictionStructurePtr;
     EB_MEMSET(predictionStructurePtr, 0, sizeof(PredictionStructure_t));
 
@@ -935,10 +937,10 @@ static EB_ERRORTYPE PredictionStructureCtor(
     }
 
     // Allocate the entry array
-    EB_MALLOC(PredictionStructureEntry_t**, predictionStructurePtr->predStructEntryPtrArray, sizeof(PredictionStructureEntry_t*) * predictionStructurePtr->predStructEntryCount, EB_N_PTR);
+    EB_MALLOC(PredictionStructureEntry_t**, predictionStructurePtr->predStructEntryPtrArray, sizeof(PredictionStructureEntry_t*) * predictionStructurePtr->predStructEntryCount, EB_N_PTR, encHandle);
     // Allocate the entries
     for(entryIndex = 0; entryIndex < predictionStructurePtr->predStructEntryCount; ++entryIndex) {
-        EB_MALLOC(PredictionStructureEntry_t*, predictionStructurePtr->predStructEntryPtrArray[entryIndex], sizeof(PredictionStructureEntry_t), EB_N_PTR);
+        EB_MALLOC(PredictionStructureEntry_t*, predictionStructurePtr->predStructEntryPtrArray[entryIndex], sizeof(PredictionStructureEntry_t), EB_N_PTR, encHandle);
         EB_MEMSET(predictionStructurePtr->predStructEntryPtrArray[entryIndex], 0, sizeof(PredictionStructureEntry_t));
     }
 
@@ -1285,7 +1287,7 @@ static EB_ERRORTYPE PredictionStructureCtor(
 
             // If the dependent list count is non-zero, allocate the list, else the list is NULL.
             if(predictionStructurePtr->predStructEntryPtrArray[entryIndex]->depList0.listCount > 0) {
-                EB_MALLOC(EB_S32*, predictionStructurePtr->predStructEntryPtrArray[entryIndex]->depList0.list, sizeof(EB_S32) * predictionStructurePtr->predStructEntryPtrArray[entryIndex]->depList0.listCount, EB_N_PTR);
+                EB_MALLOC(EB_S32*, predictionStructurePtr->predStructEntryPtrArray[entryIndex]->depList0.list, sizeof(EB_S32) * predictionStructurePtr->predStructEntryPtrArray[entryIndex]->depList0.listCount, EB_N_PTR, encHandle);
             }
             else {
                 predictionStructurePtr->predStructEntryPtrArray[entryIndex]->depList0.list = (EB_S32*) EB_NULL;
@@ -1393,7 +1395,7 @@ static EB_ERRORTYPE PredictionStructureCtor(
 
             // If the dependent list count is non-zero, allocate the list, else the list is NULL.
             if(predictionStructurePtr->predStructEntryPtrArray[entryIndex]->depList1.listCount > 0) {
-                EB_MALLOC(EB_S32*, predictionStructurePtr->predStructEntryPtrArray[entryIndex]->depList1.list, sizeof(EB_S32) * predictionStructurePtr->predStructEntryPtrArray[entryIndex]->depList1.listCount, EB_N_PTR);
+                EB_MALLOC(EB_S32*, predictionStructurePtr->predStructEntryPtrArray[entryIndex]->depList1.list, sizeof(EB_S32) * predictionStructurePtr->predStructEntryPtrArray[entryIndex]->depList1.listCount, EB_N_PTR, encHandle);
             }
             else {
                 predictionStructurePtr->predStructEntryPtrArray[entryIndex]->depList1.list = (EB_S32*) EB_NULL;
@@ -1495,13 +1497,13 @@ static EB_ERRORTYPE PredictionStructureCtor(
         // Allocate & Initialize the Timeline map
         timelineSize = predictionStructurePtr->predStructEntryCount;
         decodeOrderTableSize = CEILING(predictionStructurePtr->predStructEntryCount + predictionStructurePtr->maximumExtent, predictionStructurePtr->predStructEntryCount);
-        EB_MALLOC(EB_BOOL*, timelineMap, sizeof(EB_BOOL) * SQR(timelineSize), EB_N_PTR);
+        EB_MALLOC(EB_BOOL*, timelineMap, sizeof(EB_BOOL) * SQR(timelineSize), EB_N_PTR, encHandle);
         EB_MEMSET(timelineMap, 0, sizeof(EB_BOOL) * SQR(timelineSize));
 
         // Construct the Decode & Display Order
-        EB_MALLOC(EB_S32*, decodeOrderTable, sizeof(EB_S32) * decodeOrderTableSize, EB_N_PTR);
+        EB_MALLOC(EB_S32*, decodeOrderTable, sizeof(EB_S32) * decodeOrderTableSize, EB_N_PTR, encHandle);
 
-        EB_MALLOC(EB_U32*, displayOrderTable, sizeof(EB_U32) * decodeOrderTableSize, EB_N_PTR);
+        EB_MALLOC(EB_U32*, displayOrderTable, sizeof(EB_U32) * decodeOrderTableSize, EB_N_PTR, encHandle);
 
         for(currentPocIndex = 0, entryIndex=0; currentPocIndex < decodeOrderTableSize; ++currentPocIndex) {
 
@@ -1765,7 +1767,8 @@ static EB_ERRORTYPE PredictionStructureCtor(
  *************************************************/
 EB_ERRORTYPE PredictionStructureGroupCtor(
     PredictionStructureGroup_t   **predictionStructureGroupDblPtr,
-    EB_U32                         baseLayerSwitchMode)
+    EB_U32                         baseLayerSwitchMode,
+    EB_HANDLE                      encHandle)
 {
     EB_U32          predStructIndex = 0;
     EB_U32          refIdx = 0;
@@ -1775,7 +1778,7 @@ EB_ERRORTYPE PredictionStructureGroupCtor(
     EB_ERRORTYPE    return_error = EB_ErrorNone;
 
     PredictionStructureGroup_t *predictionStructureGroupPtr;
-    EB_MALLOC(PredictionStructureGroup_t*, predictionStructureGroupPtr, sizeof(PredictionStructureGroup_t), EB_N_PTR);
+    EB_MALLOC(PredictionStructureGroup_t*, predictionStructureGroupPtr, sizeof(PredictionStructureGroup_t), EB_N_PTR, encHandle);
     *predictionStructureGroupDblPtr = predictionStructureGroupPtr;
 
     // Count the number of Prediction Structures
@@ -1788,7 +1791,7 @@ EB_ERRORTYPE PredictionStructureGroupCtor(
     }
 
     predictionStructureGroupPtr->predictionStructureCount = MAX_TEMPORAL_LAYERS * EB_PRED_TOTAL_COUNT;
-    EB_MALLOC(PredictionStructure_t**, predictionStructureGroupPtr->predictionStructurePtrArray, sizeof(PredictionStructure_t*) * predictionStructureGroupPtr->predictionStructureCount, EB_N_PTR);
+    EB_MALLOC(PredictionStructure_t**, predictionStructureGroupPtr->predictionStructurePtrArray, sizeof(PredictionStructure_t*) * predictionStructureGroupPtr->predictionStructureCount, EB_N_PTR, encHandle);
     for(hierarchicalLevelIdx = 0; hierarchicalLevelIdx < MAX_TEMPORAL_LAYERS; ++hierarchicalLevelIdx) {
         for(predTypeIdx = 0; predTypeIdx < EB_PRED_TOTAL_COUNT; ++predTypeIdx) {
                 predStructIndex = PRED_STRUCT_INDEX(hierarchicalLevelIdx, predTypeIdx, refIdx);
@@ -1798,7 +1801,8 @@ EB_ERRORTYPE PredictionStructureGroupCtor(
                     &(predictionStructureGroupPtr->predictionStructurePtrArray[predStructIndex]),
                     &(PredictionStructureConfigArray[hierarchicalLevelIdx]),
                     (EB_PRED) predTypeIdx,
-                    numberOfReferences);
+                    numberOfReferences,
+                    encHandle);
                 if (return_error == EB_ErrorInsufficientResources){
                     return EB_ErrorInsufficientResources;
                 }

--- a/Source/Lib/Codec/EbPredictionStructure.h
+++ b/Source/Lib/Codec/EbPredictionStructure.h
@@ -194,7 +194,8 @@ typedef struct PredictionStructureGroup_s {
  ************************************************/
 extern EB_ERRORTYPE PredictionStructureGroupCtor(
     PredictionStructureGroup_t   **predictionStructureGroupDblPtr,
-    EB_U32                        baseLayerSwitchMode);
+    EB_U32                        baseLayerSwitchMode,
+    EB_HANDLE                     encHandle);
 
 extern PredictionStructure_t* GetPredictionStructure(
     PredictionStructureGroup_t    *predictionStructureGroupPtr,

--- a/Source/Lib/Codec/EbRateControlProcess.c
+++ b/Source/Lib/Codec/EbRateControlProcess.c
@@ -190,10 +190,11 @@ static void RateControlLayerResetPart2(
 }
 
 static EB_ERRORTYPE HighLevelRateControlContextCtor(
-    HighLevelRateControlContext_t   **entryDblPtr){
-
+    HighLevelRateControlContext_t   **entryDblPtr,
+    EB_HANDLE                         encHandle)
+{
     HighLevelRateControlContext_t *entryPtr;
-    EB_MALLOC(HighLevelRateControlContext_t*, entryPtr, sizeof(HighLevelRateControlContext_t), EB_N_PTR);
+    EB_MALLOC(HighLevelRateControlContext_t*, entryPtr, sizeof(HighLevelRateControlContext_t), EB_N_PTR, encHandle);
     *entryDblPtr = entryPtr;
 
     return EB_ErrorNone;
@@ -201,10 +202,11 @@ static EB_ERRORTYPE HighLevelRateControlContextCtor(
 
 
 EB_ERRORTYPE RateControlLayerContextCtor(
-    RateControlLayerContext_t   **entryDblPtr){
-
+    RateControlLayerContext_t   **entryDblPtr,
+    EB_HANDLE encHandle)
+{
     RateControlLayerContext_t *entryPtr;
-    EB_MALLOC(RateControlLayerContext_t*, entryPtr, sizeof(RateControlLayerContext_t), EB_N_PTR);
+    EB_MALLOC(RateControlLayerContext_t*, entryPtr, sizeof(RateControlLayerContext_t), EB_N_PTR, encHandle);
 
     *entryDblPtr = entryPtr;
 
@@ -218,11 +220,13 @@ EB_ERRORTYPE RateControlLayerContextCtor(
 
 
 EB_ERRORTYPE RateControlIntervalParamContextCtor(
-    RateControlIntervalParamContext_t   **entryDblPtr) {
+    RateControlIntervalParamContext_t   **entryDblPtr,
+    EB_HANDLE encHandle) {
     EB_U32 temporalIndex;
     EB_ERRORTYPE return_error = EB_ErrorNone;
     RateControlIntervalParamContext_t *entryPtr;
-    EB_MALLOC(RateControlIntervalParamContext_t*, entryPtr, sizeof(RateControlIntervalParamContext_t), EB_N_PTR);
+
+    EB_MALLOC(RateControlIntervalParamContext_t*, entryPtr, sizeof(RateControlIntervalParamContext_t), EB_N_PTR, encHandle);
 
     *entryDblPtr = entryPtr;
 
@@ -230,10 +234,10 @@ EB_ERRORTYPE RateControlIntervalParamContextCtor(
     entryPtr->wasUsed = EB_FALSE;
     entryPtr->lastGop = EB_FALSE;
     entryPtr->processedFramesNumber = 0;
-    EB_MALLOC(RateControlLayerContext_t**, entryPtr->rateControlLayerArray, sizeof(RateControlLayerContext_t*)*EB_MAX_TEMPORAL_LAYERS, EB_N_PTR);
+    EB_MALLOC(RateControlLayerContext_t**, entryPtr->rateControlLayerArray, sizeof(RateControlLayerContext_t*)*EB_MAX_TEMPORAL_LAYERS, EB_N_PTR, encHandle);
 
     for (temporalIndex = 0; temporalIndex < EB_MAX_TEMPORAL_LAYERS; temporalIndex++){
-        return_error = RateControlLayerContextCtor(&entryPtr->rateControlLayerArray[temporalIndex]);
+        return_error = RateControlLayerContextCtor(&entryPtr->rateControlLayerArray[temporalIndex], encHandle);
         entryPtr->rateControlLayerArray[temporalIndex]->temporalIndex = temporalIndex;
         entryPtr->rateControlLayerArray[temporalIndex]->frameRate = 1 << RC_PRECISION;
         if (return_error == EB_ErrorInsufficientResources){
@@ -258,10 +262,11 @@ EB_ERRORTYPE RateControlIntervalParamContextCtor(
 
 EB_ERRORTYPE RateControlCodedFramesStatsContextCtor(
     CodedFramesStatsEntry_t   **entryDblPtr,
-    EB_U64                      pictureNumber) {
-
+    EB_U64                      pictureNumber,
+    EB_HANDLE                   encHandle)
+{
     CodedFramesStatsEntry_t *entryPtr;
-    EB_MALLOC(CodedFramesStatsEntry_t*, entryPtr, sizeof(CodedFramesStatsEntry_t), EB_N_PTR);
+    EB_MALLOC(CodedFramesStatsEntry_t*, entryPtr, sizeof(CodedFramesStatsEntry_t), EB_N_PTR, encHandle);
 
     *entryDblPtr = entryPtr;
 
@@ -276,7 +281,8 @@ EB_ERRORTYPE RateControlContextCtor(
     RateControlContext_t   **contextDblPtr,
     EbFifo_t                *rateControlInputTasksFifoPtr,
     EbFifo_t                *rateControlOutputResultsFifoPtr,
-    EB_S32                   intraPeriodLength)
+    EB_S32                   intraPeriodLength,
+    EB_HANDLE                encHandle)
 {
     EB_U32 temporalIndex;
     EB_U32 intervalIndex;
@@ -287,7 +293,8 @@ EB_ERRORTYPE RateControlContextCtor(
 
     EB_ERRORTYPE return_error = EB_ErrorNone;
     RateControlContext_t *contextPtr;
-    EB_MALLOC(RateControlContext_t*, contextPtr, sizeof(RateControlContext_t), EB_N_PTR);
+
+    EB_MALLOC(RateControlContext_t*, contextPtr, sizeof(RateControlContext_t), EB_N_PTR, encHandle);
 
     *contextDblPtr = contextPtr;
 
@@ -296,7 +303,7 @@ EB_ERRORTYPE RateControlContextCtor(
 
     // High level RC
     return_error = HighLevelRateControlContextCtor(
-        &contextPtr->highLevelRateControlPtr);
+        &contextPtr->highLevelRateControlPtr, encHandle);
     if (return_error == EB_ErrorInsufficientResources){
         return EB_ErrorInsufficientResources;
     }
@@ -305,12 +312,13 @@ EB_ERRORTYPE RateControlContextCtor(
         contextPtr->framesInInterval[temporalIndex] = 0;
     }
 
-    EB_MALLOC(RateControlIntervalParamContext_t**, contextPtr->rateControlParamQueue, sizeof(RateControlIntervalParamContext_t*)*PARALLEL_GOP_MAX_NUMBER, EB_N_PTR);
+    EB_MALLOC(RateControlIntervalParamContext_t**, contextPtr->rateControlParamQueue, sizeof(RateControlIntervalParamContext_t*)*PARALLEL_GOP_MAX_NUMBER, EB_N_PTR, encHandle);
 
     contextPtr->rateControlParamQueueHeadIndex = 0;
     for (intervalIndex = 0; intervalIndex < PARALLEL_GOP_MAX_NUMBER; intervalIndex++){
         return_error = RateControlIntervalParamContextCtor(
-            &contextPtr->rateControlParamQueue[intervalIndex]);
+            &contextPtr->rateControlParamQueue[intervalIndex],
+            encHandle);
         contextPtr->rateControlParamQueue[intervalIndex]->firstPoc = (intervalIndex*(EB_U32)(intraPeriodLength + 1));
         contextPtr->rateControlParamQueue[intervalIndex]->lastPoc = ((intervalIndex + 1)*(EB_U32)(intraPeriodLength + 1)) - 1;
         if (return_error == EB_ErrorInsufficientResources){
@@ -321,12 +329,13 @@ EB_ERRORTYPE RateControlContextCtor(
 #if OVERSHOOT_STAT_PRINT
     contextPtr->codedFramesStatQueueHeadIndex = 0;
     contextPtr->codedFramesStatQueueTailIndex = 0;
-    EB_MALLOC(CodedFramesStatsEntry_t**, contextPtr->codedFramesStatQueue, sizeof(CodedFramesStatsEntry_t*)*CODED_FRAMES_STAT_QUEUE_MAX_DEPTH, EB_N_PTR);
+    EB_MALLOC(CodedFramesStatsEntry_t**, contextPtr->codedFramesStatQueue, sizeof(CodedFramesStatsEntry_t*)*CODED_FRAMES_STAT_QUEUE_MAX_DEPTH, EB_N_PTR, encHandle);
 
     for (pictureIndex = 0; pictureIndex < CODED_FRAMES_STAT_QUEUE_MAX_DEPTH; ++pictureIndex) {
         return_error = RateControlCodedFramesStatsContextCtor(
             &contextPtr->codedFramesStatQueue[pictureIndex],
-            pictureIndex);
+            pictureIndex,
+            encHandle);
         if (return_error == EB_ErrorInsufficientResources){
             return EB_ErrorInsufficientResources;
         }

--- a/Source/Lib/Codec/EbRateControlProcess.h
+++ b/Source/Lib/Codec/EbRateControlProcess.h
@@ -284,9 +284,7 @@ typedef struct RateControlContext_s
     EB_U64                       framesInInterval [EB_MAX_TEMPORAL_LAYERS];
     EB_S64                       extraBits;  
     EB_S64                       extraBitsGen;
-    EB_S16                      maxRateAdjustDeltaQP;
-   
-   
+    EB_S16                       maxRateAdjustDeltaQP;
 } RateControlContext_t;
 
 
@@ -295,18 +293,21 @@ typedef struct RateControlContext_s
  * Extern Function Declarations
  **************************************/
 extern EB_ERRORTYPE RateControlLayerContextCtor(
-    RateControlLayerContext_t   **entryDblPtr);
+    RateControlLayerContext_t   **entryDblPtr,
+    EB_HANDLE encHandle);
 
   
 
 extern EB_ERRORTYPE RateControlIntervalParamContextCtor(
-    RateControlIntervalParamContext_t   **entryDblPtr);
+    RateControlIntervalParamContext_t   **entryDblPtr,
+    EB_HANDLE encHandle);
 
 
 
 extern EB_ERRORTYPE RateControlCodedFramesStatsContextCtor(
     CodedFramesStatsEntry_t   **entryDblPtr,
-    EB_U64                      pictureNumber);
+    EB_U64                      pictureNumber,
+    EB_HANDLE                   encHandle);
 
 
 
@@ -314,7 +315,8 @@ extern EB_ERRORTYPE RateControlContextCtor(
     RateControlContext_t   **contextDblPtr,
     EbFifo_t                *rateControlInputTasksFifoPtr,
     EbFifo_t                *rateControlOutputResultsFifoPtr,
-    EB_S32                   intraPeriodLength);
+    EB_S32                   intraPeriodLength,
+    EB_HANDLE                encHandle);
     
    
     

--- a/Source/Lib/Codec/EbRateControlResults.c
+++ b/Source/Lib/Codec/EbRateControlResults.c
@@ -10,10 +10,11 @@
 
 EB_ERRORTYPE RateControlResultsCtor(
     EB_PTR *objectDblPtr,
-    EB_PTR objectInitDataPtr)
+    EB_PTR objectInitDataPtr,
+    EB_HANDLE encHandle)
 {
     RateControlResults_t *contextPtr;
-    EB_MALLOC(RateControlResults_t*, contextPtr, sizeof(RateControlResults_t), EB_N_PTR);
+    EB_MALLOC(RateControlResults_t*, contextPtr, sizeof(RateControlResults_t), EB_N_PTR, encHandle);
     *objectDblPtr = (EB_PTR) contextPtr;
 
     objectInitDataPtr = 0;

--- a/Source/Lib/Codec/EbRateControlResults.h
+++ b/Source/Lib/Codec/EbRateControlResults.h
@@ -31,7 +31,8 @@ typedef struct RateControlResultsInitData_s
  **************************************/
 extern EB_ERRORTYPE RateControlResultsCtor(
     EB_PTR *objectDblPtr, 
-    EB_PTR objectInitDataPtr);
+    EB_PTR objectInitDataPtr,
+    EB_HANDLE encHandle);
 
 
 #ifdef __cplusplus

--- a/Source/Lib/Codec/EbRateControlTasks.c
+++ b/Source/Lib/Codec/EbRateControlTasks.c
@@ -10,10 +10,11 @@
 
 EB_ERRORTYPE RateControlTasksCtor(
     EB_PTR *objectDblPtr,
-    EB_PTR objectInitDataPtr)
+    EB_PTR objectInitDataPtr,
+    EB_HANDLE encHandle)
 {
     RateControlTasks_t *contextPtr;
-    EB_MALLOC(RateControlTasks_t*, contextPtr, sizeof(RateControlTasks_t), EB_N_PTR);
+    EB_MALLOC(RateControlTasks_t*, contextPtr, sizeof(RateControlTasks_t), EB_N_PTR, encHandle);
 
     *objectDblPtr = (EB_PTR) contextPtr;
     objectInitDataPtr = EB_NULL;

--- a/Source/Lib/Codec/EbRateControlTasks.h
+++ b/Source/Lib/Codec/EbRateControlTasks.h
@@ -51,7 +51,8 @@ typedef struct RateControlTasksInitData_s
  **************************************/
 extern EB_ERRORTYPE RateControlTasksCtor(
     EB_PTR *objectDblPtr, 
-    EB_PTR objectInitDataPtr);
+    EB_PTR objectInitDataPtr,
+    EB_HANDLE encHandle);
 
 #ifdef __cplusplus
 }

--- a/Source/Lib/Codec/EbReferenceObject.c
+++ b/Source/Lib/Codec/EbReferenceObject.c
@@ -141,7 +141,8 @@ void EbHevcInitializeSamplesNeighboringReferencePicture(
  *****************************************/
 EB_ERRORTYPE EbReferenceObjectCtor(
     EB_PTR  *objectDblPtr,
-    EB_PTR   objectInitDataPtr)
+    EB_PTR   objectInitDataPtr,
+    EB_HANDLE encHandle)
 {
 
     EbReferenceObject_t              *referenceObject;
@@ -150,7 +151,8 @@ EB_ERRORTYPE EbReferenceObjectCtor(
 
 
     EB_ERRORTYPE return_error = EB_ErrorNone;
-    EB_MALLOC(EbReferenceObject_t*, referenceObject, sizeof(EbReferenceObject_t), EB_N_PTR);
+
+    EB_MALLOC(EbReferenceObject_t*, referenceObject, sizeof(EbReferenceObject_t), EB_N_PTR, encHandle);
 
     *objectDblPtr = (EB_PTR) referenceObject;
 
@@ -158,7 +160,8 @@ EB_ERRORTYPE EbReferenceObjectCtor(
 
         return_error = EbPictureBufferDescCtor(
             (EB_PTR*)&(referenceObject->referencePicture16bit),
-            (EB_PTR)&pictureBufferDescInitData16BitPtr);
+            (EB_PTR)&pictureBufferDescInitData16BitPtr,
+            encHandle);
 
         EbHevcInitializeSamplesNeighboringReferencePicture(
             referenceObject,
@@ -170,7 +173,8 @@ EB_ERRORTYPE EbReferenceObjectCtor(
 
         return_error = EbPictureBufferDescCtor(
             (EB_PTR*)&(referenceObject->referencePicture),
-            (EB_PTR)pictureBufferDescInitDataPtr);
+            (EB_PTR)pictureBufferDescInitDataPtr,
+            encHandle);
 
         EbHevcInitializeSamplesNeighboringReferencePicture(
             referenceObject,
@@ -185,7 +189,7 @@ EB_ERRORTYPE EbReferenceObjectCtor(
 
 
     // Allocate LCU based TMVP map
-    EB_MALLOC(TmvpUnit_t *, referenceObject->tmvpMap, (sizeof(TmvpUnit_t) * (((pictureBufferDescInitDataPtr->maxWidth + (64 - 1)) >> 6) * ((pictureBufferDescInitDataPtr->maxHeight + (64 - 1)) >> 6))), EB_N_PTR);
+    EB_MALLOC(TmvpUnit_t *, referenceObject->tmvpMap, (sizeof(TmvpUnit_t) * (((pictureBufferDescInitDataPtr->maxWidth + (64 - 1)) >> 6) * ((pictureBufferDescInitDataPtr->maxHeight + (64 - 1)) >> 6))), EB_N_PTR, encHandle);
 
     //RESTRICT THIS TO M4
     {
@@ -204,7 +208,7 @@ EB_ERRORTYPE EbReferenceObjectCtor(
 
 
         return_error = EbPictureBufferDescCtor((EB_PTR*)&(referenceObject->refDenSrcPicture),
-                                                (EB_PTR)&bufDesc);
+                                                (EB_PTR)&bufDesc, encHandle);
         if (return_error == EB_ErrorInsufficientResources)
             return EB_ErrorInsufficientResources;
     }
@@ -220,19 +224,21 @@ EB_ERRORTYPE EbReferenceObjectCtor(
  *****************************************/
 EB_ERRORTYPE EbPaReferenceObjectCtor(
     EB_PTR  *objectDblPtr,
-    EB_PTR   objectInitDataPtr)
+    EB_PTR   objectInitDataPtr,
+    EB_HANDLE encHandle)
 {
 
     EbPaReferenceObject_t               *paReferenceObject;
     EbPictureBufferDescInitData_t       *pictureBufferDescInitDataPtr   = (EbPictureBufferDescInitData_t*) objectInitDataPtr;
     EB_ERRORTYPE return_error                                           = EB_ErrorNone;
-    EB_MALLOC(EbPaReferenceObject_t*, paReferenceObject, sizeof(EbPaReferenceObject_t), EB_N_PTR);
+    EB_MALLOC(EbPaReferenceObject_t*, paReferenceObject, sizeof(EbPaReferenceObject_t), EB_N_PTR, encHandle);
     *objectDblPtr = (EB_PTR) paReferenceObject;
 
     // Reference picture constructor
     return_error = EbPictureBufferDescCtor(
         (EB_PTR*) &(paReferenceObject->inputPaddedPicturePtr),
-        (EB_PTR )   pictureBufferDescInitDataPtr);
+        (EB_PTR )   pictureBufferDescInitDataPtr,
+        encHandle);
     if (return_error == EB_ErrorInsufficientResources){
         return EB_ErrorInsufficientResources;
     }
@@ -241,7 +247,8 @@ EB_ERRORTYPE EbPaReferenceObjectCtor(
 	paReferenceObject->quarterDecimatedPicturePtr = (EbPictureBufferDesc_t*)EB_NULL;
         return_error = EbPictureBufferDescCtor(
             (EB_PTR*) &(paReferenceObject->quarterDecimatedPicturePtr),
-            (EB_PTR )  (pictureBufferDescInitDataPtr + 1));
+            (EB_PTR )  (pictureBufferDescInitDataPtr + 1),
+            encHandle);
         if (return_error == EB_ErrorInsufficientResources){
             return EB_ErrorInsufficientResources;
         }
@@ -250,7 +257,8 @@ EB_ERRORTYPE EbPaReferenceObjectCtor(
 	paReferenceObject->sixteenthDecimatedPicturePtr = (EbPictureBufferDesc_t*)EB_NULL;
         return_error = EbPictureBufferDescCtor(
             (EB_PTR*) &(paReferenceObject->sixteenthDecimatedPicturePtr),
-            (EB_PTR )  (pictureBufferDescInitDataPtr + 2));
+            (EB_PTR )  (pictureBufferDescInitDataPtr + 2),
+            encHandle);
 		if (return_error == EB_ErrorInsufficientResources){
             return EB_ErrorInsufficientResources;
         }

--- a/Source/Lib/Codec/EbReferenceObject.h
+++ b/Source/Lib/Codec/EbReferenceObject.h
@@ -66,11 +66,13 @@ typedef struct EbPaReferenceObjectDescInitData_s {
  **************************************/
 extern EB_ERRORTYPE EbReferenceObjectCtor(
     EB_PTR *objectDblPtr, 
-    EB_PTR objectInitDataPtr);
+    EB_PTR objectInitDataPtr,
+    EB_HANDLE encHandle);
 
 extern EB_ERRORTYPE EbPaReferenceObjectCtor(
     EB_PTR *objectDblPtr, 
-    EB_PTR objectInitDataPtr);
+    EB_PTR objectInitDataPtr,
+    EB_HANDLE encHandle);
 
 #ifdef __cplusplus
 }

--- a/Source/Lib/Codec/EbResourceCoordinationProcess.c
+++ b/Source/Lib/Codec/EbResourceCoordinationProcess.c
@@ -32,12 +32,14 @@ EB_ERRORTYPE ResourceCoordinationContextCtor(
     EbFifo_t                        *sequenceControlSetEmptyFifoPtr,
     EbCallback_t                **appCallbackPtrArray,
     EB_U32                          *computeSegmentsTotalCountArray,
-    EB_U32                           encodeInstancesTotalCount)
+    EB_U32                           encodeInstancesTotalCount,
+    EB_HANDLE                        encHandle)
 {
     EB_U32 instanceIndex;
 
     ResourceCoordinationContext_t *contextPtr;
-    EB_MALLOC(ResourceCoordinationContext_t*, contextPtr, sizeof(ResourceCoordinationContext_t), EB_N_PTR);
+
+    EB_MALLOC(ResourceCoordinationContext_t*, contextPtr, sizeof(ResourceCoordinationContext_t), EB_N_PTR, encHandle);
 
     *contextDblPtr = contextPtr;
 
@@ -51,14 +53,14 @@ EB_ERRORTYPE ResourceCoordinationContextCtor(
     contextPtr->encodeInstancesTotalCount                   = encodeInstancesTotalCount;
 
     // Allocate SequenceControlSetActiveArray
-    EB_MALLOC(EbObjectWrapper_t**, contextPtr->sequenceControlSetActiveArray, sizeof(EbObjectWrapper_t*) * contextPtr->encodeInstancesTotalCount, EB_N_PTR);
+    EB_MALLOC(EbObjectWrapper_t**, contextPtr->sequenceControlSetActiveArray, sizeof(EbObjectWrapper_t*) * contextPtr->encodeInstancesTotalCount, EB_N_PTR, encHandle);
 
     for(instanceIndex=0; instanceIndex < contextPtr->encodeInstancesTotalCount; ++instanceIndex) {
         contextPtr->sequenceControlSetActiveArray[instanceIndex] = 0;
     }
 
     // Picture Stats
-    EB_MALLOC(EB_U64*, contextPtr->pictureNumberArray, sizeof(EB_U64) * contextPtr->encodeInstancesTotalCount, EB_N_PTR);
+    EB_MALLOC(EB_U64*, contextPtr->pictureNumberArray, sizeof(EB_U64) * contextPtr->encodeInstancesTotalCount, EB_N_PTR, encHandle);
 
     for(instanceIndex=0; instanceIndex < contextPtr->encodeInstancesTotalCount; ++instanceIndex) {
         contextPtr->pictureNumberArray[instanceIndex] = 0;
@@ -82,6 +84,8 @@ EB_ERRORTYPE ResourceCoordinationContextCtor(
 
 	contextPtr->previousBufferCheck1 = 0;
 	contextPtr->prevChangeCond = 0;
+
+    contextPtr->encHandle = encHandle;
     return EB_ErrorNone;
 }
 
@@ -486,7 +490,7 @@ void* ResourceCoordinationKernel(void *inputPtr)
                 sequenceControlSetPtr,
                 inputSize);
 
-            LcuParamsInit(sequenceControlSetPtr);
+            LcuParamsInit(sequenceControlSetPtr, contextPtr->encHandle);
         }
 
         //Get a New ParentPCS where we will hold the new inputPicture

--- a/Source/Lib/Codec/EbResourceCoordinationProcess.h
+++ b/Source/Lib/Codec/EbResourceCoordinationProcess.h
@@ -54,6 +54,7 @@ typedef struct ResourceCoordinationContext_s
     EB_U64                               firstInPicArrivedTimeuSeconds;
 	EB_BOOL                              startFlag;
 
+    EB_HANDLE                            encHandle;
 } ResourceCoordinationContext_t;
 
 /***************************************
@@ -68,7 +69,8 @@ extern EB_ERRORTYPE ResourceCoordinationContextCtor(
     EbFifo_t                            *sequenceControlSetEmptyFifoPtr,
     EbCallback_t                    **appCallbackPtrArray,
     EB_U32                              *computeSegmentsTotalCountArray,
-    EB_U32                               encodeInstancesTotalCount);
+    EB_U32                               encodeInstancesTotalCount,
+    EB_HANDLE                            encHandle);
     
   
 

--- a/Source/Lib/Codec/EbResourceCoordinationResults.c
+++ b/Source/Lib/Codec/EbResourceCoordinationResults.c
@@ -9,10 +9,11 @@
 
 EB_ERRORTYPE ResourceCoordinationResultCtor(
     EB_PTR *objectDblPtr,
-    EB_PTR objectInitDataPtr)
+    EB_PTR objectInitDataPtr,
+    EB_HANDLE encHandle)
 {
     ResourceCoordinationResults_t *objectPtr;
-    EB_MALLOC(ResourceCoordinationResults_t*, objectPtr, sizeof(ResourceCoordinationResults_t), EB_N_PTR);
+    EB_MALLOC(ResourceCoordinationResults_t*, objectPtr, sizeof(ResourceCoordinationResults_t), EB_N_PTR, encHandle);
 
     *objectDblPtr = objectPtr;
 

--- a/Source/Lib/Codec/EbResourceCoordinationResults.h
+++ b/Source/Lib/Codec/EbResourceCoordinationResults.h
@@ -30,7 +30,8 @@ typedef struct ResourceCoordinationResultInitData_s
  **************************************/
 extern EB_ERRORTYPE ResourceCoordinationResultCtor(
     EB_PTR *objectDblPtr, 
-    EB_PTR objectInitDataPtr);
+    EB_PTR objectInitDataPtr,
+    EB_HANDLE encHandle);
 
 
 #ifdef __cplusplus

--- a/Source/Lib/Codec/EbSampleAdaptiveOffset.h
+++ b/Source/Lib/Codec/EbSampleAdaptiveOffset.h
@@ -18,7 +18,7 @@ extern "C" {
 #endif
 struct PictureControlSet_s;
 
-extern EB_ERRORTYPE SaoStatsCtor(SaoStats_t **saoStatsPtr);
+extern EB_ERRORTYPE SaoStatsCtor(SaoStats_t **saoStatsPtr, EB_HANDLE encHandle);
 
 
 extern EB_ERRORTYPE SaoGenerationDecision(

--- a/Source/Lib/Codec/EbSampleAdaptiveOffsetGenerationDecision.c
+++ b/Source/Lib/Codec/EbSampleAdaptiveOffsetGenerationDecision.c
@@ -21,21 +21,21 @@ static EB_S32 MinSaoOffsetvalueBO[2 /*8bit+10bit*/] = { -7 ,-31 };
 /********************************************
  * Sao Stats Ctor
  ********************************************/
-EB_ERRORTYPE SaoStatsCtor(SaoStats_t **saoStatsPtr)
+EB_ERRORTYPE SaoStatsCtor(SaoStats_t **saoStatsPtr, EB_HANDLE encHandle)
 {
     EB_U32 videoComponent; 
 
     SaoStats_t *saoStats;
-    EB_MALLOC(SaoStats_t*, saoStats, sizeof(SaoStats_t), EB_N_PTR);
+    EB_MALLOC(SaoStats_t*, saoStats, sizeof(SaoStats_t), EB_N_PTR, encHandle);
     *saoStatsPtr = saoStats;
 
-    EB_MALLOC(EB_S32**, saoStats->boDiff, sizeof(EB_S32*) * 3, EB_N_PTR);
+    EB_MALLOC(EB_S32**, saoStats->boDiff, sizeof(EB_S32*) * 3, EB_N_PTR, encHandle);
 
-    EB_MALLOC(EB_U16**, saoStats->boCount, sizeof(EB_U32*) * 3, EB_N_PTR);
+    EB_MALLOC(EB_U16**, saoStats->boCount, sizeof(EB_U32*) * 3, EB_N_PTR, encHandle);
 
     for(videoComponent = 0; videoComponent < 3; ++videoComponent) {
-        EB_MALLOC(EB_S32*, saoStats->boDiff[videoComponent], sizeof(EB_S32) * SAO_BO_INTERVALS, EB_N_PTR);
-        EB_MALLOC(EB_U16*, saoStats->boCount[videoComponent], sizeof(EB_U32) * SAO_BO_INTERVALS, EB_N_PTR);
+        EB_MALLOC(EB_S32*, saoStats->boDiff[videoComponent], sizeof(EB_S32) * SAO_BO_INTERVALS, EB_N_PTR, encHandle);
+        EB_MALLOC(EB_U16*, saoStats->boCount[videoComponent], sizeof(EB_U32) * SAO_BO_INTERVALS, EB_N_PTR, encHandle);
     }
     return EB_ErrorNone;
 }

--- a/Source/Lib/Codec/EbSei.c
+++ b/Source/Lib/Codec/EbSei.c
@@ -22,10 +22,11 @@ void EbVideoUsabilityInfoCopy(
 }
 
 EB_ERRORTYPE EbVideoUsabilityInfoCtor(
-    AppVideoUsabilityInfo_t *vuiPtr)
+    AppVideoUsabilityInfo_t *vuiPtr,
+    EB_HANDLE encHandle)
 {
     AppHrdParameters_t* hrdParamPtr;
-    EB_MALLOC(AppHrdParameters_t*, vuiPtr->hrdParametersPtr, sizeof(AppHrdParameters_t), EB_N_PTR);
+    EB_MALLOC(AppHrdParameters_t*, vuiPtr->hrdParametersPtr, sizeof(AppHrdParameters_t), EB_N_PTR, encHandle);
 
     hrdParamPtr = vuiPtr->hrdParametersPtr;
 

--- a/Source/Lib/Codec/EbSei.h
+++ b/Source/Lib/Codec/EbSei.h
@@ -307,7 +307,8 @@ extern "C" {
 
 
 EB_ERRORTYPE EbVideoUsabilityInfoCtor(
-    AppVideoUsabilityInfo_t *vuiPtr);
+    AppVideoUsabilityInfo_t *vuiPtr,
+    EB_HANDLE encHandle);
 
 
 

--- a/Source/Lib/Codec/EbSequenceControlSet.h
+++ b/Source/Lib/Codec/EbSequenceControlSet.h
@@ -220,7 +220,8 @@ typedef struct EbSequenceControlSetInstance_s
  **************************************/
 extern EB_ERRORTYPE EbSequenceControlSetCtor(
     EB_PTR                          *objectDblPtr, 
-    EB_PTR                           objectInitDataPtr);
+    EB_PTR                           objectInitDataPtr,
+    EB_HANDLE                        encHandle);
     
 
 
@@ -229,10 +230,12 @@ extern EB_ERRORTYPE CopySequenceControlSet(
     SequenceControlSet_t            *src);
         
 extern EB_ERRORTYPE EbSequenceControlSetInstanceCtor(
-    EbSequenceControlSetInstance_t **objectDblPtr);
+    EbSequenceControlSetInstance_t **objectDblPtr,
+    EB_HANDLE encHandle);
 
 extern EB_ERRORTYPE LcuParamsInit(
-    SequenceControlSet_t *sequenceControlSetPtr);
+    SequenceControlSet_t *sequenceControlSetPtr,
+    EB_HANDLE encHandle);
 extern EB_ERRORTYPE DeriveInputResolution(
     SequenceControlSet_t *sequenceControlSetPtr,
     EB_U32                inputSize);

--- a/Source/Lib/Codec/EbSourceBasedOperationsProcess.c
+++ b/Source/Lib/Codec/EbSourceBasedOperationsProcess.c
@@ -66,11 +66,12 @@ const EB_U8 EbHevcMaxDeltaQPdefault[3] = {
 EB_ERRORTYPE SourceBasedOperationsContextCtor(
     SourceBasedOperationsContext_t **contextDblPtr,
     EbFifo_t						*initialRateControlResultsInputFifoPtr,
-    EbFifo_t						*pictureDemuxResultsOutputFifoPtr)
+    EbFifo_t						*pictureDemuxResultsOutputFifoPtr,
+    EB_HANDLE                        encHandle)
 {
 	SourceBasedOperationsContext_t *contextPtr;
 
-	EB_MALLOC(SourceBasedOperationsContext_t*, contextPtr, sizeof(SourceBasedOperationsContext_t), EB_N_PTR);
+	EB_MALLOC(SourceBasedOperationsContext_t*, contextPtr, sizeof(SourceBasedOperationsContext_t), EB_N_PTR, encHandle);
 	*contextDblPtr = contextPtr;
 	contextPtr->initialrateControlResultsInputFifoPtr = initialRateControlResultsInputFifoPtr;
 	contextPtr->pictureDemuxResultsOutputFifoPtr = pictureDemuxResultsOutputFifoPtr;

--- a/Source/Lib/Codec/EbSourceBasedOperationsProcess.h
+++ b/Source/Lib/Codec/EbSourceBasedOperationsProcess.h
@@ -64,7 +64,6 @@ typedef struct SourceBasedOperationsContext_s
     EB_U8   *yMeanPtr;
 	EB_U8   *crMeanPtr;
 	EB_U8   *cbMeanPtr;
-
 } SourceBasedOperationsContext_t;
 
 /***************************************
@@ -74,7 +73,8 @@ typedef struct SourceBasedOperationsContext_s
 extern EB_ERRORTYPE SourceBasedOperationsContextCtor(
     SourceBasedOperationsContext_t **contextDblPtr,
     EbFifo_t						*initialrateControlResultsInputFifoPtr,
-    EbFifo_t					    *pictureDemuxResultsOutputFifoPtr);
+    EbFifo_t					    *pictureDemuxResultsOutputFifoPtr,
+    EB_HANDLE                        encHandle);
 
 extern void* SourceBasedOperationsKernel(void *inputPtr);
 

--- a/Source/Lib/Codec/EbSystemResourceManager.h
+++ b/Source/Lib/Codec/EbSystemResourceManager.h
@@ -220,7 +220,8 @@ extern EB_ERRORTYPE EbSystemResourceCtor(
     EbFifo_t          ***consumerFifoPtrArrayPtr,
     EB_BOOL              fullFifoEnabled,
     EB_CTOR              ObjectCtor,
-    EB_PTR               objectInitDataPtr);
+    EB_PTR               objectInitDataPtr,
+    EB_HANDLE            encHandle);
 
 /*********************************************************************
  * EbSystemResourceDtor

--- a/Source/Lib/Codec/EbThreads.c
+++ b/Source/Lib/Codec/EbThreads.c
@@ -317,3 +317,19 @@ EB_ERRORTYPE EbDestroyMutex(
 
     return return_error;
 }
+
+EB_BOOL get_enc_ctx_mem_map_entry(enc_ctx_mem_map_t **enc_ctx_mm_entry, EB_HANDLE encHandle)
+{
+    struct list_head *pos, *n;
+    EB_BOOL ret = EB_FALSE;
+
+    list_for_each_safe(pos, n, &enc_ctx_mem_map_manager) {
+        *enc_ctx_mm_entry = list_entry(pos, enc_ctx_mem_map_t, list);
+        if ((*enc_ctx_mm_entry)->encHandlePtr == encHandle) {
+            ret = EB_TRUE;
+            break;
+        }
+    }
+
+    return ret;
+}

--- a/Source/Lib/Codec/EbThreads.h
+++ b/Source/Lib/Codec/EbThreads.h
@@ -55,43 +55,48 @@ extern EB_ERRORTYPE EbBlockOnMutexTimeout(
 extern EB_ERRORTYPE EbDestroyMutex(
     EB_HANDLE mutexHandle);
 
-extern    EbMemoryMapEntry        *memoryMap;               // library Memory table
-extern    EB_U32                  *memoryMapIndex;          // library memory index
 extern    EB_U64                  *totalLibMemory;          // library Memory malloc'd
 
 #ifdef _WIN32
 extern    GROUP_AFFINITY           groupAffinity;
 extern    EB_U8                    numGroups;
 extern    EB_BOOL                  alternateGroups;
-#define EB_CREATETHREAD(type, pointer, nElements, pointerClass, threadFunction, threadContext) \
-    pointer = EbCreateThread(threadFunction, threadContext); \
-    if (pointer == (type)EB_NULL) { \
-        return EB_ErrorInsufficientResources; \
-    } \
-    else { \
-        memoryMap[*(memoryMapIndex)].ptrType = pointerClass; \
-        memoryMap[(*(memoryMapIndex))++].ptr = pointer; \
-        if (nElements % 8 == 0) { \
-            *totalLibMemory += (nElements); \
+#define EB_CREATETHREAD(type, pointer, nElements, pointerClass, threadFunction, threadContext, encHandle) \
+    do { \
+        enc_ctx_mem_map_t *enc_ctx_mm_entry = EB_NULL; \
+        if (!get_enc_ctx_mem_map_entry(&enc_ctx_mm_entry, encHandle)) { \
+            return EB_ErrorInsufficientResources; \
+        } \
+        pointer = EbCreateThread(threadFunction, threadContext); \
+        if (pointer == (type)EB_NULL) { \
+            return EB_ErrorInsufficientResources; \
         } \
         else { \
-            *totalLibMemory += ((nElements) + (8 - ((nElements) % 8))); \
+            enc_ctx_mm_entry->memoryMap[enc_ctx_mm_entry->memoryMapIndex].ptrType = pointerClass; \
+            enc_ctx_mm_entry->memoryMap[enc_ctx_mm_entry->memoryMapIndex++].ptr = pointer; \
+            if (nElements % 8 == 0) { \
+                *totalLibMemory += (nElements); \
+            } \
+            else { \
+                *totalLibMemory += ((nElements) + (8 - ((nElements) % 8))); \
+            } \
+            if(numGroups == 1) {\
+                SetThreadAffinityMask(pointer, groupAffinity.Mask);\
+            }\
+            else if (numGroups == 2 && alternateGroups){ \
+                groupAffinity.Group = 1 - groupAffinity.Group; \
+                SetThreadGroupAffinity(pointer,&groupAffinity,NULL); \
+            } \
+            else if (numGroups == 2 && !alternateGroups){ \
+                SetThreadGroupAffinity(pointer,&groupAffinity,NULL); \
+            } \
         } \
-        if(numGroups == 1) {\
-            SetThreadAffinityMask(pointer, groupAffinity.Mask);\
-        }\
-        else if (numGroups == 2 && alternateGroups){ \
-            groupAffinity.Group = 1 - groupAffinity.Group; \
-            SetThreadGroupAffinity(pointer,&groupAffinity,NULL); \
+        if (enc_ctx_mm_entry->memoryMapIndex >= MAX_NUM_PTR) { \
+            EbDestroyThread(pointer); \
+            return EB_ErrorInsufficientResources; \
         } \
-        else if (numGroups == 2 && !alternateGroups){ \
-            SetThreadGroupAffinity(pointer,&groupAffinity,NULL); \
-        } \
-    } \
-    if (*(memoryMapIndex) >= MAX_NUM_PTR) { \
-        return EB_ErrorInsufficientResources; \
-    } \
-    libThreadCount++;
+        libThreadCount++; \
+    } while (0)
 #elif defined(__linux__)
 #ifndef __cplusplus
 #define __USE_GNU
@@ -100,48 +105,61 @@ extern    EB_BOOL                  alternateGroups;
 #include <sched.h>
 #include <pthread.h>
 extern    cpu_set_t                   groupAffinity;
-#define EB_CREATETHREAD(type, pointer, nElements, pointerClass, threadFunction, threadContext) \
-    pointer = EbCreateThread(threadFunction, threadContext); \
-    if (pointer == (type)EB_NULL) { \
-        return EB_ErrorInsufficientResources; \
-    } \
-    else { \
-        pthread_setaffinity_np(*((pthread_t*)pointer),sizeof(cpu_set_t),&groupAffinity); \
-        memoryMap[*(memoryMapIndex)].ptrType = pointerClass; \
-        memoryMap[(*(memoryMapIndex))++].ptr = pointer; \
-		if (nElements % 8 == 0) { \
-			*totalLibMemory += (nElements); \
-		} \
-		else { \
-			*totalLibMemory += ((nElements) + (8 - ((nElements) % 8))); \
-		} \
-    } \
-    if (*(memoryMapIndex) >= MAX_NUM_PTR) { \
-        return EB_ErrorInsufficientResources; \
-    } \
-    libThreadCount++;
+#define EB_CREATETHREAD(type, pointer, nElements, pointerClass, threadFunction, threadContext, encHandle) \
+    do { \
+        enc_ctx_mem_map_t *enc_ctx_mm_entry = EB_NULL; \
+        if (!get_enc_ctx_mem_map_entry(&enc_ctx_mm_entry, encHandle)) { \
+            return EB_ErrorInsufficientResources; \
+        } \
+        pointer = EbCreateThread(threadFunction, threadContext); \
+        if (pointer == (type)EB_NULL) { \
+            return EB_ErrorInsufficientResources; \
+        } \
+        else { \
+            pthread_setaffinity_np(*((pthread_t*)pointer),sizeof(cpu_set_t),&groupAffinity); \
+            enc_ctx_mm_entry->memoryMap[enc_ctx_mm_entry->memoryMapIndex].ptrType = pointerClass; \
+            enc_ctx_mm_entry->memoryMap[enc_ctx_mm_entry->memoryMapIndex++].ptr = pointer; \
+            if (nElements % 8 == 0) { \
+                *totalLibMemory += (nElements); \
+            } \
+            else { \
+                *totalLibMemory += ((nElements) + (8 - ((nElements) % 8))); \
+            } \
+        } \
+        if (enc_ctx_mm_entry->memoryMapIndex >= MAX_NUM_PTR) { \
+            EbDestroyThread(pointer); \
+            return EB_ErrorInsufficientResources; \
+        } \
+        libThreadCount++; \
+    } while (0)
 #else
-#define EB_CREATETHREAD(type, pointer, nElements, pointerClass, threadFunction, threadContext) \
-    pointer = EbCreateThread(threadFunction, threadContext); \
-    if (pointer == (type)EB_NULL) { \
-        return EB_ErrorInsufficientResources; \
-    } \
-    else { \
-        memoryMap[*(memoryMapIndex)].ptrType = pointerClass; \
-        memoryMap[(*(memoryMapIndex))++].ptr = pointer; \
-		if (nElements % 8 == 0) { \
-			*totalLibMemory += (nElements); \
-		} \
-		else { \
-			*totalLibMemory += ((nElements) + (8 - ((nElements) % 8))); \
-		} \
-    } \
-    if (*(memoryMapIndex) >= MAX_NUM_PTR) { \
-        return EB_ErrorInsufficientResources; \
-    } \
-    libThreadCount++;
+#define EB_CREATETHREAD(type, pointer, nElements, pointerClass, threadFunction, threadContext, encHandle) \
+    do { \
+        enc_ctx_mem_map_t *enc_ctx_mm_entry = EB_NULL; \
+        if (!get_enc_ctx_mem_map_entry(&enc_ctx_mm_entry, encHandle)) { \
+            return EB_ErrorInsufficientResources; \
+        } \
+        pointer = EbCreateThread(threadFunction, threadContext); \
+        if (pointer == (type)EB_NULL) { \
+            return EB_ErrorInsufficientResources; \
+        } \
+        else { \
+            enc_ctx_mm_entry->memoryMap[enc_ctx_mm_entry->memoryMapIndex].ptrType = pointerClass; \
+            enc_ctx_mm_entry->memoryMap[enc_ctx_mm_entry->memoryMapIndex++].ptr = pointer; \
+            if (nElements % 8 == 0) { \
+                *totalLibMemory += (nElements); \
+            } \
+            else { \
+                *totalLibMemory += ((nElements) + (8 - ((nElements) % 8))); \
+            } \
+        } \
+        if (enc_ctx_mm_entry->memoryMapIndex >= MAX_NUM_PTR) { \
+            EbDestroyThread(pointer); \
+            return EB_ErrorInsufficientResources; \
+        } \
+        libThreadCount++; \
+    } while (0)
 #endif
-
 
 #ifdef __cplusplus
 }

--- a/Source/Lib/Codec/EbTransQuantBuffers.c
+++ b/Source/Lib/Codec/EbTransQuantBuffers.c
@@ -10,7 +10,8 @@
 
 
 EB_ERRORTYPE EbTransQuantBuffersCtor(
-    EbTransQuantBuffers_t          *transQuantBuffersPtr)
+    EbTransQuantBuffers_t          *transQuantBuffersPtr,
+    EB_HANDLE                       encHandle)
 {
     EB_ERRORTYPE return_error = EB_ErrorNone;
     EbPictureBufferDescInitData_t transCoeffInitArray;
@@ -28,34 +29,39 @@ EB_ERRORTYPE EbTransQuantBuffersCtor(
 
     return_error = EbPictureBufferDescCtor(
         (EB_PTR*) &(transQuantBuffersPtr->tuTransCoeff2Nx2NPtr),
-        (EB_PTR ) &transCoeffInitArray);
+        (EB_PTR ) &transCoeffInitArray,
+        encHandle);
     if (return_error == EB_ErrorInsufficientResources){
         return EB_ErrorInsufficientResources;
     }
 
     return_error = EbPictureBufferDescCtor(
         (EB_PTR*) &(transQuantBuffersPtr->tuTransCoeffNxNPtr),
-        (EB_PTR ) &transCoeffInitArray);
+        (EB_PTR ) &transCoeffInitArray,
+        encHandle);
     if (return_error == EB_ErrorInsufficientResources){
         return EB_ErrorInsufficientResources;
     }
 
     return_error = EbPictureBufferDescCtor(
         (EB_PTR*) &(transQuantBuffersPtr->tuTransCoeffN2xN2Ptr),
-        (EB_PTR ) &transCoeffInitArray);
+        (EB_PTR ) &transCoeffInitArray,
+        encHandle);
     if (return_error == EB_ErrorInsufficientResources){
         return EB_ErrorInsufficientResources;
     }
     return_error = EbPictureBufferDescCtor(
         (EB_PTR*) &(transQuantBuffersPtr->tuQuantCoeffNxNPtr),
-        (EB_PTR ) &transCoeffInitArray);
+        (EB_PTR ) &transCoeffInitArray,
+        encHandle);
     if (return_error == EB_ErrorInsufficientResources){
         return EB_ErrorInsufficientResources;
     }
 
     return_error = EbPictureBufferDescCtor(
         (EB_PTR*) &(transQuantBuffersPtr->tuQuantCoeffN2xN2Ptr),
-        (EB_PTR ) &transCoeffInitArray);
+        (EB_PTR ) &transCoeffInitArray,
+        encHandle);
     if (return_error == EB_ErrorInsufficientResources){
         return EB_ErrorInsufficientResources;
     }

--- a/Source/Lib/Codec/EbTransQuantBuffers.h
+++ b/Source/Lib/Codec/EbTransQuantBuffers.h
@@ -24,7 +24,8 @@ typedef struct EbTransQuantBuffers_s
 
   
 extern EB_ERRORTYPE EbTransQuantBuffersCtor(
-	EbTransQuantBuffers_t			*transQuantBuffersPtr);  
+	EbTransQuantBuffers_t			*transQuantBuffersPtr,
+    EB_HANDLE                        encHandle);
     
    
 #ifdef __cplusplus

--- a/Source/Lib/Codec/EbUtility.h
+++ b/Source/Lib/Codec/EbUtility.h
@@ -1,6 +1,7 @@
 /*
 * Copyright(c) 2018 Intel Corporation
 * SPDX - License - Identifier: BSD - 2 - Clause - Patent
+* SPDX-License-Identifier: GPL-2.0
 */
 
 #ifndef EbUtility_h
@@ -203,6 +204,65 @@ void EbHevcStartTime(EB_U64 *Startseconds, EB_U64 *Startuseconds);
 void EbHevcFinishTime(EB_U64 *Finishseconds, EB_U64 *Finishuseconds);
 void EbHevcComputeOverallElapsedTime(EB_U64 Startseconds, EB_U64 Startuseconds, EB_U64 Finishseconds, EB_U64 Finishuseconds, double *duration);
 void EbHevcComputeOverallElapsedTimeMs(EB_U64 Startseconds, EB_U64 Startuseconds, EB_U64 Finishseconds, EB_U64 Finishuseconds, double *duration);
+
+/*
+ * Simple doubly linked list implementation copied from Linux kernel.
+ *
+ * Some of the internal functions ("__xxx") are useful when
+ * manipulating whole lists rather than single entries, as
+ * sometimes we already know the next/prev entries and we can
+ * generate better code by using them directly rather than
+ * using the generic single-entry routines.
+ */
+
+#define LIST_POISON1 ((void *)0x00100100)
+#define LIST_POISON2 ((void *)0x00200200)
+
+#define list_for_each(pos, head) \
+    for (pos = (head)->next; pos != (head); pos = pos->next)
+
+static inline void __list_add(struct list_head *new,
+        struct list_head *prev, struct list_head *next)
+{
+    next->prev = new;
+    new->next = next;
+    new->prev = prev;
+    prev->next = new;
+}
+
+static inline void list_add(struct list_head *new, struct list_head *head)
+{
+    __list_add(new, head, head->next);
+}
+
+static inline void INIT_LIST_HEAD(struct list_head *list)
+{
+    list->next = list;
+    list->prev = list;
+}
+
+static inline void list_add_tail(struct list_head *new, struct list_head *head)
+{
+    __list_add(new, head->prev, head);
+}
+
+static inline void __list_del(struct list_head *prev, struct list_head *next)
+{
+    next->prev = prev;
+    prev->next = next;
+}
+
+static inline void list_del(struct list_head *entry)
+{
+    __list_del(entry->prev, entry->next);
+    entry->next = LIST_POISON1;
+    entry->prev = LIST_POISON2;
+}
+
+static inline int list_empty(const struct list_head *head)
+{
+    return head->next == head;
+}
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Because currently almost all the objects allocated in heap are
managed by the memoryMap, addressed the issue by:
1. Managing the memory maps with encoding context via linked list;
2. Searching for the corresponding memory map with the current
   encoding context.

Note: thread ID (POSIX pthread_t) can't be used to distinguish the
memory maps, because the SVT APIs may be invoked within different
threads by applications or framework plugins.

NOTE: the most reasonable solution is:
1. Free the allocated objects at the end of each kernel thread;
2. Join each kernel thread, destruct each kernel context and System
   Resource object in EbDeinitEncoder().

Signed-off-by: Austin Hu <austin.hu@intel.com>

Fixes Issue #357 .