### PR TITLE
Refined the DEADLOCK_DEBUG outputs in each encoding stage.

### DIFF
--- a/Source/Lib/Codec/EbDefinitions.h
+++ b/Source/Lib/Codec/EbDefinitions.h
@@ -517,13 +517,13 @@ typedef void * EB_HANDLE;
 #if DEADLOCK_DEBUG
 #include <limits.h>
 // The recommended steps to debug encoding dead lock (hang) issue:
-// 1. Track the POCs in the entrace and exit of the encoding pipeline,
+// 1. Track the POCs in the entrance and exit of the encoding pipeline,
 //    by forcibly printing the 1st DEADLOCK_DEBUG log in RC, and the
 //    last DEADLOCK_DEBUG log in PK;
 // 2. Reorder the POC numbers of RC and PK separately, to check the
 //    1st POC which couldn't be outputted from PK;
 // 3. Open the DEADLOCK_DEBUG switch, and change the MIN_POC & MAX_POC
-//    values clamping the range where that POC locates.
+//    values clamping the range where that POC locates;
 // 4. Check the specific stage where that POC can't go through.
 #define MIN_POC 0
 #define MAX_POC UINT_MAX

--- a/Source/Lib/Codec/EbDefinitions.h
+++ b/Source/Lib/Codec/EbDefinitions.h
@@ -516,6 +516,15 @@ typedef void * EB_HANDLE;
 #define DEADLOCK_DEBUG                   0
 #if DEADLOCK_DEBUG
 #include <limits.h>
+// The recommended steps to debug encoding dead lock (hang) issue:
+// 1. Track the POCs in the entrace and exit of the encoding pipeline,
+//    by forcibly printing the 1st DEADLOCK_DEBUG log in RC, and the
+//    last DEADLOCK_DEBUG log in PK;
+// 2. Reorder the POC numbers of RC and PK separately, to check the
+//    1st POC which couldn't be outputted from PK;
+// 3. Open the DEADLOCK_DEBUG switch, and change the MIN_POC & MAX_POC
+//    values clamping the range where that POC locates.
+// 4. Check the specific stage where that POC can't go through.
 #define MIN_POC 0
 #define MAX_POC UINT_MAX
 #endif

--- a/Source/Lib/Codec/EbDefinitions.h
+++ b/Source/Lib/Codec/EbDefinitions.h
@@ -514,6 +514,12 @@ typedef void * EB_HANDLE;
                                             // Target rate and and max buffer size should be set properly even for fixed QP.
                                             // Disabled by default.
 #define DEADLOCK_DEBUG                   0
+#if DEADLOCK_DEBUG
+#include <limits.h>
+#define MIN_POC 0
+#define MAX_POC UINT_MAX
+#endif
+
 #define LIB_PRINTF_ENABLE                1
 #if LIB_PRINTF_ENABLE
 #define SVT_LOG printf

--- a/Source/Lib/Codec/EbEncDecProcess.c
+++ b/Source/Lib/Codec/EbEncDecProcess.c
@@ -3065,6 +3065,10 @@ void* EncDecKernel(void *inputPtr)
         EbReleaseMutex(pictureControlSetPtr->intraMutex);
 
         if (lastLcuFlag) {
+#if DEADLOCK_DEBUG
+            SVT_LOG("POC %lu ENCDEC OUT \n", pictureControlSetPtr->pictureNumber);
+#endif
+
             if (pictureControlSetPtr->ParentPcsPtr->referencePictureWrapperPtr != NULL){
                 // copy stat to ref object (intraCodedArea, Luminance, Scene change detection flags)
                 CopyStatisticsToRefObject(
@@ -3222,9 +3226,6 @@ void* EncDecKernel(void *inputPtr)
                     EbReleaseObject(pictureControlSetPtr->refPicPtrArray[1]);
                 }
             }
-#if DEADLOCK_DEBUG
-            SVT_LOG("POC %lu ENCDEC OUT \n", pictureControlSetPtr->pictureNumber);
-#endif
         }
         EbReleaseObject(encDecTasksPtr->pictureControlSetWrapperPtr);
 

--- a/Source/Lib/Codec/EbEncDecProcess.c
+++ b/Source/Lib/Codec/EbEncDecProcess.c
@@ -2706,7 +2706,8 @@ void* EncDecKernel(void *inputPtr)
         lastLcuFlag = EB_FALSE;
         is16bit = (EB_BOOL)(sequenceControlSetPtr->staticConfig.encoderBitDepth > EB_8BIT);
 #if DEADLOCK_DEBUG
-        SVT_LOG("POC %lld ENCDEC IN \n", pictureControlSetPtr->pictureNumber);
+        if ((encDecTasksPtr->inputType == ENCDEC_TASKS_MDC_INPUT) && (tileGroupIdx == 0))
+            SVT_LOG("POC %lu ENCDEC IN \n", pictureControlSetPtr->pictureNumber);
 #endif
 
         // LCU Constants
@@ -3221,12 +3222,11 @@ void* EncDecKernel(void *inputPtr)
                     EbReleaseObject(pictureControlSetPtr->refPicPtrArray[1]);
                 }
             }
+#if DEADLOCK_DEBUG
+            SVT_LOG("POC %lu ENCDEC OUT \n", pictureControlSetPtr->pictureNumber);
+#endif
         }
         EbReleaseObject(encDecTasksPtr->pictureControlSetWrapperPtr);
-
-#if DEADLOCK_DEBUG
-        SVT_LOG("POC %lld ENCDEC OUT \n", pictureControlSetPtr->pictureNumber);
-#endif
 
         // Release Mode Decision Results
         EbReleaseObject(encDecTasksWrapperPtr);

--- a/Source/Lib/Codec/EbEncDecProcess.c
+++ b/Source/Lib/Codec/EbEncDecProcess.c
@@ -2706,8 +2706,9 @@ void* EncDecKernel(void *inputPtr)
         lastLcuFlag = EB_FALSE;
         is16bit = (EB_BOOL)(sequenceControlSetPtr->staticConfig.encoderBitDepth > EB_8BIT);
 #if DEADLOCK_DEBUG
-        if ((encDecTasksPtr->inputType == ENCDEC_TASKS_MDC_INPUT) && (tileGroupIdx == 0))
-            SVT_LOG("POC %lu ENCDEC IN \n", pictureControlSetPtr->pictureNumber);
+        if ((pictureControlSetPtr->pictureNumber >= MIN_POC) && (pictureControlSetPtr->pictureNumber <= MAX_POC))
+            if ((encDecTasksPtr->inputType == ENCDEC_TASKS_MDC_INPUT) && (tileGroupIdx == 0))
+                SVT_LOG("POC %lu ENCDEC IN \n", pictureControlSetPtr->pictureNumber);
 #endif
 
         // LCU Constants
