### PR TITLE
Optimize MaxNumReorderPics in vps/sps

### DIFF
--- a/Source/Lib/Codec/EbEntropyCoding.c
+++ b/Source/Lib/Codec/EbEntropyCoding.c
@@ -5344,9 +5344,9 @@ static void CodeProfileTierLevel(
 }
 
 /**************************************************
-* DetermineMax
+* ComputeNumReorderPics
 **************************************************/
-EB_U32 DetermineNumReorderPics(SequenceControlSet_t    *scsPtr)
+EB_U32 ComputeNumReorderPics(SequenceControlSet_t    *scsPtr)
 {
     // NumReorderPics indicates the maximum number of pictures that can precede any picture in decoding 
     // order and follow it in output order.  The value needs to be no greater than the DPB size
@@ -5438,11 +5438,11 @@ static void CodeVPS(
 		    bitstreamPtr,
 			scsPtr->maxDpbSize - 1/*4*/);//(1 << (scsPtr->maxTemporalLayers-syntaxItr)));
 
-        // Max Num Reorder pics - indicates the maximum number of pictures that can precede any picture in
-        // decoding order and follow it in output order.
-        WriteUvlc(
-            bitstreamPtr,
-            DetermineNumReorderPics(scsPtr));
+		// Max Num Reorder pics - indicates the maximum number of pictures that can precede any picture in
+		// decoding order and follow it in output order.
+		WriteUvlc(
+			bitstreamPtr,
+			ComputeNumReorderPics(scsPtr));
 
         // Max Latency Increase Plus1
 		WriteUvlc(
@@ -6063,11 +6063,11 @@ static void CodeSPS(
 			bitstreamPtr,
 			scsPtr->maxDpbSize - 1/*4*/);//(1 << (scsPtr->maxTemporalLayers-syntaxItr)));
         
-        // Max Num Reorder pics - indicates the maximum number of pictures that can precede any picture in
-        // decoding order and follow it in output order.
-        WriteUvlc(
-            bitstreamPtr,
-            DetermineNumReorderPics(scsPtr));
+		// Max Num Reorder pics - indicates the maximum number of pictures that can precede any picture in
+		// decoding order and follow it in output order.
+		WriteUvlc(
+		bitstreamPtr,
+		ComputeNumReorderPics(scsPtr));
 
 		WriteUvlc(
 			bitstreamPtr,

--- a/Source/Lib/Codec/EbEntropyCoding.c
+++ b/Source/Lib/Codec/EbEntropyCoding.c
@@ -5351,25 +5351,15 @@ EB_U32 ComputeNumReorderPics(SequenceControlSet_t    *scsPtr)
     // NumReorderPics indicates the maximum number of pictures that can precede any picture in decoding 
     // order and follow it in output order.  The value needs to be no greater than the DPB size
     //
-    // The reorderPicsPerHierarchy values are determined by inspection of the graphs at the top of 
-    // shown at the top of EbPredictionStructure.c and determining the highest observed value for 
-    // NumReorderPics in any one picture within that prediction structure.
-    //
-    // Although hierchical level is defined up to level 6, current encoding configuration only will allow
-    // hierarchies up to level 4
-    //
-    //                   hierarchical level   1  2  3  4  5   6
-    const EB_U8 reorderPicsPerHierarchy[] = { 0, 1, 2, 4, 6, 14 };
+    //                   hierarchical level   1  2  3  4
+    const EB_U8 reorderPicsPerHierarchy[] = { 0, 1, 2, 3 };
 
     if (scsPtr->predStructPtr->predType == EB_PRED_LOW_DELAY_P || scsPtr->predStructPtr->predType == EB_PRED_LOW_DELAY_B)
         // For low delay prediction structures set num reorder pictures to 0
         return 0;
     else
         // For Random Access prediction structures set num reorder pictures according to the number of hierarchical layers
-        if (reorderPicsPerHierarchy[scsPtr->maxTemporalLayers] > (scsPtr->maxDpbSize - 1))
-            return scsPtr->maxDpbSize - 1;
-        else
-            return reorderPicsPerHierarchy[scsPtr->maxTemporalLayers];
+        return MIN(scsPtr->maxDpbSize - 1, reorderPicsPerHierarchy[scsPtr->maxTemporalLayers]);
 }
 
 /**************************************************
@@ -5442,7 +5432,7 @@ static void CodeVPS(
 		// Supports Main Profile Level 5 (Max Picture resolution 4Kx2K, up to 6 Hierarchy Levels)
 		// Max Dec Pic Buffering [i]
 		WriteUvlc(
-		    bitstreamPtr,
+			bitstreamPtr,
 			scsPtr->maxDpbSize - 1/*4*/);//(1 << (scsPtr->maxTemporalLayers-syntaxItr)));
 
 		// vps_max_num_reorder_pics - indicates the maximum number of pictures that can precede any picture in
@@ -5451,7 +5441,7 @@ static void CodeVPS(
 			bitstreamPtr,
 			ComputeNumReorderPics(scsPtr));
 
-        // Max Latency Increase Plus1
+		// Max Latency Increase Plus1
 		WriteUvlc(
 			bitstreamPtr,
 			0);


### PR DESCRIPTION
Changed the algorithm used to set the MaxNumReorderPics
written to the bitstream (both in SPS and VPS structures)

NumReorderPics indicates the maximum number of pictures that can precede
any picture in decoding order and follow it in output order.  The value
needs to be no greater than the DPB size

Added DetermineNumReorderPics to calculate the value based on the
prediction structure in the configuration.  For Low Delay we set
NumReorderPics to 0 and for Random Acces we set NumReorderPics to
a value according to the number of hierarchical levels