### PR TITLE
Fix hang caused by OUT_ALLOC and remove macro

### DIFF
--- a/Source/Lib/Codec/EbDefinitions.h
+++ b/Source/Lib/Codec/EbDefinitions.h
@@ -12,7 +12,6 @@ extern "C" {
 #endif
 
 #define PAREF_OUT 1 // Disconnect pa ref  from input for both single/multi core
-#define OUT_ALLOC 0 // Output bitsream allocation at run time for both single/multi core
 
 //#define BENCHMARK 0
 #define LATENCY_PROFILE 0

--- a/Source/Lib/Codec/EbInitialRateControlProcess.c
+++ b/Source/Lib/Codec/EbInitialRateControlProcess.c
@@ -866,9 +866,6 @@ void* InitialRateControlKernel(void *inputPtr)
     EB_U8                               temporalLayerIndex;
 	EbObjectWrapper_t                  *referencePictureWrapperPtr;
 
-#if !OUT_ALLOC
-	EbObjectWrapper_t                *outputStreamWrapperPtr;
-#endif
 
 	for (;;) {
 
@@ -1070,14 +1067,6 @@ void* InitialRateControlKernel(void *inputPtr)
 						((PictureParentControlSet_t*)(queueEntryPtr->parentPcsWrapperPtr->objectPtr))->referencePictureWrapperPtr,
 						1);
 					//OPTION 1:  get the buffer in resource coordination
-
-#if !OUT_ALLOC
-					EbGetEmptyObject(
-						sequenceControlSetPtr->encodeContextPtr->streamOutputFifoPtr,
-						&outputStreamWrapperPtr);
-
-					pictureControlSetPtr->outputStreamWrapperPtr = outputStreamWrapperPtr;
-#endif
 
                     // Get Empty Results Object
 					EbGetEmptyObject(

--- a/Source/Lib/Codec/EbPacketizationProcess.c
+++ b/Source/Lib/Codec/EbPacketizationProcess.c
@@ -340,7 +340,7 @@ void* PacketizationKernel(void *inputPtr)
             FlushBitstream(
                 pictureControlSetPtr->bitstreamPtr->outputBitstreamPtr);
 
-            // Copy SPS, PPS and PPS to the Output Bitstream
+            // Copy SPS & PPS to the Output Bitstream
             CopyRbspBitstreamToPayload(
                 pictureControlSetPtr->bitstreamPtr,
                 &outputStreamPtr->pBuffer,
@@ -606,21 +606,20 @@ void* PacketizationKernel(void *inputPtr)
                 &sequenceControlSetPtr->bufferingPeriod,
                 sequenceControlSetPtr->videoUsabilityInfoPtr,
                 sequenceControlSetPtr->encodeContextPtr);
-
-            // Flush the Bitstream
-            FlushBitstream(
-                pictureControlSetPtr->bitstreamPtr->outputBitstreamPtr);
-
-            // Copy Buffering Period SEI to the Output Bitstream
-            CopyRbspBitstreamToPayload(
-                pictureControlSetPtr->bitstreamPtr,
-                &outputStreamPtr->pBuffer,
-                (EB_U32*) &(outputStreamPtr->nFilledLen),
-                (EB_U32*) &(outputStreamPtr->nAllocLen),
-                encodeContextPtr,
-                NAL_UNIT_INVALID);
         }
 
+        // Flush the Bitstream
+        FlushBitstream(
+            pictureControlSetPtr->bitstreamPtr->outputBitstreamPtr);
+
+        // Copy Buffering Period SEI to the Output Bitstream
+        CopyRbspBitstreamToPayload(
+            pictureControlSetPtr->bitstreamPtr,
+            &outputStreamPtr->pBuffer,
+            (EB_U32*) &(outputStreamPtr->nFilledLen),
+            (EB_U32*) &(outputStreamPtr->nAllocLen),
+            encodeContextPtr,
+			NAL_UNIT_INVALID);
         queueEntryPtr->startSplicing = outputStreamPtr->nFilledLen;
         if (sequenceControlSetPtr->staticConfig.pictureTimingSEI) {
             if (sequenceControlSetPtr->staticConfig.hrdFlag == 1)
@@ -764,7 +763,7 @@ void* PacketizationKernel(void *inputPtr)
             // Flush the Bitstream
             FlushBitstream(pictureControlSetPtr->bitstreamPtr->outputBitstreamPtr);
 
-            // Copy EOS to the Output Bitstream
+            // Copy SPS & PPS to the Output Bitstream
             CopyRbspBitstreamToPayload(
                 pictureControlSetPtr->bitstreamPtr,
                 &outputStreamPtr->pBuffer,

--- a/Source/Lib/Codec/EbSequenceControlSet.h
+++ b/Source/Lib/Codec/EbSequenceControlSet.h
@@ -163,7 +163,8 @@ typedef struct SequenceControlSet_s
     EB_U32                      paReferencePictureBufferInitCount;
     EB_U32                      referencePictureBufferInitCount;
     EB_U32                      reconBufferFifoInitCount;
-    EB_U32                      inputOutputBufferFifoInitCount;
+    EB_U32                      inputBufferFifoInitCount;
+    EB_U32                      outputBufferFifoInitCount;
     EB_U32                      resourceCoordinationFifoInitCount;     
     EB_U32                      pictureAnalysisFifoInitCount;
     EB_U32                      pictureDecisionFifoInitCount;


### PR DESCRIPTION
1. The reason of hang caused by OUT_ALLOC is lack of available output stream buffer.
   The fix is to seperate the outputBufferFifoInitCount from inputOutputBufferFifoInitCount.
   And increase its size.
2. Remove the OUT_ALLOC macro.

Signed-off-by: Jun Tian <jun.tian@intel.com>

closes #514, #497