@@ -3066,7 +3067,8 @@ void* EncDecKernel(void *inputPtr)
 
         if (lastLcuFlag) {
 #if DEADLOCK_DEBUG
-            SVT_LOG("POC %lu ENCDEC OUT \n", pictureControlSetPtr->pictureNumber);
+            if ((pictureControlSetPtr->pictureNumber >= MIN_POC) && (pictureControlSetPtr->pictureNumber <= MAX_POC))
+                SVT_LOG("POC %lu ENCDEC OUT \n", pictureControlSetPtr->pictureNumber);
 #endif
 
             if (pictureControlSetPtr->ParentPcsPtr->referencePictureWrapperPtr != NULL){

--- a/Source/Lib/Codec/EbEntropyCodingProcess.c
+++ b/Source/Lib/Codec/EbEntropyCodingProcess.c
@@ -365,8 +365,9 @@ void* EntropyCodingKernel(void *inputPtr)
         lastLcuFlagInTile      = EB_FALSE;
         tileCnt                = pictureControlSetPtr->ParentPcsPtr->tileRowCount * pictureControlSetPtr->ParentPcsPtr->tileColumnCount;
 #if DEADLOCK_DEBUG
-        if (pictureControlSetPtr->encDecCodedLcuCount == pictureControlSetPtr->lcuTotalCount)
-            SVT_LOG("POC %lu EC IN \n", pictureControlSetPtr->pictureNumber);
+        if ((pictureControlSetPtr->pictureNumber >= MIN_POC) && (pictureControlSetPtr->pictureNumber <= MAX_POC))
+            if (pictureControlSetPtr->encDecCodedLcuCount == pictureControlSetPtr->lcuTotalCount)
+                SVT_LOG("POC %lu EC IN \n", pictureControlSetPtr->pictureNumber);
 #endif
         //SVT_LOG("[%lld]: POC %lld EC IN, tile %d, (%d, %d) \n",
         //        EbGetSysTimeMs(),
@@ -515,7 +516,8 @@ void* EntropyCodingKernel(void *inputPtr)
                             EbPostFullObject(entropyCodingResultsWrapperPtr);
 
 #if DEADLOCK_DEBUG
-                            SVT_LOG("POC %lu EC OUT \n", pictureControlSetPtr->pictureNumber);
+                            if ((pictureControlSetPtr->pictureNumber >= MIN_POC) && (pictureControlSetPtr->pictureNumber <= MAX_POC))
+                                SVT_LOG("POC %lu EC OUT \n", pictureControlSetPtr->pictureNumber);
 #endif
                         }
 					} // End if(PictureCompleteFlag)

--- a/Source/Lib/Codec/EbEntropyCodingProcess.c
+++ b/Source/Lib/Codec/EbEntropyCodingProcess.c
@@ -365,7 +365,8 @@ void* EntropyCodingKernel(void *inputPtr)
         lastLcuFlagInTile      = EB_FALSE;
         tileCnt                = pictureControlSetPtr->ParentPcsPtr->tileRowCount * pictureControlSetPtr->ParentPcsPtr->tileColumnCount;
 #if DEADLOCK_DEBUG
-        SVT_LOG("POC %lld EC IN \n", pictureControlSetPtr->pictureNumber);
+        if (pictureControlSetPtr->encDecCodedLcuCount == pictureControlSetPtr->lcuTotalCount)
+            SVT_LOG("POC %lu EC IN \n", pictureControlSetPtr->pictureNumber);
 #endif
         //SVT_LOG("[%lld]: POC %lld EC IN, tile %d, (%d, %d) \n",
         //        EbGetSysTimeMs(),
@@ -512,16 +513,16 @@ void* EntropyCodingKernel(void *inputPtr)
                             //SVT_LOG("[%lld]: Entropy post result, POC %d\n", EbGetSysTimeMs(), pictureControlSetPtr->pictureNumber);
                             // Post EntropyCoding Results
                             EbPostFullObject(entropyCodingResultsWrapperPtr);
+
+#if DEADLOCK_DEBUG
+                            SVT_LOG("POC %lu EC OUT \n", pictureControlSetPtr->pictureNumber);
+#endif
                         }
 					} // End if(PictureCompleteFlag)
 				}
 				EbReleaseMutex(pictureControlSetPtr->entropyCodingInfo[tileIdx]->entropyCodingMutex);
 			}
         }
-
-#if DEADLOCK_DEBUG
-        SVT_LOG("POC %lld EC OUT \n", pictureControlSetPtr->pictureNumber);
-#endif
         // Release Mode Decision Results
         EbReleaseObject(encDecResultsWrapperPtr);
 

--- a/Source/Lib/Codec/EbInitialRateControlProcess.c
+++ b/Source/Lib/Codec/EbInitialRateControlProcess.c
@@ -916,11 +916,11 @@ void* InitialRateControlKernel(void *inputPtr)
 
 		inputResultsPtr = (MotionEstimationResults_t*)inputResultsWrapperPtr->objectPtr;
 		pictureControlSetPtr = (PictureParentControlSet_t*)inputResultsPtr->pictureControlSetWrapperPtr->objectPtr;
-#if DEADLOCK_DEBUG
-        SVT_LOG("POC %lld IRC IN \n", pictureControlSetPtr->pictureNumber);
-#endif
         pictureControlSetPtr->meSegmentsCompletionMask++;
         if (pictureControlSetPtr->meSegmentsCompletionMask == pictureControlSetPtr->meSegmentsTotalCount) {
+#if DEADLOCK_DEBUG
+            SVT_LOG("POC %lu IRC IN \n", pictureControlSetPtr->pictureNumber);
+#endif
 			sequenceControlSetPtr = (SequenceControlSet_t*)pictureControlSetPtr->sequenceControlSetWrapperPtr->objectPtr;
 			encodeContextPtr = (EncodeContext_t*)sequenceControlSetPtr->encodeContextPtr;
 
@@ -1128,6 +1128,10 @@ void* InitialRateControlKernel(void *inputPtr)
 					/////////////////////////////
 					// Post the Full Results Object
 					EbPostFullObject(outputResultsWrapperPtr);
+#if DEADLOCK_DEBUG
+                    SVT_LOG("POC %lu IRC OUT \n", pictureControlSetPtr->pictureNumber);
+#endif
+
 #if LATENCY_PROFILE
         double latency = 0.0;
         EB_U64 finishTimeSeconds = 0;
@@ -1159,9 +1163,6 @@ void* InitialRateControlKernel(void *inputPtr)
 				}
 			}
 		}
