### PR TITLE
Handle corner case of sad64x64 comparison

### DIFF
--- a/Source/Lib/ASM_AVX2/EbComputeSAD_Intrinsic_AVX2.c
+++ b/Source/Lib/ASM_AVX2/EbComputeSAD_Intrinsic_AVX2.c
@@ -2139,11 +2139,11 @@ void GetEightHorizontalSearchPointResults_32x32_64x64_PU_AVX2_INTRIN(
         bestSad64x64 = temSum;
         bestMV64x64 = 7 * 4;
     }
-    if (bestSad64x64 <= pBestSad64x64[0]) {
-        pBestSad64x64[0] = bestSad64x64;
-        xMv = _MVXT(mv) + (EB_S16)bestMV64x64;  yMv = _MVYT(mv);
-        pBestMV64x64[0] = ((EB_U16)yMv << 16) | ((EB_U16)xMv);
-    }
+
+    pBestSad64x64[0] = bestSad64x64;
+    xMv = _MVXT(mv) + (EB_S16)bestMV64x64;  yMv = _MVYT(mv);
+    pBestMV64x64[0] = ((EB_U16)yMv << 16) | ((EB_U16)xMv);
+
 
     // ****CODE PAST HERE IS BUGGY FOR GCC****
 

--- a/Source/Lib/ASM_AVX2/EbComputeSAD_Intrinsic_AVX2.c
+++ b/Source/Lib/ASM_AVX2/EbComputeSAD_Intrinsic_AVX2.c
@@ -1938,7 +1938,8 @@ void GetEightHorizontalSearchPointResults_32x32_64x64_PU_AVX2_INTRIN(
     EB_U32   mv)
 {
     EB_S16 xMv, yMv;
-    EB_U32 temSum, bestSad64x64, bestMV64x64;
+    EB_U32 temSum, bestMV64x64;
+
     __m128i s0, s1, s2, s3, s4, s5, s6, s7, sad_0, sad_1;
     __m128i sad_00, sad_01, sad_10, sad_11, sad_20, sad_21, sad_30, sad_31;
     __m256i ss0, ss1, ss2, ss3, ss4, ss5, ss6, ss7;
@@ -2095,55 +2096,64 @@ void GetEightHorizontalSearchPointResults_32x32_64x64_PU_AVX2_INTRIN(
     sad_0 = _mm_slli_epi32(sad_0, 1);
     sad_1 = _mm_slli_epi32(sad_1, 1);
 
-    bestSad64x64 = pBestSad64x64[0];
+    EB_BOOL sadChanged = EB_FALSE;
     bestMV64x64 = 0;
+
     //sad_0
     temSum = _mm_extract_epi32(sad_0, 0);
-    if (temSum < bestSad64x64) {
-        bestSad64x64 = temSum;
+    if (temSum <= pBestSad64x64[0]) {
+        pBestSad64x64[0] = temSum;
+        sadChanged = EB_TRUE;
     }
     temSum = _mm_extract_epi32(sad_0, 1);
-    if (temSum < bestSad64x64) {
-        bestSad64x64 = temSum;
+    if (temSum <= pBestSad64x64[0]) {
+        pBestSad64x64[0] = temSum;
         bestMV64x64 = 1 * 4;
+        sadChanged = EB_TRUE;
     }
     temSum = _mm_extract_epi32(sad_0, 2);
-    if (temSum < bestSad64x64) {
-        bestSad64x64 = temSum;
+    if (temSum <= pBestSad64x64[0]) {
+        pBestSad64x64[0] = temSum;
         bestMV64x64 = 2 * 4;
+        sadChanged = EB_TRUE;
     }
     temSum = _mm_extract_epi32(sad_0, 3);
-    if (temSum < bestSad64x64) {
-        bestSad64x64 = temSum;
+    if (temSum <= pBestSad64x64[0]) {
+        pBestSad64x64[0] = temSum;
         bestMV64x64 = 3 * 4;
+        sadChanged = EB_TRUE;
     }
 
     //sad_1
     temSum = _mm_extract_epi32(sad_1, 0);
-    if (temSum < bestSad64x64) {
-        bestSad64x64 = temSum;
+    if (temSum <= pBestSad64x64[0]) {
+        pBestSad64x64[0] = temSum;
         bestMV64x64 = 4 * 4;
+        sadChanged = EB_TRUE;
     }
     temSum = _mm_extract_epi32(sad_1, 1);
-    if (temSum < bestSad64x64) {
-        bestSad64x64 = temSum;
+    if (temSum <= pBestSad64x64[0]) {
+        pBestSad64x64[0] = temSum;
         bestMV64x64 = 5 * 4;
+        sadChanged = EB_TRUE;
     }
     temSum = _mm_extract_epi32(sad_1, 2);
-    if (temSum < bestSad64x64) {
-        bestSad64x64 = temSum;
+    if (temSum <= pBestSad64x64[0]) {
+        pBestSad64x64[0] = temSum;
         bestMV64x64 = 6 * 4;
+        sadChanged = EB_TRUE;
     }
     temSum = _mm_extract_epi32(sad_1, 3);
-    if (temSum < bestSad64x64) {
-        bestSad64x64 = temSum;
+    if (temSum <= pBestSad64x64[0]) {
+        pBestSad64x64[0] = temSum;
         bestMV64x64 = 7 * 4;
+        sadChanged = EB_TRUE;
     }
 
-    pBestSad64x64[0] = bestSad64x64;
-    xMv = _MVXT(mv) + (EB_S16)bestMV64x64;  yMv = _MVYT(mv);
-    pBestMV64x64[0] = ((EB_U16)yMv << 16) | ((EB_U16)xMv);
-
+    if (sadChanged) {
+        xMv = _MVXT(mv) + (EB_S16)bestMV64x64;  yMv = _MVYT(mv);
+        pBestMV64x64[0] = ((EB_U16)yMv << 16) | ((EB_U16)xMv);
+    }
 
     // ****CODE PAST HERE IS BUGGY FOR GCC****
 

--- a/Source/Lib/ASM_AVX2/EbComputeSAD_Intrinsic_AVX2.c
+++ b/Source/Lib/ASM_AVX2/EbComputeSAD_Intrinsic_AVX2.c
@@ -2103,6 +2103,7 @@ void GetEightHorizontalSearchPointResults_32x32_64x64_PU_AVX2_INTRIN(
     temSum = _mm_extract_epi32(sad_0, 0);
     if (temSum <= pBestSad64x64[0]) {
         pBestSad64x64[0] = temSum;
+		bestMV64x64 = 0;
     }
     temSum = _mm_extract_epi32(sad_0, 1);
     if (temSum <= pBestSad64x64[0]) {

--- a/Source/Lib/ASM_AVX2/EbComputeSAD_Intrinsic_AVX2.c
+++ b/Source/Lib/ASM_AVX2/EbComputeSAD_Intrinsic_AVX2.c
@@ -2139,7 +2139,7 @@ void GetEightHorizontalSearchPointResults_32x32_64x64_PU_AVX2_INTRIN(
         bestSad64x64 = temSum;
         bestMV64x64 = 7 * 4;
     }
-    if (pBestSad64x64[0] != bestSad64x64) {
+    if (bestSad64x64 <= pBestSad64x64[0]) {
         pBestSad64x64[0] = bestSad64x64;
         xMv = _MVXT(mv) + (EB_S16)bestMV64x64;  yMv = _MVYT(mv);
         pBestMV64x64[0] = ((EB_U16)yMv << 16) | ((EB_U16)xMv);

--- a/Source/Lib/ASM_AVX2/EbComputeSAD_Intrinsic_AVX2.c
+++ b/Source/Lib/ASM_AVX2/EbComputeSAD_Intrinsic_AVX2.c
@@ -2096,32 +2096,28 @@ void GetEightHorizontalSearchPointResults_32x32_64x64_PU_AVX2_INTRIN(
     sad_0 = _mm_slli_epi32(sad_0, 1);
     sad_1 = _mm_slli_epi32(sad_1, 1);
 
-    EB_BOOL sadChanged = EB_FALSE;
-    bestMV64x64 = 0;
+
+    bestMV64x64 = 0xff;
 
     //sad_0
     temSum = _mm_extract_epi32(sad_0, 0);
     if (temSum <= pBestSad64x64[0]) {
         pBestSad64x64[0] = temSum;
-        sadChanged = EB_TRUE;
     }
     temSum = _mm_extract_epi32(sad_0, 1);
     if (temSum <= pBestSad64x64[0]) {
         pBestSad64x64[0] = temSum;
         bestMV64x64 = 1 * 4;
-        sadChanged = EB_TRUE;
     }
     temSum = _mm_extract_epi32(sad_0, 2);
     if (temSum <= pBestSad64x64[0]) {
         pBestSad64x64[0] = temSum;
         bestMV64x64 = 2 * 4;
-        sadChanged = EB_TRUE;
     }
     temSum = _mm_extract_epi32(sad_0, 3);
     if (temSum <= pBestSad64x64[0]) {
         pBestSad64x64[0] = temSum;
         bestMV64x64 = 3 * 4;
-        sadChanged = EB_TRUE;
     }
 
     //sad_1
@@ -2129,28 +2125,24 @@ void GetEightHorizontalSearchPointResults_32x32_64x64_PU_AVX2_INTRIN(
     if (temSum <= pBestSad64x64[0]) {
         pBestSad64x64[0] = temSum;
         bestMV64x64 = 4 * 4;
-        sadChanged = EB_TRUE;
     }
     temSum = _mm_extract_epi32(sad_1, 1);
     if (temSum <= pBestSad64x64[0]) {
         pBestSad64x64[0] = temSum;
         bestMV64x64 = 5 * 4;
-        sadChanged = EB_TRUE;
     }
     temSum = _mm_extract_epi32(sad_1, 2);
     if (temSum <= pBestSad64x64[0]) {
         pBestSad64x64[0] = temSum;
         bestMV64x64 = 6 * 4;
-        sadChanged = EB_TRUE;
     }
     temSum = _mm_extract_epi32(sad_1, 3);
     if (temSum <= pBestSad64x64[0]) {
         pBestSad64x64[0] = temSum;
         bestMV64x64 = 7 * 4;
-        sadChanged = EB_TRUE;
     }
 
-    if (sadChanged) {
+    if (bestMV64x64 != 0xff) {
         xMv = _MVXT(mv) + (EB_S16)bestMV64x64;  yMv = _MVYT(mv);
         pBestMV64x64[0] = ((EB_U16)yMv << 16) | ((EB_U16)xMv);
     }

--- a/Source/Lib/ASM_AVX2/EbComputeSAD_SadLoopKernel_AVX512.c
+++ b/Source/Lib/ASM_AVX2/EbComputeSAD_SadLoopKernel_AVX512.c
@@ -2180,11 +2180,11 @@ void GetEightHorizontalSearchPointResults_32x32_64x64_PU_AVX2_INTRIN(
 		bestSad64x64 = temSum;
 		bestMV64x64 = 7 * 4;
 	}
-	if (bestSad64x64 <= pBestSad64x64[0]) {
-		pBestSad64x64[0] = bestSad64x64;
-		xMv = _MVXT(mv) + (EB_S16) bestMV64x64;  yMv = _MVYT(mv);
-		pBestMV64x64[0] = ((EB_U16)yMv << 16) | ((EB_U16)xMv);
-	}
+
+	pBestSad64x64[0] = bestSad64x64;
+	xMv = _MVXT(mv) + (EB_S16) bestMV64x64;  yMv = _MVYT(mv);
+	pBestMV64x64[0] = ((EB_U16)yMv << 16) | ((EB_U16)xMv);
+
 
 	// ****CODE PAST HERE IS BUGGY FOR GCC****
 

--- a/Source/Lib/ASM_AVX2/EbComputeSAD_SadLoopKernel_AVX512.c
+++ b/Source/Lib/ASM_AVX2/EbComputeSAD_SadLoopKernel_AVX512.c
@@ -2142,6 +2142,7 @@ void GetEightHorizontalSearchPointResults_32x32_64x64_PU_AVX2_INTRIN(
 	temSum = _mm_extract_epi32(sad_0, 0);
 	if (temSum <= pBestSad64x64[0]){
 		pBestSad64x64[0] = temSum;
+		bestMV64x64 = 0;
 	}
 	temSum = _mm_extract_epi32(sad_0, 1);
 	if (temSum <= pBestSad64x64[0]){

--- a/Source/Lib/ASM_AVX2/EbComputeSAD_SadLoopKernel_AVX512.c
+++ b/Source/Lib/ASM_AVX2/EbComputeSAD_SadLoopKernel_AVX512.c
@@ -2136,32 +2136,27 @@ void GetEightHorizontalSearchPointResults_32x32_64x64_PU_AVX2_INTRIN(
 	sad_0 = _mm_slli_epi32(sad_0, 1);
 	sad_1 = _mm_slli_epi32(sad_1, 1);
 
-	EB_BOOL sadChanged = EB_FALSE;
-	bestMV64x64 = 0;
+	bestMV64x64 = 0xff;
 
 	//sad_0
 	temSum = _mm_extract_epi32(sad_0, 0);
 	if (temSum <= pBestSad64x64[0]){
 		pBestSad64x64[0] = temSum;
-		sadChanged = EB_TRUE;
 	}
 	temSum = _mm_extract_epi32(sad_0, 1);
 	if (temSum <= pBestSad64x64[0]){
 		pBestSad64x64[0] = temSum;
 		bestMV64x64 = 1 * 4;
-		sadChanged = EB_TRUE;
 	}
 	temSum = _mm_extract_epi32(sad_0, 2);
 	if (temSum <= pBestSad64x64[0]){
 		pBestSad64x64[0] = temSum;
 		bestMV64x64 = 2 * 4;
-		sadChanged = EB_TRUE;
 	}
 	temSum = _mm_extract_epi32(sad_0, 3);
 	if (temSum <= pBestSad64x64[0]){
 		pBestSad64x64[0] = temSum;
 		bestMV64x64 = 3 * 4;
-		sadChanged = EB_TRUE;
 	}
 
 	//sad_1
@@ -2169,28 +2164,24 @@ void GetEightHorizontalSearchPointResults_32x32_64x64_PU_AVX2_INTRIN(
 	if (temSum <= pBestSad64x64[0]){
 		pBestSad64x64[0] = temSum;
 		bestMV64x64 = 4 * 4;
-		sadChanged = EB_TRUE;
 	}
 	temSum = _mm_extract_epi32(sad_1, 1);
 	if (temSum <= pBestSad64x64[0]){
 		pBestSad64x64[0] = temSum;
 		bestMV64x64 = 5 * 4;
-		sadChanged = EB_TRUE;
 	}
 	temSum = _mm_extract_epi32(sad_1, 2);
 	if (temSum <= pBestSad64x64[0]){
 		pBestSad64x64[0] = temSum;
 		bestMV64x64 = 6 * 4;
-		sadChanged = EB_TRUE;
 	}
 	temSum = _mm_extract_epi32(sad_1, 3);
 	if (temSum <= pBestSad64x64[0]){
 		pBestSad64x64[0] = temSum;
 		bestMV64x64 = 7 * 4;
-		sadChanged = EB_TRUE;
 	}
 
-    if (sadChanged)
+    if (bestMV64x64 != 0xff)
     {
         xMv = _MVXT(mv) + (EB_S16)bestMV64x64;  yMv = _MVYT(mv);
         pBestMV64x64[0] = ((EB_U16)yMv << 16) | ((EB_U16)xMv);

--- a/Source/Lib/ASM_AVX2/EbComputeSAD_SadLoopKernel_AVX512.c
+++ b/Source/Lib/ASM_AVX2/EbComputeSAD_SadLoopKernel_AVX512.c
@@ -1979,7 +1979,7 @@ void GetEightHorizontalSearchPointResults_32x32_64x64_PU_AVX2_INTRIN(
 	EB_U32   mv)
 {
 	EB_S16 xMv, yMv;
-	EB_U32 temSum, bestSad64x64, bestMV64x64;
+	EB_U32 temSum, bestMV64x64;
 	__m128i s0, s1, s2, s3, s4, s5, s6, s7, sad_0, sad_1;
 	__m128i sad_00, sad_01, sad_10, sad_11, sad_20, sad_21, sad_30, sad_31;
 	__m256i ss0, ss1, ss2, ss3, ss4, ss5, ss6, ss7;
@@ -2136,55 +2136,65 @@ void GetEightHorizontalSearchPointResults_32x32_64x64_PU_AVX2_INTRIN(
 	sad_0 = _mm_slli_epi32(sad_0, 1);
 	sad_1 = _mm_slli_epi32(sad_1, 1);
 
-	bestSad64x64 = pBestSad64x64[0];
+	EB_BOOL sadChanged = EB_FALSE;
 	bestMV64x64 = 0;
+
 	//sad_0
 	temSum = _mm_extract_epi32(sad_0, 0);
-	if (temSum < bestSad64x64){
-		bestSad64x64 = temSum;
+	if (temSum <= pBestSad64x64[0]){
+		pBestSad64x64[0] = temSum;
+		sadChanged = EB_TRUE;
 	}
 	temSum = _mm_extract_epi32(sad_0, 1);
-	if (temSum < bestSad64x64){
-		bestSad64x64 = temSum;
+	if (temSum <= pBestSad64x64[0]){
+		pBestSad64x64[0] = temSum;
 		bestMV64x64 = 1 * 4;
+		sadChanged = EB_TRUE;
 	}
 	temSum = _mm_extract_epi32(sad_0, 2);
-	if (temSum < bestSad64x64){
-		bestSad64x64 = temSum;
+	if (temSum <= pBestSad64x64[0]){
+		pBestSad64x64[0] = temSum;
 		bestMV64x64 = 2 * 4;
+		sadChanged = EB_TRUE;
 	}
 	temSum = _mm_extract_epi32(sad_0, 3);
-	if (temSum < bestSad64x64){
-		bestSad64x64 = temSum;
+	if (temSum <= pBestSad64x64[0]){
+		pBestSad64x64[0] = temSum;
 		bestMV64x64 = 3 * 4;
+		sadChanged = EB_TRUE;
 	}
 
 	//sad_1
 	temSum = _mm_extract_epi32(sad_1, 0);
-	if (temSum < bestSad64x64){
-		bestSad64x64 = temSum;
+	if (temSum <= pBestSad64x64[0]){
+		pBestSad64x64[0] = temSum;
 		bestMV64x64 = 4 * 4;
+		sadChanged = EB_TRUE;
 	}
 	temSum = _mm_extract_epi32(sad_1, 1);
-	if (temSum < bestSad64x64){
-		bestSad64x64 = temSum;
+	if (temSum <= pBestSad64x64[0]){
+		pBestSad64x64[0] = temSum;
 		bestMV64x64 = 5 * 4;
+		sadChanged = EB_TRUE;
 	}
 	temSum = _mm_extract_epi32(sad_1, 2);
-	if (temSum < bestSad64x64){
-		bestSad64x64 = temSum;
+	if (temSum <= pBestSad64x64[0]){
+		pBestSad64x64[0] = temSum;
 		bestMV64x64 = 6 * 4;
+		sadChanged = EB_TRUE;
 	}
 	temSum = _mm_extract_epi32(sad_1, 3);
-	if (temSum < bestSad64x64){
-		bestSad64x64 = temSum;
+	if (temSum <= pBestSad64x64[0]){
+		pBestSad64x64[0] = temSum;
 		bestMV64x64 = 7 * 4;
+		sadChanged = EB_TRUE;
 	}
 
-	pBestSad64x64[0] = bestSad64x64;
-	xMv = _MVXT(mv) + (EB_S16) bestMV64x64;  yMv = _MVYT(mv);
-	pBestMV64x64[0] = ((EB_U16)yMv << 16) | ((EB_U16)xMv);
-
+    if (sadChanged)
+    {
+        xMv = _MVXT(mv) + (EB_S16)bestMV64x64;  yMv = _MVYT(mv);
+        pBestMV64x64[0] = ((EB_U16)yMv << 16) | ((EB_U16)xMv);
+    }
 
 	// ****CODE PAST HERE IS BUGGY FOR GCC****
 

--- a/Source/Lib/ASM_AVX2/EbComputeSAD_SadLoopKernel_AVX512.c
+++ b/Source/Lib/ASM_AVX2/EbComputeSAD_SadLoopKernel_AVX512.c
@@ -2180,7 +2180,7 @@ void GetEightHorizontalSearchPointResults_32x32_64x64_PU_AVX2_INTRIN(
 		bestSad64x64 = temSum;
 		bestMV64x64 = 7 * 4;
 	}
-	if (pBestSad64x64[0] != bestSad64x64) {
+	if (bestSad64x64 <= pBestSad64x64[0]) {
 		pBestSad64x64[0] = bestSad64x64;
 		xMv = _MVXT(mv) + (EB_S16) bestMV64x64;  yMv = _MVYT(mv);
 		pBestMV64x64[0] = ((EB_U16)yMv << 16) | ((EB_U16)xMv);

--- a/Source/Lib/C_DEFAULT/EbComputeSAD_C.c
+++ b/Source/Lib/C_DEFAULT/EbComputeSAD_C.c
@@ -436,7 +436,7 @@ void GetEightHorizontalSearchPointResults_32x32_64x64(
 
         //64x64
         sad64x64 = sad32x32_0 + sad32x32_1 + sad32x32_2 + sad32x32_3;
-        if (2 * sad64x64 < pBestSad64x64[0]){
+        if (2 * sad64x64 <= pBestSad64x64[0]){
             pBestSad64x64[0] = 2 * sad64x64;
             xMv = _MVXT(mv) + (EB_S16)xSearchIndex * 4;
             yMv = _MVYT(mv);


### PR DESCRIPTION
Changed the check for pBestSad64x64 to also
include being equal to the value, as the computed
value might equal pBestSad64x64 without a correct
corresponding motion vector ever being set.

We are thus changing to <= to include this corner
case.

Signed-off-by: Mark Feldman <mark.feldman@intel.com>

Closes #481 