### PR TITLE
Fix output buffer too small issue

### DIFF
--- a/Source/App/EbAppContext.c
+++ b/Source/App/EbAppContext.c
@@ -19,9 +19,7 @@
 #define INPUT_SIZE_4K_TH				0x29F630    // 2.75 Million
 #define INPUT_SIZE_8K_TH				0xB71B00    // 12 Million
 
-#define SIZE_OF_ONE_FRAME_IN_BYTES(width, height,is16bit) ( ( ((width)*(height)*3)>>1 )<<is16bit)
 #define IS_16_BIT(bit_depth) (bit_depth==10?1:0)
-#define EB_OUTPUTSTREAMBUFFERSIZE_MACRO(ResolutionSize)                ((ResolutionSize) < (INPUT_SIZE_1080i_TH) ? 0x1E8480 : (ResolutionSize) < (INPUT_SIZE_1080p_TH) ? 0x2DC6C0 : (ResolutionSize) < (INPUT_SIZE_4K_TH) ? 0x2DC6C0 : (ResolutionSize) < (INPUT_SIZE_8K_TH) ? 0x2DC6C0:0x5B8D80)
 
  /***************************************
  * Variables Defining a memory table
@@ -423,7 +421,8 @@ EB_ERRORTYPE AllocateOutputBuffers(
 {
 
     EB_ERRORTYPE   return_error = EB_ErrorNone;
-    uint32_t		   outputStreamBufferSize = (uint32_t)(EB_OUTPUTSTREAMBUFFERSIZE_MACRO(config->inputPaddedHeight * config->inputPaddedWidth));;
+    uint32_t outputStreamBufferSize = SIZE_OF_ONE_FRAME_IN_BYTES(config->sourceWidth, config->sourceHeight,
+            config->encoderColorFormat, (config->encoderBitDepth > 8), config->compressedTenBitFormat);
     {
         EB_APP_MALLOC(EB_BUFFERHEADERTYPE*, callbackData->streamBufferPool, sizeof(EB_BUFFERHEADERTYPE), EB_N_PTR, EB_ErrorInsufficientResources);
 

--- a/Source/App/EbAppContext.h
+++ b/Source/App/EbAppContext.h
@@ -9,6 +9,13 @@
 #include "EbApi.h"
 #include "EbAppConfig.h"
 
+// For compressed 10-bit format, the Y/U/V 2-bit samples of each pixel are packed
+// into 1 byte for any YUV format.
+#define SIZE_OF_ONE_FRAME_IN_BYTES(width, height, format, is16bit, compressedTenBitFormat) \
+    (compressedTenBitFormat ? \
+    ((width) * (height) + 2 * (((width) * (height)) >> (3 - format)) + (width) * (height)) : \
+    ((((width) * (height)) + 2 * (((width) * (height)) >> (3 - format))) << (is16bit)))
+
 /***************************************
 
  * App Callback data struct

--- a/Source/App/EbAppProcessCmd.c
+++ b/Source/App/EbAppProcessCmd.c
@@ -24,8 +24,6 @@
 #define MIN(x, y)                       ((x)<(y)?(x):(y))
 #define CLIP3(MinVal, MaxVal, a)        (((a)<(MinVal)) ? (MinVal) : (((a)>(MaxVal)) ? (MaxVal) :(a)))
 #define FUTURE_WINDOW_WIDTH                 4
-#define SIZE_OF_ONE_FRAME_IN_BYTES(width, height, csp, is16bit) \
-    ( (((width)*(height)) + 2*(((width)*(height))>>(3-csp)) )<<is16bit)
 extern volatile int32_t keepRunning;
 
 /***************************************
@@ -780,7 +778,8 @@ static void ReadInputFrames(
     if (config->bufferedInput == -1) {
         if (is16bit == 0 || (is16bit == 1 && config->compressedTenBitFormat == 0)) {
 
-            uint32_t readSize = SIZE_OF_ONE_FRAME_IN_BYTES(inputPaddedWidth, inputPaddedHeight, colorFormat, is16bit);
+            uint32_t readSize = SIZE_OF_ONE_FRAME_IN_BYTES(inputPaddedWidth, inputPaddedHeight,
+                    colorFormat, is16bit, config->compressedTenBitFormat);
 
             headerPtr->nFilledLen = 0;
 
@@ -918,8 +917,8 @@ static void ReadInputFrames(
             inputPtr->cb = config->sequenceBuffer[config->processedFrameCount % config->bufferedInput] + lumaSize;
             inputPtr->cr = config->sequenceBuffer[config->processedFrameCount % config->bufferedInput] + lumaSize + chromaSize;
 
-            headerPtr->nFilledLen = (uint32_t)(uint64_t)SIZE_OF_ONE_FRAME_IN_BYTES(inputPaddedWidth, inputPaddedHeight, colorFormat, is16bit);
-
+            headerPtr->nFilledLen = (uint32_t)(uint64_t)SIZE_OF_ONE_FRAME_IN_BYTES(inputPaddedWidth, inputPaddedHeight,
+                    colorFormat, is16bit, config->compressedTenBitFormat);
         }
     }
 
@@ -1232,7 +1231,7 @@ APPEXITCONDITIONTYPE ProcessInputBuffer(EbConfig_t *config, EbAppContext_t *appC
 
 	totalBytesToProcessCount = (framesToBeEncoded < 0) ? -1 : (config->encoderBitDepth == 10 && config->compressedTenBitFormat == 1) ?
 		framesToBeEncoded * compressed10bitFrameSize:
-        framesToBeEncoded * SIZE_OF_ONE_FRAME_IN_BYTES(inputPaddedWidth, inputPaddedHeight, colorFormat, is16bit);
+        framesToBeEncoded * SIZE_OF_ONE_FRAME_IN_BYTES(inputPaddedWidth, inputPaddedHeight, colorFormat, is16bit, config->compressedTenBitFormat);
 
 
     remainingByteCount       = (totalBytesToProcessCount < 0) ?   -1 :  totalBytesToProcessCount - (int64_t)config->processedByteCount;


### PR DESCRIPTION
Fixed by allocating the output buffer big enough (for the worst
case of 0% compression rate), with the width, height, format, bit
depth info of the input YUV samples.

The "side" effect of the change is that more memory will be allocated
for the output buffers (typically 162 buffer with the config below):
* Encoding configuration: FrameRate: 60FPS; LookaheadDistance: 17.
  - 4096x2160 YUV420 8-bit: ~1.46 GB
  - 7680x3840 YUV444 8-bit: ~12.44 GB

Signed-off-by: Austin Hu <austin.hu@intel.com>

Fixes #64 .