-#if DEADLOCK_DEBUG
-        SVT_LOG("POC %lld IRC OUT \n", pictureControlSetPtr->pictureNumber);
-#endif
 		// Release the Input Results
 		EbReleaseObject(inputResultsWrapperPtr);
 

--- a/Source/Lib/Codec/EbInitialRateControlProcess.c
+++ b/Source/Lib/Codec/EbInitialRateControlProcess.c
@@ -919,7 +919,8 @@ void* InitialRateControlKernel(void *inputPtr)
         pictureControlSetPtr->meSegmentsCompletionMask++;
         if (pictureControlSetPtr->meSegmentsCompletionMask == pictureControlSetPtr->meSegmentsTotalCount) {
 #if DEADLOCK_DEBUG
-            SVT_LOG("POC %lu IRC IN \n", pictureControlSetPtr->pictureNumber);
+            if ((pictureControlSetPtr->pictureNumber >= MIN_POC) && (pictureControlSetPtr->pictureNumber <= MAX_POC))
+                SVT_LOG("POC %lu IRC IN \n", pictureControlSetPtr->pictureNumber);
 #endif
 			sequenceControlSetPtr = (SequenceControlSet_t*)pictureControlSetPtr->sequenceControlSetWrapperPtr->objectPtr;
 			encodeContextPtr = (EncodeContext_t*)sequenceControlSetPtr->encodeContextPtr;
@@ -1129,7 +1130,8 @@ void* InitialRateControlKernel(void *inputPtr)
 					// Post the Full Results Object
 					EbPostFullObject(outputResultsWrapperPtr);
 #if DEADLOCK_DEBUG
-                    SVT_LOG("POC %lu IRC OUT \n", pictureControlSetPtr->pictureNumber);
+                    if ((pictureControlSetPtr->pictureNumber >= MIN_POC) && (pictureControlSetPtr->pictureNumber <= MAX_POC))
+                        SVT_LOG("POC %lu IRC OUT \n", pictureControlSetPtr->pictureNumber);
 #endif
 
 #if LATENCY_PROFILE

--- a/Source/Lib/Codec/EbModeDecisionConfigurationProcess.c
+++ b/Source/Lib/Codec/EbModeDecisionConfigurationProcess.c
@@ -1930,7 +1930,8 @@ void* ModeDecisionConfigurationKernel(void *inputPtr)
 		pictureControlSetPtr = (PictureControlSet_t*)rateControlResultsPtr->pictureControlSetWrapperPtr->objectPtr;
 		sequenceControlSetPtr = (SequenceControlSet_t*)pictureControlSetPtr->sequenceControlSetWrapperPtr->objectPtr;
 #if DEADLOCK_DEBUG
-        SVT_LOG("POC %lu MDC IN \n", pictureControlSetPtr->pictureNumber);
+        if ((pictureControlSetPtr->pictureNumber >= MIN_POC) && (pictureControlSetPtr->pictureNumber <= MAX_POC))
+            SVT_LOG("POC %lu MDC IN \n", pictureControlSetPtr->pictureNumber);
 #endif
         SignalDerivationModeDecisionConfigKernelOq(
                 pictureControlSetPtr,
@@ -2098,7 +2099,8 @@ void* ModeDecisionConfigurationKernel(void *inputPtr)
             }
         }
 #if DEADLOCK_DEBUG
-        SVT_LOG("POC %lu MDC OUT \n", pictureControlSetPtr->pictureNumber);
+        if ((pictureControlSetPtr->pictureNumber >= MIN_POC) && (pictureControlSetPtr->pictureNumber <= MAX_POC))
+            SVT_LOG("POC %lu MDC OUT \n", pictureControlSetPtr->pictureNumber);
 #endif
 
 #if LATENCY_PROFILE

--- a/Source/Lib/Codec/EbModeDecisionConfigurationProcess.c
+++ b/Source/Lib/Codec/EbModeDecisionConfigurationProcess.c
@@ -1930,7 +1930,7 @@ void* ModeDecisionConfigurationKernel(void *inputPtr)
 		pictureControlSetPtr = (PictureControlSet_t*)rateControlResultsPtr->pictureControlSetWrapperPtr->objectPtr;
 		sequenceControlSetPtr = (SequenceControlSet_t*)pictureControlSetPtr->sequenceControlSetWrapperPtr->objectPtr;
 #if DEADLOCK_DEBUG
-        SVT_LOG("POC %lld MDC IN \n", pictureControlSetPtr->pictureNumber);
+        SVT_LOG("POC %lu MDC IN \n", pictureControlSetPtr->pictureNumber);
 #endif
         SignalDerivationModeDecisionConfigKernelOq(
                 pictureControlSetPtr,
@@ -2078,9 +2078,6 @@ void* ModeDecisionConfigurationKernel(void *inputPtr)
             pictureControlSetPtr->ParentPcsPtr->averageQp = (EB_U8)pictureControlSetPtr->ParentPcsPtr->pictureQp;
         }
 
-#if DEADLOCK_DEBUG
-        SVT_LOG("POC %lld MDC OUT \n", pictureControlSetPtr->pictureNumber);
-#endif
         // Post the results to the MD processes
         EB_U16 tileGroupRowCnt = sequenceControlSetPtr->tileGroupRowCountArray[pictureControlSetPtr->temporalLayerIndex];
         EB_U16 tileGroupColCnt = sequenceControlSetPtr->tileGroupColCountArray[pictureControlSetPtr->temporalLayerIndex];
@@ -2100,6 +2097,9 @@ void* ModeDecisionConfigurationKernel(void *inputPtr)
                 EbPostFullObject(encDecTasksWrapperPtr);
             }
         }
+#if DEADLOCK_DEBUG
+        SVT_LOG("POC %lu MDC OUT \n", pictureControlSetPtr->pictureNumber);
+#endif
 
 #if LATENCY_PROFILE
         double latency = 0.0;

--- a/Source/Lib/Codec/EbMotionEstimationProcess.c
+++ b/Source/Lib/Codec/EbMotionEstimationProcess.c
@@ -670,8 +670,9 @@ void* MotionEstimationKernel(void *inputPtr)
 		// Segments
 		segmentIndex = inputResultsPtr->segmentIndex;
 #if DEADLOCK_DEBUG
