### PR TITLE
Fix interlacedVideo configuration

### DIFF
--- a/Source/Lib/Codec/EbEncHandle.c
+++ b/Source/Lib/Codec/EbEncHandle.c
@@ -2207,6 +2207,8 @@ void EbHevcCopyApiFromApp(
     sequenceControlSetPtr->maxInputLumaWidth  = (EB_U16)((EB_H265_ENC_CONFIGURATION*)pComponentParameterStructure)->sourceWidth;
     sequenceControlSetPtr->maxInputLumaHeight = (EB_U16)((EB_H265_ENC_CONFIGURATION*)pComponentParameterStructure)->sourceHeight;
 
+    sequenceControlSetPtr->interlacedVideo = sequenceControlSetPtr->staticConfig.interlacedVideo;
+
     sequenceControlSetPtr->intraPeriodLength = sequenceControlSetPtr->staticConfig.intraPeriodLength;
     sequenceControlSetPtr->intraRefreshType = sequenceControlSetPtr->staticConfig.intraRefreshType;
     sequenceControlSetPtr->maxTemporalLayers = sequenceControlSetPtr->staticConfig.hierarchicalLevels;


### PR DESCRIPTION
`-interlaced-video 1` has not been updating the VPS and VUI since this line was removed in https://github.com/OpenVisualCloud/SVT-HEVC/commit/5ebc0b284557959a0579dccfc4e5cdee621e06ed#diff-c34b031bdf161695d0bd85bdc4ebf7e3L2052

Confirm using `SvtHevcEncApp -i /dev/zero -b out.265 -interlaced-video 1 -w 1920 -h 540 -fps 60 -n 5`; expect `general_interlaced_source_flag = 1` in the VPS.


Signed-off-by: Don Pham <dpham@live.ca>