### PR TITLE
Increase MEM_ENTRY_SIZE

### DIFF
--- a/Source/Lib/Codec/EbMalloc.c
+++ b/Source/Lib/Codec/EbMalloc.c
@@ -71,7 +71,7 @@ typedef struct MemoryEntry{
 } MemoryEntry;
 
 //+1 to get a better hash result
-#define MEM_ENTRY_SIZE (4 * 1024 * 1024 + 1)
+#define MEM_ENTRY_SIZE (16 * 1024 * 1024 + 1)
 
 MemoryEntry gMemEntry[MEM_ENTRY_SIZE];
 


### PR DESCRIPTION
Increasing MEM_ENTRY_SIZE  x4 to allow for 8k media
encoding using a debug build.

This eliminates seeing these messages when the encoding
is stopped:
SVT: can't add memory entry.
SVT: You have memory leak or you need increase MEM_ENTRY_SIZE

closes #506 
Signed-off-by: Mark Feldman <mark.feldman@intel.com>