-        if (segmentIndex == 0)
-            SVT_LOG("POC %lu ME IN \n", pictureControlSetPtr->pictureNumber);
+        if ((pictureControlSetPtr->pictureNumber >= MIN_POC) && (pictureControlSetPtr->pictureNumber <= MAX_POC))
+            if (segmentIndex == 0)
+                SVT_LOG("POC %lu ME IN \n", pictureControlSetPtr->pictureNumber);
 #endif
 		pictureWidthInLcu = (sequenceControlSetPtr->lumaWidth + sequenceControlSetPtr->lcuSize - 1) / sequenceControlSetPtr->lcuSize;
 		pictureHeightInLcu = (sequenceControlSetPtr->lumaHeight + sequenceControlSetPtr->lcuSize - 1) / sequenceControlSetPtr->lcuSize;
@@ -970,8 +971,9 @@ void* MotionEstimationKernel(void *inputPtr)
 		// Post the Full Results Object
 		EbPostFullObject(outputResultsWrapperPtr);
 #if DEADLOCK_DEBUG
-        if (segmentIndex == (EB_U32)(pictureControlSetPtr->meSegmentsTotalCount - 1))
-            SVT_LOG("POC %lu ME OUT \n", pictureControlSetPtr->pictureNumber);
+        if ((pictureControlSetPtr->pictureNumber >= MIN_POC) && (pictureControlSetPtr->pictureNumber <= MAX_POC))
+            if (segmentIndex == (EB_U32)(pictureControlSetPtr->meSegmentsTotalCount - 1))
+                SVT_LOG("POC %lu ME OUT \n", pictureControlSetPtr->pictureNumber);
 #endif
 	}
 	return EB_NULL;

--- a/Source/Lib/Codec/EbMotionEstimationProcess.c
+++ b/Source/Lib/Codec/EbMotionEstimationProcess.c
@@ -667,11 +667,12 @@ void* MotionEstimationKernel(void *inputPtr)
 		sixteenthDecimatedPicturePtr = (EbPictureBufferDesc_t*)paReferenceObject->sixteenthDecimatedPicturePtr;
         inputPaddedPicturePtr = (EbPictureBufferDesc_t*)paReferenceObject->inputPaddedPicturePtr;
 		inputPicturePtr = pictureControlSetPtr->enhancedPicturePtr;
-#if DEADLOCK_DEBUG
-        SVT_LOG("POC %lld ME IN \n", pictureControlSetPtr->pictureNumber);
-#endif
 		// Segments
 		segmentIndex = inputResultsPtr->segmentIndex;
+#if DEADLOCK_DEBUG
+        if (segmentIndex == 0)
+            SVT_LOG("POC %lu ME IN \n", pictureControlSetPtr->pictureNumber);
+#endif
 		pictureWidthInLcu = (sequenceControlSetPtr->lumaWidth + sequenceControlSetPtr->lcuSize - 1) / sequenceControlSetPtr->lcuSize;
 		pictureHeightInLcu = (sequenceControlSetPtr->lumaHeight + sequenceControlSetPtr->lcuSize - 1) / sequenceControlSetPtr->lcuSize;
 		SEGMENT_CONVERT_IDX_TO_XY(segmentIndex, xSegmentIndex, ySegmentIndex, pictureControlSetPtr->meSegmentsColumnCount);
@@ -953,9 +954,6 @@ void* MotionEstimationKernel(void *inputPtr)
 				}
 			}
 		}
-#if DEADLOCK_DEBUG
-        SVT_LOG("POC %lld ME OUT \n", pictureControlSetPtr->pictureNumber);
-#endif
         EbReleaseMutex(pictureControlSetPtr->rcDistortionHistogramMutex);
 		// Get Empty Results Object
 		EbGetEmptyObject(
@@ -971,6 +969,10 @@ void* MotionEstimationKernel(void *inputPtr)
 
 		// Post the Full Results Object
 		EbPostFullObject(outputResultsWrapperPtr);
+#if DEADLOCK_DEBUG
+        if (segmentIndex == (EB_U32)(pictureControlSetPtr->meSegmentsTotalCount - 1))
+            SVT_LOG("POC %lu ME OUT \n", pictureControlSetPtr->pictureNumber);
+#endif
 	}
 	return EB_NULL;
 }

--- a/Source/Lib/Codec/EbPacketizationProcess.c
+++ b/Source/Lib/Codec/EbPacketizationProcess.c
@@ -178,7 +178,8 @@ void* PacketizationKernel(void *inputPtr)
         encodeContextPtr        = (EncodeContext_t*)        sequenceControlSetPtr->encodeContextPtr;
         tileCnt = pictureControlSetPtr->ParentPcsPtr->tileRowCount * pictureControlSetPtr->ParentPcsPtr->tileColumnCount;
 #if DEADLOCK_DEBUG
-        SVT_LOG("POC %lu PK IN \n", pictureControlSetPtr->pictureNumber);
+        if ((pictureControlSetPtr->pictureNumber >= MIN_POC) && (pictureControlSetPtr->pictureNumber <= MAX_POC))
+            SVT_LOG("POC %lu PK IN \n", pictureControlSetPtr->pictureNumber);
 #endif
 
         //****************************************************
@@ -966,7 +967,8 @@ void* PacketizationKernel(void *inputPtr)
             EbPostFullObject(outputStreamWrapperPtr);
 
 #if DEADLOCK_DEBUG
-            SVT_LOG("POC %lu PK OUT \n", queueEntryPtr->pictureNumber);
+            if ((queueEntryPtr->pictureNumber >= MIN_POC) && (queueEntryPtr->pictureNumber <= MAX_POC))
+                SVT_LOG("POC %lu PK OUT \n", queueEntryPtr->pictureNumber);
 #endif
             // Reset the Reorder Queue Entry
             queueEntryPtr->pictureNumber    += PACKETIZATION_REORDER_QUEUE_MAX_DEPTH;

--- a/Source/Lib/Codec/EbPacketizationProcess.c
+++ b/Source/Lib/Codec/EbPacketizationProcess.c
@@ -178,7 +178,7 @@ void* PacketizationKernel(void *inputPtr)
         encodeContextPtr        = (EncodeContext_t*)        sequenceControlSetPtr->encodeContextPtr;
         tileCnt = pictureControlSetPtr->ParentPcsPtr->tileRowCount * pictureControlSetPtr->ParentPcsPtr->tileColumnCount;
 #if DEADLOCK_DEBUG
