### PR TITLE
Revert "Fix reading input for fifo in ReadInputFrames"

### DIFF
--- a/Source/App/EbAppInputy4m.c
+++ b/Source/App/EbAppInputy4m.c
@@ -345,7 +345,12 @@ EB_BOOL check_if_y4m(EbConfig_t *cfg) {
         return EB_TRUE; /* YUV4MPEG2 file */
     }
     else {
-        EB_STRNCPY((char*)cfg->y4m_buf, sizeof(cfg->y4m_buf), (char*)buffer, YUV4MPEG2_IND_SIZE);
+        if (cfg->inputFile != stdin) {
+            fseek(cfg->inputFile, 0, SEEK_SET);
+        }
+        else {
+            EB_STRNCPY((char*)cfg->y4m_buf, sizeof(cfg->y4m_buf), (char*)buffer, YUV4MPEG2_IND_SIZE);
+        }
         return EB_FALSE; /* Not a YUV4MPEG2 file */
     }
 }

--- a/Source/App/EbAppProcessCmd.c
+++ b/Source/App/EbAppProcessCmd.c
@@ -822,9 +822,9 @@ static void ReadInputFrames(
                     read_y4m_frame_delimiter(config);
                 const uint32_t lumaReadSize = inputPaddedWidth * inputPaddedHeight << is16bit;
                 ebInputPtr = inputPtr->luma;
-                if (config->y4m_input == EB_FALSE && config->processedFrameCount == 0) {
-                    /* if not a y4m file, 9 bytes were already read when checking
-                       the YUV4MPEG2 string in the stream, so copy those bytes over */
+                if (config->y4m_input == EB_FALSE && config->processedFrameCount == 0 && config->inputFile == stdin) {
+                    /* if not a y4m file and input is read from stdin, 9 bytes were already read when checking
+                       or the YUV4MPEG2 string in the stream, so copy those bytes over */
                     memcpy(ebInputPtr, config->y4m_buf, YUV4MPEG2_IND_SIZE);
                     headerPtr->nFilledLen += YUV4MPEG2_IND_SIZE;
                     ebInputPtr += YUV4MPEG2_IND_SIZE;


### PR DESCRIPTION
Reverts OpenVisualCloud/SVT-HEVC#436 which breaks reading 10bits and -nb input.
For non-stdin input(-i), only seekable stream is supported by sample app for now.
For other corner case(fifo, socket etc.) please disable y4m probing(in SetCfgInputFile) on your personal branch.

Signed-off-by: Jun Tian <jun.tian@intel.com>

Fixes #443  #441 