### PR TITLE
Worked around the random encoding hang issue due to incorrect number

### DIFF
--- a/Source/Lib/Codec/EbEncHandle.c
+++ b/Source/Lib/Codec/EbEncHandle.c
@@ -1724,7 +1724,9 @@ void LoadDefaultBufferConfigurationSettings(
     }
     threadUnit = totalThreadCount / EB_THREAD_COUNT_MIN_CORE;
 
-    sequenceControlSetPtr->inputOutputBufferFifoInitCount = inputPic + SCD_LAD;
+    sequenceControlSetPtr->inputOutputBufferFifoInitCount = inputPic + SCD_LAD +
+        sequenceControlSetPtr->staticConfig.lookAheadDistance +
+        sequenceControlSetPtr->staticConfig.intraPeriodLength;
 
     // ME segments
     sequenceControlSetPtr->meSegmentRowCountArray[0] = meSegH;


### PR DESCRIPTION
of FIFO objects.

Signed-off-by: Austin Hu <austin.hu@intel.com>

As the 3rd (work around) option, to fix #497 , #514 .