-        SVT_LOG("POC %lld PK IN \n", pictureControlSetPtr->pictureNumber);
+        SVT_LOG("POC %lu PK IN \n", pictureControlSetPtr->pictureNumber);
 #endif
 
         //****************************************************
@@ -192,6 +192,7 @@ void* PacketizationKernel(void *inputPtr)
         queueEntryPtr->startTimeuSeconds = pictureControlSetPtr->ParentPcsPtr->startTimeuSeconds;
         queueEntryPtr->isUsedAsReferenceFlag = pictureControlSetPtr->ParentPcsPtr->isUsedAsReferenceFlag;
         queueEntryPtr->sliceType = pictureControlSetPtr->sliceType;
+        queueEntryPtr->pictureNumber = pictureControlSetPtr->pictureNumber;
 
 #if OUT_ALLOC
         EbGetEmptyObject(sequenceControlSetPtr->encodeContextPtr->streamOutputFifoPtr,
@@ -963,6 +964,10 @@ void* PacketizationKernel(void *inputPtr)
                 EbReleaseMutex(encodeContextPtr->bufferFillMutex);
             }
             EbPostFullObject(outputStreamWrapperPtr);
+
+#if DEADLOCK_DEBUG
+            SVT_LOG("POC %lu PK OUT \n", queueEntryPtr->pictureNumber);
+#endif
             // Reset the Reorder Queue Entry
             queueEntryPtr->pictureNumber    += PACKETIZATION_REORDER_QUEUE_MAX_DEPTH;
             queueEntryPtr->outputStreamWrapperPtr = (EbObjectWrapper_t *)EB_NULL;
@@ -975,9 +980,6 @@ void* PacketizationKernel(void *inputPtr)
 
 
         }
-#if DEADLOCK_DEBUG
-        SVT_LOG("POC %lld PK OUT \n", pictureControlSetPtr->pictureNumber);
-#endif
     }
 return EB_NULL;
 }

--- a/Source/Lib/Codec/EbPictureAnalysisProcess.c
+++ b/Source/Lib/Codec/EbPictureAnalysisProcess.c
@@ -4333,10 +4333,6 @@ void* PictureAnalysisKernel(void *inputPtr)
 		outputResultsPtr = (PictureAnalysisResults_t*)outputResultsWrapperPtr->objectPtr;
 		outputResultsPtr->pictureControlSetWrapperPtr = inputResultsPtr->pictureControlSetWrapperPtr;
 
-#if DEADLOCK_DEBUG
-        SVT_LOG("POC %lu PA OUT \n", pictureControlSetPtr->pictureNumber);
-#endif
-
 		// Release the Input Results
 		EbReleaseObject(inputResultsWrapperPtr);
 
@@ -4361,6 +4357,9 @@ void* PictureAnalysisKernel(void *inputPtr)
 		// Post the Full Results Object
 		EbPostFullObject(outputResultsWrapperPtr);
 
+#if DEADLOCK_DEBUG
+        SVT_LOG("POC %lu PA OUT \n", pictureControlSetPtr->pictureNumber);
+#endif
 	}
 	return EB_NULL;
 }

--- a/Source/Lib/Codec/EbPictureAnalysisProcess.c
+++ b/Source/Lib/Codec/EbPictureAnalysisProcess.c
@@ -4241,7 +4241,8 @@ void* PictureAnalysisKernel(void *inputPtr)
 		sequenceControlSetPtr = (SequenceControlSet_t*)pictureControlSetPtr->sequenceControlSetWrapperPtr->objectPtr;
 		inputPicturePtr = pictureControlSetPtr->enhancedPicturePtr;
 #if DEADLOCK_DEBUG
-        SVT_LOG("POC %lu PA IN \n", pictureControlSetPtr->pictureNumber);
+        if ((pictureControlSetPtr->pictureNumber >= MIN_POC) && (pictureControlSetPtr->pictureNumber <= MAX_POC))
+            SVT_LOG("POC %lu PA IN \n", pictureControlSetPtr->pictureNumber);
 #endif
 		paReferenceObject = (EbPaReferenceObject_t*)pictureControlSetPtr->paReferencePictureWrapperPtr->objectPtr;
 		inputPaddedPicturePtr = (EbPictureBufferDesc_t*)paReferenceObject->inputPaddedPicturePtr;
@@ -4358,7 +4359,8 @@ void* PictureAnalysisKernel(void *inputPtr)
 		EbPostFullObject(outputResultsWrapperPtr);
 
 #if DEADLOCK_DEBUG
-        SVT_LOG("POC %lu PA OUT \n", pictureControlSetPtr->pictureNumber);
+        if ((pictureControlSetPtr->pictureNumber >= MIN_POC) && (pictureControlSetPtr->pictureNumber <= MAX_POC))
+            SVT_LOG("POC %lu PA OUT \n", pictureControlSetPtr->pictureNumber);
 #endif
 	}
 	return EB_NULL;

--- a/Source/Lib/Codec/EbPictureAnalysisProcess.c
+++ b/Source/Lib/Codec/EbPictureAnalysisProcess.c
@@ -4241,7 +4241,7 @@ void* PictureAnalysisKernel(void *inputPtr)
 		sequenceControlSetPtr = (SequenceControlSet_t*)pictureControlSetPtr->sequenceControlSetWrapperPtr->objectPtr;
 		inputPicturePtr = pictureControlSetPtr->enhancedPicturePtr;
 #if DEADLOCK_DEBUG
-        SVT_LOG("POC %lld PA IN \n", pictureControlSetPtr->pictureNumber);
+        SVT_LOG("POC %lu PA IN \n", pictureControlSetPtr->pictureNumber);
 #endif
 		paReferenceObject = (EbPaReferenceObject_t*)pictureControlSetPtr->paReferencePictureWrapperPtr->objectPtr;
 		inputPaddedPicturePtr = (EbPictureBufferDesc_t*)paReferenceObject->inputPaddedPicturePtr;
@@ -4334,7 +4334,7 @@ void* PictureAnalysisKernel(void *inputPtr)
 		outputResultsPtr->pictureControlSetWrapperPtr = inputResultsPtr->pictureControlSetWrapperPtr;
 
 #if DEADLOCK_DEBUG
