### PR TITLE
Unpack fixes

### DIFF
--- a/Source/Lib/Codec/EbEncHandle.c
+++ b/Source/Lib/Codec/EbEncHandle.c
@@ -538,7 +538,7 @@ static EB_ERRORTYPE EbEncHandleCtor(
     encHandlePtr->encDecContextPtrArray                             = (EB_PTR*) EB_NULL;
     encHandlePtr->entropyCodingContextPtrArray                      = (EB_PTR*) EB_NULL;
     encHandlePtr->packetizationContextPtr                           = (EB_PTR) EB_NULL;
-    encHandlePtr->unpackContextPtr                                  = (EB_PTR) EB_NULL;
+    encHandlePtr->unpackContextPtr                                  = (EB_PTR*) EB_NULL;
 
     // System Resource Managers
     encHandlePtr->inputBufferResourcePtr                         = (EbSystemResource_t*) EB_NULL;

--- a/Source/Lib/Codec/EbPackUnPack.h
+++ b/Source/Lib/Codec/EbPackUnPack.h
@@ -67,7 +67,7 @@ COMPPack_TYPE  Convert_Unpack_CPack_funcPtrArray[EB_ASM_TYPE_TOTAL] =
 
 };
 
-typedef void(*EB_ENC_UnPack2D_TYPE)(
+typedef void(*EB_ENC_UnPack2D_FUNC_TYPE)(
     EB_U16      *in16BitBuffer,
     EB_U32       inStride,
     EB_U8       *out8BitBuffer,
@@ -77,7 +77,7 @@ typedef void(*EB_ENC_UnPack2D_TYPE)(
     EB_U32       width,
     EB_U32       height);
 
-EB_ENC_UnPack2D_TYPE UnPack2D_funcPtrArray_16Bit[2][EB_ASM_TYPE_TOTAL] =
+EB_ENC_UnPack2D_FUNC_TYPE FUNC_TABLE UnPack2D_funcPtrArray_16Bit[2][EB_ASM_TYPE_TOTAL] =
 {
     {
         // C_DEFAULT

--- a/Source/Lib/Codec/EbPictureOperators.c
+++ b/Source/Lib/Codec/EbPictureOperators.c
@@ -509,8 +509,8 @@ void UnpackL0L1AvgSafeSub(
 
 
  }
-void UnPack2D(
-    UnPackContext_t *context
+void *UnPack2D(
+    void *context
     )
 {
     EbObjectWrapper_t   *copyFrameBufferWrapperPtr;
@@ -518,7 +518,7 @@ void UnPack2D(
     EB_ENC_UnPack2D_TYPE_t            *unpack;
     
     for(;;){
-        EbGetFullObject(context->copyFrameOutputFifoPtr,&copyFrameBufferWrapperPtr);
+        EbGetFullObject(((UnPackContext_t*)context)->copyFrameOutputFifoPtr,&copyFrameBufferWrapperPtr);
         EB_CHECK_END_OBJ(copyFrameBufferWrapperPtr);
         unpack = (EB_ENC_UnPack2D_TYPE_t*)copyFrameBufferWrapperPtr->objectPtr;
 #ifndef NON_AVX512_SUPPORT
@@ -535,10 +535,11 @@ void UnPack2D(
         unpack->width,
         unpack->height);
     
-        EbGetEmptyObject(context->unPackInputFifoPtr,&unpackEndSyncWrapperPtr);
+        EbGetEmptyObject(((UnPackContext_t *)context)->unPackInputFifoPtr,&unpackEndSyncWrapperPtr);
         EbReleaseObject(copyFrameBufferWrapperPtr);
         EbPostFullObject(unpackEndSyncWrapperPtr);
     }
+    return EB_NULL;
 }
 
 void Pack2D_SRC(

--- a/Source/Lib/Codec/EbPictureOperators.h
+++ b/Source/Lib/Codec/EbPictureOperators.h
@@ -177,8 +177,8 @@ void Pack2D_SRC(
    EB_U32     width,
    EB_U32     height);
 
-void UnPack2D(
-   UnPackContext_t *context);
+void*UnPack2D(
+   void *context);
    
 void extract8Bitdata(
     EB_U16      *in16BitBuffer,


### PR DESCRIPTION
Some changes to make unpack process more consistent
with other processes

1) Changed cast of unpackContexPtr from EB_PTR to EB_PTR* to match
encHandlePtr->unpackContextPtr  definition

2) EB_ENC_UnPack2D_TYPE identify is used for two different purposes -
structure for parameters and for function type.  Renamed
definition in EbPackUnPack.h to EB_ENC_UnPack2D_FUNC_TYPE

3) Change UnPack2D function parameter to void* and cast to
UnPackContext_t* in EbGetFullObject  and EbGetEmptyObject calls

Signed-off-by: Mark Feldman <mark.feldman@intel.com>