### PR TITLE
Change icc compiler ordering

### DIFF
--- a/Build/linux/build.sh
+++ b/Build/linux/build.sh
@@ -184,12 +184,12 @@ parse_options() {
 
 # Defines
 if [ -z "$CC" ] && [ "$(uname -a | cut -c1-5)" != "MINGW" ]; then
-    if check_executable icc "/opt/intel/bin"; then
-        CC=$(check_executable -p icc "/opt/intel/bin")
-    elif check_executable gcc; then
+    if check_executable gcc; then
         CC=$(check_executable -p gcc)
     elif check_executable clang; then
         CC=$(check_executable -p clang)
+    elif check_executable icc "/opt/intel/bin"; then
+        CC=$(check_executable -p icc "/opt/intel/bin")
     else
         CC=$(check_executable -p cc)
     fi


### PR DESCRIPTION
Changing the order that cc compilers are
checking in the linux build script.

The Intel C Compiler (icc) is now checked
after gcc and clang so that it only used
when both gcc and clang are not available.

Signed-off-by: Mark Feldman <mark.feldman@intel.com>