-        SVT_LOG("POC %lld PA OUT \n", pictureControlSetPtr->pictureNumber);
+        SVT_LOG("POC %lu PA OUT \n", pictureControlSetPtr->pictureNumber);
 #endif
 
 		// Release the Input Results

--- a/Source/Lib/Codec/EbPictureDecisionProcess.c
+++ b/Source/Lib/Codec/EbPictureDecisionProcess.c
@@ -615,7 +615,7 @@ void* PictureDecisionKernel(void *inputPtr)
         encodeContextPtr        = (EncodeContext_t*)            sequenceControlSetPtr->encodeContextPtr;
 
 #if DEADLOCK_DEBUG
-        SVT_LOG("POC %lld PD IN \n", pictureControlSetPtr->pictureNumber);
+        SVT_LOG("POC %lu PD IN \n", pictureControlSetPtr->pictureNumber);
 #endif
 
         loopCount ++;
@@ -1309,6 +1309,9 @@ void* PictureDecisionKernel(void *inputPtr)
                                 // Post the Full Results Object
                                 EbPostFullObject(outputResultsWrapperPtr);
                             }
+#if DEADLOCK_DEBUG
+                            SVT_LOG("POC %lu PD OUT \n", pictureControlSetPtr->pictureNumber);
+#endif
                         }
 
 						if (pictureIndex == contextPtr->miniGopEndIndex[miniGopIndex]) {
@@ -1373,9 +1376,6 @@ void* PictureDecisionKernel(void *inputPtr)
             if(windowAvail == EB_FALSE  && framePasseThru == EB_FALSE)
                 break;
         }
-#if DEADLOCK_DEBUG
-        SVT_LOG("POC %lld PD OUT \n", pictureControlSetPtr->pictureNumber);
-#endif
         // Release the Input Results
         EbReleaseObject(inputResultsWrapperPtr);
     }

--- a/Source/Lib/Codec/EbPictureDecisionProcess.c
+++ b/Source/Lib/Codec/EbPictureDecisionProcess.c
@@ -615,7 +615,8 @@ void* PictureDecisionKernel(void *inputPtr)
         encodeContextPtr        = (EncodeContext_t*)            sequenceControlSetPtr->encodeContextPtr;
 
 #if DEADLOCK_DEBUG
-        SVT_LOG("POC %lu PD IN \n", pictureControlSetPtr->pictureNumber);
+        if ((pictureControlSetPtr->pictureNumber >= MIN_POC) && (pictureControlSetPtr->pictureNumber <= MAX_POC))
+            SVT_LOG("POC %lu PD IN \n", pictureControlSetPtr->pictureNumber);
 #endif
 
         loopCount ++;
@@ -1310,7 +1311,8 @@ void* PictureDecisionKernel(void *inputPtr)
                                 EbPostFullObject(outputResultsWrapperPtr);
                             }
 #if DEADLOCK_DEBUG
-                            SVT_LOG("POC %lu PD OUT \n", pictureControlSetPtr->pictureNumber);
+                            if ((pictureControlSetPtr->pictureNumber >= MIN_POC) && (pictureControlSetPtr->pictureNumber <= MAX_POC))
+                                SVT_LOG("POC %lu PD OUT \n", pictureControlSetPtr->pictureNumber);
 #endif
                         }
 

--- a/Source/Lib/Codec/EbPictureManagerProcess.c
+++ b/Source/Lib/Codec/EbPictureManagerProcess.c
@@ -211,7 +211,8 @@ void* PictureManagerKernel(void *inputPtr)
             encodeContextPtr                = sequenceControlSetPtr->encodeContextPtr;
 
 #if DEADLOCK_DEBUG
-            SVT_LOG("POC %lu PM IN \n", pictureControlSetPtr->pictureNumber);
+            if ((pictureControlSetPtr->pictureNumber >= MIN_POC) && (pictureControlSetPtr->pictureNumber <= MAX_POC))
+                SVT_LOG("POC %lu PM IN \n", pictureControlSetPtr->pictureNumber);
 #endif
 		   queueEntryIndex = (EB_S32)(pictureControlSetPtr->pictureNumber - encodeContextPtr->pictureManagerReorderQueue[encodeContextPtr->pictureManagerReorderQueueHeadIndex]->pictureNumber);
 		   queueEntryIndex += encodeContextPtr->pictureManagerReorderQueueHeadIndex;
@@ -894,7 +895,8 @@ void* PictureManagerKernel(void *inputPtr)
                     // Post the Full Results Object
                     EbPostFullObject(outputWrapperPtr);
 #if DEADLOCK_DEBUG
-                    SVT_LOG("POC %lu PM OUT \n", ChildPictureControlSetPtr->pictureNumber);
+                    if ((ChildPictureControlSetPtr->pictureNumber >= MIN_POC) && (ChildPictureControlSetPtr->pictureNumber <= MAX_POC))
+                        SVT_LOG("POC %lu PM OUT \n", ChildPictureControlSetPtr->pictureNumber);
 #endif
 
 #if LATENCY_PROFILE

--- a/Source/Lib/Codec/EbPictureManagerProcess.c
+++ b/Source/Lib/Codec/EbPictureManagerProcess.c
@@ -502,9 +502,7 @@ void* PictureManagerKernel(void *inputPtr)
 				   EbReleaseObject(pictureControlSetPtr->referencePictureWrapperPtr);
 				   pictureControlSetPtr->referencePictureWrapperPtr = (EbObjectWrapper_t*)EB_NULL;
 			   }
-#if DEADLOCK_DEBUG
-               SVT_LOG("POC %lu PM OUT \n", pictureControlSetPtr->pictureNumber);
-#endif
+
 			   // Release the Picture Manager Reorder Queue
 			   queueEntryPtr->parentPcsWrapperPtr = (EbObjectWrapper_t*)EB_NULL;
 			   queueEntryPtr->pictureNumber += PICTURE_MANAGER_REORDER_QUEUE_MAX_DEPTH;
@@ -895,6 +893,10 @@ void* PictureManagerKernel(void *inputPtr)
 
                     // Post the Full Results Object
                     EbPostFullObject(outputWrapperPtr);
+#if DEADLOCK_DEBUG
+                    SVT_LOG("POC %lu PM OUT \n", ChildPictureControlSetPtr->pictureNumber);
+#endif
+
 #if LATENCY_PROFILE
                     double latency = 0.0;
                     EB_U64 finishTimeSeconds = 0;

