### PR TITLE
Fixed the SegFault issue for 64x64 fractional search in ME.

### DIFF
--- a/Source/Lib/Codec/EbMotionEstimation.c
+++ b/Source/Lib/Codec/EbMotionEstimation.c
@@ -799,7 +799,7 @@ static void PU_HalfPelRefinement(
         *pBestSsd = (EB_U32) SpatialFullDistortionKernel_funcPtrArray[!!(ASM_TYPES & PREAVX2_MASK)][Log2f(puWidth) - 2](
             &(contextPtr->lcuSrcPtr[puLcuBufferIndex]),
             contextPtr->lcuSrcStride,
-            refBuffer + (ySearchIndex * (EB_S32)refStride + xSearchIndex),
+            &(refBuffer[ySearchIndex * refStride + xSearchIndex]),
             refStride,
             puHeight,
             puWidth);

--- a/Source/Lib/Codec/EbMotionEstimation.c
+++ b/Source/Lib/Codec/EbMotionEstimation.c
@@ -799,7 +799,7 @@ static void PU_HalfPelRefinement(
         *pBestSsd = (EB_U32) SpatialFullDistortionKernel_funcPtrArray[!!(ASM_TYPES & PREAVX2_MASK)][Log2f(puWidth) - 2](
             &(contextPtr->lcuSrcPtr[puLcuBufferIndex]),
             contextPtr->lcuSrcStride,
-            &(refBuffer[ySearchIndex * refStride + xSearchIndex]),
+            refBuffer + (ySearchIndex * (EB_S32)refStride + xSearchIndex),
             refStride,
             puHeight,
             puWidth);

--- a/Source/Lib/Codec/EbMotionEstimation.c
+++ b/Source/Lib/Codec/EbMotionEstimation.c
@@ -4216,6 +4216,7 @@ EB_ERRORTYPE MotionEstimateLcu(
                 contextPtr->pBestSad16x16 = &(contextPtr->pLcuBestSad[listIndex][0][ME_TIER_ZERO_PU_16x16_0]);
                 contextPtr->pBestSad8x8 = &(contextPtr->pLcuBestSad[listIndex][0][ME_TIER_ZERO_PU_8x8_0]);
 
+                InitializeBuffer_32bits_funcPtrArray[!!(ASM_TYPES & PREAVX2_MASK)](contextPtr->pLcuBestMV[listIndex][0], 21, 1, 0);
                 contextPtr->pBestMV64x64 = &(contextPtr->pLcuBestMV[listIndex][0][ME_TIER_ZERO_PU_64x64]);
                 contextPtr->pBestMV32x32 = &(contextPtr->pLcuBestMV[listIndex][0][ME_TIER_ZERO_PU_32x32_0]);
                 contextPtr->pBestMV16x16 = &(contextPtr->pLcuBestMV[listIndex][0][ME_TIER_ZERO_PU_16x16_0]);


### PR DESCRIPTION
The issue happens when 64x64 fractional search is enabled with
encMode 0~2. Occationally the calculated xSearchIndex in
PU_HalfPelRefinement() could be less than 0. So getting the Y
pixels of reference buffer (integerBufferPtr of ME context) can
be done by forward shift, rather than indexing. Because
integerBufferPtr locates at some middle region region of the PA
reference buffer's Y component, and it's "legal" to access its
preceding memory region.

Signed-off-by: Austin Hu <austin.hu@intel.com>

Fixes #481 .