### PR TITLE
Fixed the random encoding hang issue due to incorrect number of FIFOs.

### DIFF
--- a/Source/Lib/Codec/EbSequenceControlSet.h
+++ b/Source/Lib/Codec/EbSequenceControlSet.h
@@ -176,6 +176,7 @@ typedef struct SequenceControlSet_s
     //EB_U32                    modeDecisionFifoInitCount;            
     EB_U32                      encDecFifoInitCount;
     EB_U32                      entropyCodingFifoInitCount;
+    EB_U32                      unpackFifoInitCount;
     EB_U32                      pictureAnalysisProcessInitCount;     
     EB_U32                      motionEstimationProcessInitCount; 
     EB_U32                      sourceBasedOperationsProcessInitCount;


### PR DESCRIPTION
Fixed by calculating the number of FIFO objects with desired FPS and
life cycle of the objects.

Signed-off-by: Austin Hu <austin.hu@intel.com>

2nd option to fix #497 .