--- a/Source/Lib/Codec/EbPictureManagerProcess.c
+++ b/Source/Lib/Codec/EbPictureManagerProcess.c
@@ -211,7 +211,7 @@ void* PictureManagerKernel(void *inputPtr)
             encodeContextPtr                = sequenceControlSetPtr->encodeContextPtr;
 
 #if DEADLOCK_DEBUG
-            SVT_LOG("POC %lld PM IN \n", pictureControlSetPtr->pictureNumber);
+            SVT_LOG("POC %lu PM IN \n", pictureControlSetPtr->pictureNumber);
 #endif
 		   queueEntryIndex = (EB_S32)(pictureControlSetPtr->pictureNumber - encodeContextPtr->pictureManagerReorderQueue[encodeContextPtr->pictureManagerReorderQueueHeadIndex]->pictureNumber);
 		   queueEntryIndex += encodeContextPtr->pictureManagerReorderQueueHeadIndex;
@@ -503,7 +503,7 @@ void* PictureManagerKernel(void *inputPtr)
 				   pictureControlSetPtr->referencePictureWrapperPtr = (EbObjectWrapper_t*)EB_NULL;
 			   }
 #if DEADLOCK_DEBUG
-               SVT_LOG("POC %lld PM OUT \n", pictureControlSetPtr->pictureNumber);
+               SVT_LOG("POC %lu PM OUT \n", pictureControlSetPtr->pictureNumber);
 #endif
 			   // Release the Picture Manager Reorder Queue
 			   queueEntryPtr->parentPcsWrapperPtr = (EbObjectWrapper_t*)EB_NULL;

--- a/Source/Lib/Codec/EbRateControlProcess.c
+++ b/Source/Lib/Codec/EbRateControlProcess.c
@@ -2319,7 +2319,8 @@ void* RateControlKernel(void *inputPtr)
             sequenceControlSetPtr = (SequenceControlSet_t*)pictureControlSetPtr->sequenceControlSetWrapperPtr->objectPtr;
             encodeContextPtr = (EncodeContext_t*)sequenceControlSetPtr->encodeContextPtr;
 #if DEADLOCK_DEBUG
-            SVT_LOG("POC %lu RC IN \n", pictureControlSetPtr->pictureNumber);
+            if ((pictureControlSetPtr->pictureNumber >= MIN_POC) && (pictureControlSetPtr->pictureNumber <= MAX_POC))
+                SVT_LOG("POC %lu RC IN \n", pictureControlSetPtr->pictureNumber);
 #endif
 
             // High level RC
@@ -2597,7 +2598,8 @@ void* RateControlKernel(void *inputPtr)
             EbPostFullObject(rateControlResultsWrapperPtr);
 
 #if DEADLOCK_DEBUG
-            SVT_LOG("POC %lu RC OUT \n", pictureControlSetPtr->pictureNumber);
+            if ((pictureControlSetPtr->pictureNumber >= MIN_POC) && (pictureControlSetPtr->pictureNumber <= MAX_POC))
+                SVT_LOG("POC %lu RC OUT \n", pictureControlSetPtr->pictureNumber);
 #endif
             // Release Rate Control Tasks
             EbReleaseObject(rateControlTasksWrapperPtr);

--- a/Source/Lib/Codec/EbRateControlProcess.c
+++ b/Source/Lib/Codec/EbRateControlProcess.c
@@ -2319,7 +2319,7 @@ void* RateControlKernel(void *inputPtr)
             sequenceControlSetPtr = (SequenceControlSet_t*)pictureControlSetPtr->sequenceControlSetWrapperPtr->objectPtr;
             encodeContextPtr = (EncodeContext_t*)sequenceControlSetPtr->encodeContextPtr;
 #if DEADLOCK_DEBUG
-            SVT_LOG("POC %lld RC IN \n", pictureControlSetPtr->pictureNumber);
+            SVT_LOG("POC %lu RC IN \n", pictureControlSetPtr->pictureNumber);
 #endif
 
             // High level RC
@@ -2593,13 +2593,12 @@ void* RateControlKernel(void *inputPtr)
             rateControlResultsPtr = (RateControlResults_t*)rateControlResultsWrapperPtr->objectPtr;
             rateControlResultsPtr->pictureControlSetWrapperPtr = rateControlTasksPtr->pictureControlSetWrapperPtr;
 
-#if DEADLOCK_DEBUG
-            SVT_LOG("POC %lld RC OUT \n", pictureControlSetPtr->pictureNumber);
-#endif
-
             // Post Full Rate Control Results
             EbPostFullObject(rateControlResultsWrapperPtr);
 
+#if DEADLOCK_DEBUG
+            SVT_LOG("POC %lu RC OUT \n", pictureControlSetPtr->pictureNumber);
+#endif
             // Release Rate Control Tasks
             EbReleaseObject(rateControlTasksWrapperPtr);
 

--- a/Source/Lib/Codec/EbResourceCoordinationProcess.c
+++ b/Source/Lib/Codec/EbResourceCoordinationProcess.c
@@ -584,7 +584,8 @@ void* ResourceCoordinationKernel(void *inputPtr)
         pictureControlSetPtr->pictureNumber                   = contextPtr->pictureNumberArray[instanceIndex]++;
 
 #if DEADLOCK_DEBUG
-        SVT_LOG("POC %lld RESCOOR IN \n", pictureControlSetPtr->pictureNumber);
+        if (!endOfSequenceFlag)
+            SVT_LOG("POC %lu RESCOOR IN \n", pictureControlSetPtr->pictureNumber);
 #endif
         // Set the picture structure: 0: progressive, 1: top, 2: bottom
         pictureControlSetPtr->pictStruct = sequenceControlSetPtr->interlacedVideo == EB_FALSE ?
@@ -638,6 +639,9 @@ void* ResourceCoordinationKernel(void *inputPtr)
 
             // Post the finished Results Object
             EbPostFullObject(outputWrapperPtr);
+#if DEADLOCK_DEBUG
+            SVT_LOG("POC %lu RESCOOR OUT \n", ((PictureParentControlSet_t *)outputResultsPtr->pictureControlSetWrapperPtr->objectPtr)->pictureNumber);
+#endif
         }
 
         prevPictureControlSetWrapperPtr = pictureControlSetWrapperPtr;
@@ -645,11 +649,6 @@ void* ResourceCoordinationKernel(void *inputPtr)
         if (sequenceControlSetPtr->staticConfig.segmentOvEnabled) {
             EB_MEMCPY(pictureControlSetPtr->segmentOvArray, ebInputPtr->segmentOvPtr, sizeof(SegmentOverride_t) * sequenceControlSetPtr->lcuTotalCount);
         }
