### PR TITLE
y4m file rewind logic

### DIFF
--- a/Source/App/EbAppInputy4m.c
+++ b/Source/App/EbAppInputy4m.c
@@ -314,8 +314,18 @@ int32_t read_y4m_frame_delimiter(EbConfig_t *cfg) {
     fresult = fgets((char *)bufferY4Mheader, sizeof(bufferY4Mheader), cfg->inputFile);
 
     if (fresult == NULL) {
-        assert(feof(cfg->inputFile));
-        return EB_ErrorNone;
+        // Could be at end of file
+        // Rewind file and skip over header
+        fseek(cfg->inputFile, 0, SEEK_SET);
+        char buffer[YFM_HEADER_MAX];
+        fresult = fgets(buffer, sizeof(buffer), cfg->inputFile);
+
+        // try reading delimiter again
+        fresult = fgets((char *)bufferY4Mheader, sizeof(bufferY4Mheader), cfg->inputFile);
+        if (fresult == NULL) {
+            assert(feof(cfg->inputFile));
+            return EB_ErrorNone;
+        }
     }
     if (!validateAlphanumeric(bufferY4Mheader)){
         return EB_ErrorBadParameter;

--- a/Source/App/EbAppInputy4m.c
+++ b/Source/App/EbAppInputy4m.c
@@ -5,6 +5,7 @@
 
 #include "EbAppInputy4m.h"
 #define YFM_HEADER_MAX 80
+#define YFM_FRAME_DELIMITER_MAX 10
 
 #define CHROMA_MAX 4
 
@@ -308,10 +309,10 @@ EB_BOOL validateAlphanumeric(unsigned char* buffer)
 
 /* read next line which contains the "FRAME" delimiter */
 int32_t read_y4m_frame_delimiter(EbConfig_t *cfg) {
-    unsigned char bufferY4Mheader[10];
+    unsigned char bufferY4Mframedelimiter[YFM_FRAME_DELIMITER_MAX];
     char *fresult;
 
-    fresult = fgets((char *)bufferY4Mheader, sizeof(bufferY4Mheader), cfg->inputFile);
+    fresult = fgets((char *)bufferY4Mframedelimiter, sizeof(bufferY4Mframedelimiter), cfg->inputFile);
 
     if (fresult == NULL) {
         // Could be at end of file
@@ -321,16 +322,16 @@ int32_t read_y4m_frame_delimiter(EbConfig_t *cfg) {
         fresult = fgets(buffer, sizeof(buffer), cfg->inputFile);
 
         // try reading delimiter again
-        fresult = fgets((char *)bufferY4Mheader, sizeof(bufferY4Mheader), cfg->inputFile);
+        fresult = fgets((char *)bufferY4Mframedelimiter, sizeof(bufferY4Mframedelimiter), cfg->inputFile);
         if (fresult == NULL) {
             assert(feof(cfg->inputFile));
             return EB_ErrorNone;
         }
     }
-    if (!validateAlphanumeric(bufferY4Mheader)){
+    if (!validateAlphanumeric(bufferY4Mframedelimiter)){
         return EB_ErrorBadParameter;
     }
-    if (EB_STRCMP((const char*)bufferY4Mheader, "FRAME\n") != 0) {
+    if (EB_STRCMP((const char*)bufferY4Mframedelimiter, "FRAME\n") != 0) {
         fprintf(cfg->errorLogFile, "Failed to read proper y4m frame delimeter. Read broken.\n");
         return EB_ErrorBadParameter;
     }


### PR DESCRIPTION
Core problem is that the existing assert and return of
EB_ErrorNone when the y4m frame delimiter is read
are happening when the file stream reader is at the end of
the file.  This can happen when the -n value is larger than the
actual number of frames in the file.

To fix this problem with y4m files, an additional check is
added to when the y4m frame delimiter is being read.  Rather
than asserting after the feof check, the y4m file is rewound, the
header is skipped over, and the frame delimiter is attempted to be
read again.

Note: One alternative solution could be to first figure out how many
bytes are in the file (using fseek and ftell), and then use ftell
to see if the file reader is at the end of the file.

This logic would replace the feof call at the end of ReadInputFrames,
since that call is not correctly being used. feof uses an indicator that
is set by a previous operation on the stream that attempted to read
at or past the end-of-file. By itself calling feof does not return any
useful information.

Signed-off-by: Mark Feldman <mark.feldman@intel.com>