-
-#if DEADLOCK_DEBUG
-        SVT_LOG("POC %lld RESCOOR OUT \n", pictureControlSetPtr->pictureNumber);
-#endif
-
     }
 
     return EB_NULL;

--- a/Source/Lib/Codec/EbResourceCoordinationProcess.c
+++ b/Source/Lib/Codec/EbResourceCoordinationProcess.c
@@ -584,8 +584,9 @@ void* ResourceCoordinationKernel(void *inputPtr)
         pictureControlSetPtr->pictureNumber                   = contextPtr->pictureNumberArray[instanceIndex]++;
 
 #if DEADLOCK_DEBUG
-        if (!endOfSequenceFlag)
-            SVT_LOG("POC %lu RESCOOR IN \n", pictureControlSetPtr->pictureNumber);
+        if ((pictureControlSetPtr->pictureNumber >= MIN_POC) && (pictureControlSetPtr->pictureNumber <= MAX_POC))
+            if (!endOfSequenceFlag)
+                SVT_LOG("POC %lu RESCOOR IN \n", pictureControlSetPtr->pictureNumber);
 #endif
         // Set the picture structure: 0: progressive, 1: top, 2: bottom
         pictureControlSetPtr->pictStruct = sequenceControlSetPtr->interlacedVideo == EB_FALSE ?
@@ -640,7 +641,9 @@ void* ResourceCoordinationKernel(void *inputPtr)
             // Post the finished Results Object
             EbPostFullObject(outputWrapperPtr);
 #if DEADLOCK_DEBUG
-            SVT_LOG("POC %lu RESCOOR OUT \n", ((PictureParentControlSet_t *)outputResultsPtr->pictureControlSetWrapperPtr->objectPtr)->pictureNumber);
+            if ((((PictureParentControlSet_t *)outputResultsPtr->pictureControlSetWrapperPtr->objectPtr)->pictureNumber >= MIN_POC) &&
+                    (((PictureParentControlSet_t *)outputResultsPtr->pictureControlSetWrapperPtr->objectPtr)->pictureNumber <= MAX_POC))
+                SVT_LOG("POC %lu RESCOOR OUT \n", ((PictureParentControlSet_t *)outputResultsPtr->pictureControlSetWrapperPtr->objectPtr)->pictureNumber);
 #endif
         }
 

--- a/Source/Lib/Codec/EbSourceBasedOperationsProcess.c
+++ b/Source/Lib/Codec/EbSourceBasedOperationsProcess.c
@@ -1417,7 +1417,7 @@ void* SourceBasedOperationsKernel(void *inputPtr)
 		sequenceControlSetPtr = (SequenceControlSet_t*)pictureControlSetPtr->sequenceControlSetWrapperPtr->objectPtr;
 
 #if DEADLOCK_DEBUG
-        SVT_LOG("POC %lld SRC IN \n", pictureControlSetPtr->pictureNumber);
+        SVT_LOG("POC %lu SRC IN \n", pictureControlSetPtr->pictureNumber);
 #endif
 		pictureControlSetPtr->darkBackGroundlightForeGround = EB_FALSE;
 		contextPtr->pictureNumGrassLcu = 0;
@@ -1665,10 +1665,6 @@ void* SourceBasedOperationsKernel(void *inputPtr)
             }
         }
 
-#if DEADLOCK_DEBUG
-        SVT_LOG("POC %lld SRC OUT \n", pictureControlSetPtr->pictureNumber);
-#endif
-
         // Get Empty Results Object
         EbGetEmptyObject(
             contextPtr->pictureDemuxResultsOutputFifoPtr,
@@ -1702,6 +1698,10 @@ void* SourceBasedOperationsKernel(void *inputPtr)
 
         // Post the Full Results Object
         EbPostFullObject(outputResultsWrapperPtr);
+
+#if DEADLOCK_DEBUG
+        SVT_LOG("POC %lu SRC OUT \n", pictureControlSetPtr->pictureNumber);
+#endif
 
     }
     return EB_NULL;

--- a/Source/Lib/Codec/EbSourceBasedOperationsProcess.c
+++ b/Source/Lib/Codec/EbSourceBasedOperationsProcess.c
@@ -1417,7 +1417,8 @@ void* SourceBasedOperationsKernel(void *inputPtr)
 		sequenceControlSetPtr = (SequenceControlSet_t*)pictureControlSetPtr->sequenceControlSetWrapperPtr->objectPtr;
 
 #if DEADLOCK_DEBUG
-        SVT_LOG("POC %lu SRC IN \n", pictureControlSetPtr->pictureNumber);
+        if ((pictureControlSetPtr->pictureNumber >= MIN_POC) && (pictureControlSetPtr->pictureNumber <= MAX_POC))
+            SVT_LOG("POC %lu SRC IN \n", pictureControlSetPtr->pictureNumber);
 #endif
 		pictureControlSetPtr->darkBackGroundlightForeGround = EB_FALSE;
 		contextPtr->pictureNumGrassLcu = 0;
@@ -1700,7 +1701,8 @@ void* SourceBasedOperationsKernel(void *inputPtr)
         EbPostFullObject(outputResultsWrapperPtr);
 
 #if DEADLOCK_DEBUG
-        SVT_LOG("POC %lu SRC OUT \n", pictureControlSetPtr->pictureNumber);
+        if ((pictureControlSetPtr->pictureNumber >= MIN_POC) && (pictureControlSetPtr->pictureNumber <= MAX_POC))
+            SVT_LOG("POC %lu SRC OUT \n", pictureControlSetPtr->pictureNumber);
 #endif
 
     }


### PR DESCRIPTION
To track each picture whether it's posted from every encoding kernel or not, after being fed into kernels.

As the message is to track picture level, this change can output picture flow once in each encoding kernel, with redundant outputs eliminated.

The recommended steps to debug encoding dead lock (hang) issue:
1. Track the POCs in the entrance and exit of the encoding pipeline,
   by forcibly printing the 1st DEADLOCK_DEBUG log in RC, and the
   last DEADLOCK_DEBUG log in PK;
2. Reorder the POC numbers of RC and PK separately, to check the
   1st POC which couldn't be outputted from PK;
3. Open the DEADLOCK_DEBUG switch, and change the MIN_POC & MAX_POC
   values clamping the range where that POC locates;
2. Check the specific stage where that POC can't go through.

Signed-off-by: Austin Hu <austin.hu@intel.com>