### PR TITLE
Replaced memcpy with referencing input frame buffers.

### DIFF
--- a/Source/API/EbApi.h
+++ b/Source/API/EbApi.h
@@ -10,7 +10,6 @@
 #include <string.h>
 #include <stdint.h>
 #include <EbApiVersion.h>
-#include <sys/queue.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -101,8 +100,6 @@ extern "C" {
         uint8_t* naluBase64Encode;
 
         SegmentOverride_t *segmentOvPtr;
-
-        LIST_ENTRY(EB_BUFFERHEADERTYPE) list;
     } EB_BUFFERHEADERTYPE;
 
     typedef struct EB_COMPONENTTYPE

--- a/Source/API/EbApi.h
+++ b/Source/API/EbApi.h
@@ -10,6 +10,7 @@
 #include <string.h>
 #include <stdint.h>
 #include <EbApiVersion.h>
+#include <sys/queue.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -100,6 +101,8 @@ extern "C" {
         uint8_t* naluBase64Encode;
 
         SegmentOverride_t *segmentOvPtr;
+
+        LIST_ENTRY(EB_BUFFERHEADERTYPE) list;
     } EB_BUFFERHEADERTYPE;
 
     typedef struct EB_COMPONENTTYPE

--- a/Source/App/EbAppContext.c
+++ b/Source/App/EbAppContext.c
@@ -369,7 +369,7 @@ EB_ERRORTYPE AllocateInputBuffers(
     } else
         callbackData->inputBufferPoolSize = 1;
 
-    EB_APP_MALLOC(EB_BUFFERHEADERTYPE **, callbackData->inputBufferPool, sizeof(EB_BUFFERHEADERTYPE *) * callbackData->inputBufferPoolSize,
+    EB_APP_MALLOC(EbAppInputFrame_t **, callbackData->inputBufferPool, sizeof(EbAppInputFrame_t *) * callbackData->inputBufferPoolSize,
             EB_N_PTR, EB_ErrorInsufficientResources);
 
     LIST_INIT(&callbackData->poolList);
@@ -377,33 +377,34 @@ EB_ERRORTYPE AllocateInputBuffers(
 
     for (uint16_t i = 0; i < callbackData->inputBufferPoolSize; i++)
     {
-        EB_APP_MALLOC(EB_BUFFERHEADERTYPE*, callbackData->inputBufferPool[i], sizeof(EB_BUFFERHEADERTYPE), EB_N_PTR, EB_ErrorInsufficientResources);
+        EB_APP_MALLOC(EbAppInputFrame_t *, callbackData->inputBufferPool[i], sizeof(EbAppInputFrame_t), EB_N_PTR, EB_ErrorInsufficientResources);
+        EB_APP_MALLOC(EB_BUFFERHEADERTYPE *, callbackData->inputBufferPool[i]->inputFrame, sizeof(EB_BUFFERHEADERTYPE), EB_N_PTR, EB_ErrorInsufficientResources);
 
         // Initialize Header
-        callbackData->inputBufferPool[i]->nSize                       = sizeof(EB_BUFFERHEADERTYPE);
+        callbackData->inputBufferPool[i]->inputFrame->nSize = sizeof(EB_BUFFERHEADERTYPE);
 
-        EB_APP_MALLOC(uint8_t*, callbackData->inputBufferPool[i]->pBuffer, sizeof(EB_H265_ENC_INPUT), EB_N_PTR, EB_ErrorInsufficientResources);
+        EB_APP_MALLOC(uint8_t*, callbackData->inputBufferPool[i]->inputFrame->pBuffer, sizeof(EB_H265_ENC_INPUT), EB_N_PTR, EB_ErrorInsufficientResources);
 
         if (config->bufferedInput == -1) {
 
             // Allocate frame buffer for the pBuffer
             AllocateInputBuffer(
                     config,
-                    callbackData->inputBufferPool[i]->pBuffer);
+                    callbackData->inputBufferPool[i]->inputFrame->pBuffer);
         }
 
         // Assign the variables
-        callbackData->inputBufferPool[i]->pAppPrivate = NULL;
-        callbackData->inputBufferPool[i]->sliceType   = EB_INVALID_PICTURE;
+        callbackData->inputBufferPool[i]->inputFrame->pAppPrivate = NULL;
+        callbackData->inputBufferPool[i]->inputFrame->sliceType   = EB_INVALID_PICTURE;
 
         if (callbackData->ebEncParameters.segmentOvEnabled) {
             size_t pictureWidthInLcu = (config->sourceWidth + EB_SEGMENT_BLOCK_SIZE - 1) / EB_SEGMENT_BLOCK_SIZE;
             size_t pictureHeightInLcu = (config->sourceHeight + EB_SEGMENT_BLOCK_SIZE - 1) / EB_SEGMENT_BLOCK_SIZE;
             size_t lcuTotalCount = pictureWidthInLcu * pictureHeightInLcu;
-            EB_APP_MALLOC(SegmentOverride_t*, callbackData->inputBufferPool[i]->segmentOvPtr, sizeof(SegmentOverride_t) * lcuTotalCount, EB_N_PTR, EB_ErrorInsufficientResources);
+            EB_APP_MALLOC(SegmentOverride_t*, callbackData->inputBufferPool[i]->inputFrame->segmentOvPtr, sizeof(SegmentOverride_t) * lcuTotalCount, EB_N_PTR, EB_ErrorInsufficientResources);
         }
         else {
-            callbackData->inputBufferPool[i]->segmentOvPtr = NULL;
+            callbackData->inputBufferPool[i]->inputFrame->segmentOvPtr = NULL;
         }
 
         if (callbackData->inputBufferPoolSize > 1) {

--- a/Source/App/EbAppContext.c
+++ b/Source/App/EbAppContext.c
@@ -23,8 +23,6 @@
 #define IS_16_BIT(bit_depth) (bit_depth==10?1:0)
 #define EB_OUTPUTSTREAMBUFFERSIZE_MACRO(ResolutionSize)                ((ResolutionSize) < (INPUT_SIZE_1080i_TH) ? 0x1E8480 : (ResolutionSize) < (INPUT_SIZE_1080p_TH) ? 0x2DC6C0 : (ResolutionSize) < (INPUT_SIZE_4K_TH) ? 0x2DC6C0 : (ResolutionSize) < (INPUT_SIZE_8K_TH) ? 0x2DC6C0:0x5B8D80)
 
-#define HEVC_LCU_SIZE 64
-
  /***************************************
  * Variables Defining a memory table
  *  hosting all allocated pointers
@@ -361,13 +359,9 @@ EB_ERRORTYPE AllocateInputBuffers(
 {
     EB_ERRORTYPE   return_error = EB_ErrorNone;
 
-    if (!(callbackData->ebEncParameters.sourceWidth % HEVC_LCU_SIZE) &&
-            !(callbackData->ebEncParameters.sourceHeight % HEVC_LCU_SIZE)) {
-        // To create the input buffer pool for direct reference, rather
-        // then memcpy to Input FIFO objects.
-        callbackData->inputBufferPoolSize = MAX(INPUT_BUFFER_POOL_SIZE, config->bufferedInput);
-    } else
-        callbackData->inputBufferPoolSize = 1;
+    // To create the input buffer pool for direct reference, rather
+    // then memcpy to Input FIFO objects.
+    callbackData->inputBufferPoolSize = MAX(INPUT_BUFFER_POOL_SIZE, config->bufferedInput);
 
     EB_APP_MALLOC(EbAppInputFrame_t **, callbackData->inputBufferPool, sizeof(EbAppInputFrame_t *) * callbackData->inputBufferPoolSize,
             EB_N_PTR, EB_ErrorInsufficientResources);

--- a/Source/App/EbAppContext.c
+++ b/Source/App/EbAppContext.c
@@ -366,8 +366,14 @@ EB_ERRORTYPE AllocateInputBuffers(
     EB_APP_MALLOC(EbAppInputFrame_t **, callbackData->inputBufferPool, sizeof(EbAppInputFrame_t *) * callbackData->inputBufferPoolSize,
             EB_N_PTR, EB_ErrorInsufficientResources);
 
+#ifdef _WIN32
+    InitializeSListHead(&callbackData->poolList);
+    InitializeSListHead(&callbackData->encodingList);
+    InitializeSListHead(&callbackData->tmpEncodingList);
+#else
     LIST_INIT(&callbackData->poolList);
     LIST_INIT(&callbackData->encodingList);
+#endif
 
     for (uint16_t i = 0; i < callbackData->inputBufferPoolSize; i++)
     {
@@ -403,7 +409,11 @@ EB_ERRORTYPE AllocateInputBuffers(
 
         if (callbackData->inputBufferPoolSize > 1) {
             // Insert the created input buffer into the pool, with linked list connected.
+#ifdef _WIN32
+            InterlockedPushEntrySList(&callbackData->poolList, &callbackData->inputBufferPool[i]->list);
+#else
             LIST_INSERT_HEAD(&callbackData->poolList, callbackData->inputBufferPool[i], list);
+#endif
         }
     }
 

--- a/Source/App/EbAppContext.h
+++ b/Source/App/EbAppContext.h
@@ -9,6 +9,12 @@
 #include "EbApi.h"
 #include "EbAppConfig.h"
 
+// Close to the Input FIFO size, and can be tuned.
+#define INPUT_BUFFER_POOL_SIZE 100
+
+#define MAX(x, y)                       ((x)>(y)?(x):(y))
+#define MIN(x, y)                       ((x)<(y)?(x):(y))
+
 /***************************************
 
  * App Callback data struct
@@ -26,7 +32,10 @@ typedef struct EbAppContext_s {
     EB_COMPONENTTYPE*                   svtEncoderHandle;
 
     // Buffer Pools
-    EB_BUFFERHEADERTYPE                *inputBufferPool;
+    EB_BUFFERHEADERTYPE                **inputBufferPool;
+    uint16_t                            inputBufferPoolSize;
+    LIST_HEAD(pool_list, EB_BUFFERHEADERTYPE)       poolList;
+    LIST_HEAD(encoding_list, EB_BUFFERHEADERTYPE)   encodingList;
     EB_BUFFERHEADERTYPE                *streamBufferPool;
     EB_BUFFERHEADERTYPE                *reconBuffer;
 

--- a/Source/App/EbAppContext.h
+++ b/Source/App/EbAppContext.h
@@ -12,7 +12,7 @@
 #include <sys/queue.h>
 
 // Close to the Input FIFO size, and can be tuned.
-#define INPUT_BUFFER_POOL_SIZE 100
+#define INPUT_BUFFER_POOL_SIZE 120
 
 #define MAX(x, y)                       ((x)>(y)?(x):(y))
 #define MIN(x, y)                       ((x)<(y)?(x):(y))

--- a/Source/App/EbAppContext.h
+++ b/Source/App/EbAppContext.h
@@ -9,7 +9,11 @@
 #include "EbApi.h"
 #include "EbAppConfig.h"
 
+#ifdef _WIN32
+#include <windows.h>
+#else
 #include <sys/queue.h>
+#endif
 
 // Close to the Input FIFO size, and can be tuned.
 #define INPUT_BUFFER_POOL_SIZE 120
@@ -23,8 +27,12 @@
  ***************************************/
 typedef struct EbAppInputFrame_s
 {
-    EB_BUFFERHEADERTYPE *inputFrame;
+#ifdef _WIN32
+    SLIST_ENTRY list;
+#else
     LIST_ENTRY(EbAppInputFrame_s) list;
+#endif
+    EB_BUFFERHEADERTYPE* inputFrame;
 } EbAppInputFrame_t;
 
 typedef struct EbAppContext_s {
@@ -42,8 +50,18 @@ typedef struct EbAppContext_s {
     // Buffer Pools
     EbAppInputFrame_t                  **inputBufferPool;
     uint16_t                            inputBufferPoolSize;
+#ifdef _WIN32
+    SLIST_HEADER                                  poolList;
+    SLIST_HEADER                                  encodingList;
+    // Windows interlockedapi just has the functions to insert
+    // or remove item at the front of a singly linked list, so
+    // add additional list to store the items popped from
+    // encodingList for checking.
+    SLIST_HEADER                                  tmpEncodingList;
+#else
     LIST_HEAD(pool_list, EbAppInputFrame_s)       poolList;
     LIST_HEAD(encoding_list, EbAppInputFrame_s)   encodingList;
+#endif
     EB_BUFFERHEADERTYPE                *reconBuffer;
 
 	// Instance Index

--- a/Source/App/EbAppContext.h
+++ b/Source/App/EbAppContext.h
@@ -9,6 +9,8 @@
 #include "EbApi.h"
 #include "EbAppConfig.h"
 
+#include <sys/queue.h>
+
 // Close to the Input FIFO size, and can be tuned.
 #define INPUT_BUFFER_POOL_SIZE 100
 
@@ -19,6 +21,12 @@
 
  * App Callback data struct
  ***************************************/
+typedef struct EbAppInputFrame_s
+{
+    EB_BUFFERHEADERTYPE *inputFrame;
+    LIST_ENTRY(EbAppInputFrame_s) list;
+} EbAppInputFrame_t;
+
 typedef struct EbAppContext_s {
     void                               *cmdSemaphoreHandle;
     void                               *inputSemaphoreHandle;
@@ -32,10 +40,10 @@ typedef struct EbAppContext_s {
     EB_COMPONENTTYPE*                   svtEncoderHandle;
 
     // Buffer Pools
-    EB_BUFFERHEADERTYPE                **inputBufferPool;
+    EbAppInputFrame_t                  **inputBufferPool;
     uint16_t                            inputBufferPoolSize;
-    LIST_HEAD(pool_list, EB_BUFFERHEADERTYPE)       poolList;
-    LIST_HEAD(encoding_list, EB_BUFFERHEADERTYPE)   encodingList;
+    LIST_HEAD(pool_list, EbAppInputFrame_s)       poolList;
+    LIST_HEAD(encoding_list, EbAppInputFrame_s)   encodingList;
     EB_BUFFERHEADERTYPE                *streamBufferPool;
     EB_BUFFERHEADERTYPE                *reconBuffer;
 

--- a/Source/App/EbAppProcessCmd.c
+++ b/Source/App/EbAppProcessCmd.c
@@ -1407,7 +1407,7 @@ APPEXITCONDITIONTYPE ProcessOutputStreamBuffer(
 
                     if (QueryDepthSList(&appCallBack->tmpEncodingList) && lastEntry && firstEntry) {
                         // firstEntry has been pushed to the last entry of tmpEncodingList.
-                        InterlockedPushListSListEx(&appCallBack->encodingList, lastEntry,
+                        InterlockedPushListSList(&appCallBack->encodingList, lastEntry,
                             firstEntry, QueryDepthSList(&appCallBack->tmpEncodingList));
                     }
                     break;

--- a/Source/Lib/Codec/EbEncHandle.c
+++ b/Source/Lib/Codec/EbEncHandle.c
@@ -1918,7 +1918,12 @@ void EbHevcSetParamBasedOnInput(
     sequenceControlSetPtr->lumaWidth    = sequenceControlSetPtr->maxInputLumaWidth;
     sequenceControlSetPtr->lumaHeight   = sequenceControlSetPtr->maxInputLumaHeight;
 
-    sequenceControlSetPtr->refInputFrame = EB_TRUE;
+    // Temporarily not to reference the input frames directly when sharpness improvement
+    // is enabled. Because some frames have been completedly encoded and returned to
+    // application to be unreferenced, but they may be still used to generate the
+    // reconstructed picture in EncDec.
+    sequenceControlSetPtr->refInputFrame =
+        !sequenceControlSetPtr->staticConfig.improveSharpness ? EB_TRUE : EB_FALSE;
 
     // Configure the padding
     if (sequenceControlSetPtr->refInputFrame) {

--- a/Source/Lib/Codec/EbEncHandle.c
+++ b/Source/Lib/Codec/EbEncHandle.c
@@ -3886,14 +3886,6 @@ EB_ERRORTYPE AllocateFrameBuffer(
         (EB_PTR)&inputPictureBufferDescInitData);
     inputBuffer->pBuffer = (uint8_t*)buf;
 
-    if (is16bit && config->compressedTenBitFormat == 1) {
-        const EB_COLOR_FORMAT colorFormat = (EB_COLOR_FORMAT)sequenceControlSetPtr->chromaFormatIdc;
-        //pack 4 2bit pixels into 1Byte
-        EB_MALLOC_ALIGNED_ARRAY(buf->bufferBitIncY, (inputPictureBufferDescInitData.maxWidth * inputPictureBufferDescInitData.maxHeight / 4));
-        EB_MALLOC_ALIGNED_ARRAY(buf->bufferBitIncCb, (inputPictureBufferDescInitData.maxWidth * inputPictureBufferDescInitData.maxHeight / 4) >> (3 - colorFormat));
-        EB_MALLOC_ALIGNED_ARRAY(buf->bufferBitIncCr, (inputPictureBufferDescInitData.maxWidth * inputPictureBufferDescInitData.maxHeight / 4) >> (3 - colorFormat));
-    }
-
     return return_error;
 }
 
@@ -3931,11 +3923,6 @@ void EbInputBufferHeaderDestroyer(EB_PTR p)
 {
     EB_BUFFERHEADERTYPE *obj = (EB_BUFFERHEADERTYPE*)p;
     EbPictureBufferDesc_t* buf = (EbPictureBufferDesc_t*)obj->pBuffer;
-    if (buf) {
-        EB_FREE_ALIGNED_ARRAY(buf->bufferBitIncY);
-        EB_FREE_ALIGNED_ARRAY(buf->bufferBitIncCb);
-        EB_FREE_ALIGNED_ARRAY(buf->bufferBitIncCr);
-    }
 
     EB_FREE_ARRAY(obj->segmentOvPtr);
     EB_DELETE(buf);

--- a/Source/Lib/Codec/EbEncHandle.c
+++ b/Source/Lib/Codec/EbEncHandle.c
@@ -1918,12 +1918,7 @@ void EbHevcSetParamBasedOnInput(
     sequenceControlSetPtr->lumaWidth    = sequenceControlSetPtr->maxInputLumaWidth;
     sequenceControlSetPtr->lumaHeight   = sequenceControlSetPtr->maxInputLumaHeight;
 
-    // Temporarily not to reference the input frames directly when sharpness improvement
-    // is enabled. Because some frames have been completedly encoded and returned to
-    // application to be unreferenced, but they may be still used to generate the
-    // reconstructed picture in EncDec.
-    sequenceControlSetPtr->refInputFrame =
-        !sequenceControlSetPtr->staticConfig.improveSharpness ? EB_TRUE : EB_FALSE;
+    sequenceControlSetPtr->refInputFrame = EB_TRUE;
 
     // Configure the padding
     if (sequenceControlSetPtr->refInputFrame) {

--- a/Source/Lib/Codec/EbModeDecision.c
+++ b/Source/Lib/Codec/EbModeDecision.c
@@ -83,7 +83,8 @@ void intraSearchTheseModesOutputBest(
     EB_U32   mode;
     EB_U32   bestSAD = 32 * 32 * 255;
     EB_U32	 sadCurr;
-
+    EB_U32   picWidth = ((SequenceControlSet_t *)pictureControlSetPtr->sequenceControlSetWrapperPtr->objectPtr)->lumaWidth;
+    EB_U32   picHeight = ((SequenceControlSet_t *)pictureControlSetPtr->sequenceControlSetWrapperPtr->objectPtr)->lumaHeight;
 
     for (candidateIndex = 0; candidateIndex < NumOfModesToTest; candidateIndex++) {
 
@@ -98,6 +99,8 @@ void intraSearchTheseModesOutputBest(
             mode);
 
         const EB_U32 puOriginIndex = (contextPtr->cuOriginY & 63) * 64 + (contextPtr->cuOriginX & 63);
+        EB_U32 cuWidth = MIN(cuSize, picWidth - contextPtr->cuOriginX);
+        EB_U32 cuHeight = MIN(cuSize, picHeight - contextPtr->cuOriginY);
 
         //Distortion
         sadCurr  = (EB_U32)NxMSadKernel_funcPtrArray[!!(ASM_TYPES & AVX2_MASK)][cuSize >> 3](
@@ -105,8 +108,8 @@ void intraSearchTheseModesOutputBest(
             srcStride,
             &(contextPtr->predictionBuffer->bufferY[puOriginIndex]),
             MAX_LCU_SIZE,
-            cuSize,
-            cuSize);
+            cuHeight,
+            cuWidth);
 
         //keep track of best SAD
         if (sadCurr < bestSAD) {

--- a/Source/Lib/Codec/EbMotionEstimationProcess.c
+++ b/Source/Lib/Codec/EbMotionEstimationProcess.c
@@ -219,10 +219,6 @@ static EB_ERRORTYPE ComputeDecimatedZzSad(
 			lcuOriginX = lcuParams->originX;
 			lcuOriginY = lcuParams->originY;
 
-			lcuWidth = lcuParams->width;
-			lcuHeight = lcuParams->height;
-
-
 			decimatedLcuWidth = lcuWidth >> 2;
 			decimatedLcuHeight = lcuHeight >> 2;
 
@@ -238,8 +234,8 @@ static EB_ERRORTYPE ComputeDecimatedZzSad(
 				Decimation2D(
 					&previousInputPictureFull->bufferY[blkDisplacementFull],
 					previousInputPictureFull->strideY,
-					MAX_LCU_SIZE,
-					MAX_LCU_SIZE,
+                    lcuWidth,
+                    lcuHeight,
 					contextPtr->meContextPtr->sixteenthLcuBuffer,
 					contextPtr->meContextPtr->sixteenthLcuBufferStride,
 					4);
@@ -250,7 +246,7 @@ static EB_ERRORTYPE ComputeDecimatedZzSad(
 					sixteenthDecimatedPicturePtr->strideY,
 					contextPtr->meContextPtr->sixteenthLcuBuffer,
 					contextPtr->meContextPtr->sixteenthLcuBufferStride,
-					16, 16);
+                    lcuHeight >> 2, lcuWidth >> 2);
 
 				// Background Enhancement Algorithm
 				// Classification is important to:
@@ -722,9 +718,8 @@ void* MotionEstimationKernel(void *inputPtr)
 
                     contextPtr->meContextPtr->hmeSearchType = HME_RECTANGULAR;
 
-                    for (lcuRow = 0; lcuRow < MAX_LCU_SIZE; lcuRow++) {
+                    for (lcuRow = 0; lcuRow < lcuHeight; lcuRow++) {
                         EB_MEMCPY((&(contextPtr->meContextPtr->lcuBuffer[lcuRow * MAX_LCU_SIZE])), (&(inputPicturePtr->bufferY[bufferIndex + lcuRow * inputPicturePtr->strideY])), MAX_LCU_SIZE * sizeof(EB_U8));
-
                     }
 
                     EB_U8 * srcPtr = &inputPaddedPicturePtr->bufferY[bufferIndex];

--- a/Source/Lib/Codec/EbPictureAnalysisProcess.c
+++ b/Source/Lib/Codec/EbPictureAnalysisProcess.c
@@ -4269,10 +4269,12 @@ void* PictureAnalysisKernel(void *inputPtr)
 		SetPictureParametersForStatisticsGathering(
 			sequenceControlSetPtr);
 
-		// Pad pictures to multiple min cu size
-		PadPictureToMultipleOfMinCuSizeDimensions(
-			sequenceControlSetPtr,
-			inputPicturePtr);
+        if (!sequenceControlSetPtr->lcuAligned) {
+            // Pad pictures to multiple min cu size
+            PadPictureToMultipleOfMinCuSizeDimensions(
+                    sequenceControlSetPtr,
+                    inputPicturePtr);
+        }
 
 		// Pre processing operations performed on the input picture
         PicturePreProcessingOperations(
@@ -4294,10 +4296,10 @@ void* PictureAnalysisKernel(void *inputPtr)
             pictureControlSetPtr->chromaDownSamplePicturePtr = inputPicturePtr;
         }
 
-		// Pad input picture to complete border LCUs
-		PadPictureToMultipleOfLcuDimensions(
-			inputPaddedPicturePtr
-        );
+        if (!sequenceControlSetPtr->lcuAligned) {
+            // Pad input picture to complete border LCUs
+            PadPictureToMultipleOfLcuDimensions(inputPaddedPicturePtr);
+        }
 
 		// 1/4 & 1/16 input picture decimation
 		DecimateInputPicture(

--- a/Source/Lib/Codec/EbPictureAnalysisProcess.c
+++ b/Source/Lib/Codec/EbPictureAnalysisProcess.c
@@ -4269,7 +4269,7 @@ void* PictureAnalysisKernel(void *inputPtr)
 		SetPictureParametersForStatisticsGathering(
 			sequenceControlSetPtr);
 
-        if (!sequenceControlSetPtr->lcuAligned) {
+        if (!sequenceControlSetPtr->refInputFrame) {
             // Pad pictures to multiple min cu size
             PadPictureToMultipleOfMinCuSizeDimensions(
                     sequenceControlSetPtr,
@@ -4296,7 +4296,7 @@ void* PictureAnalysisKernel(void *inputPtr)
             pictureControlSetPtr->chromaDownSamplePicturePtr = inputPicturePtr;
         }
 
-        if (!sequenceControlSetPtr->lcuAligned) {
+        if (!sequenceControlSetPtr->refInputFrame) {
             // Pad input picture to complete border LCUs
             PadPictureToMultipleOfLcuDimensions(inputPaddedPicturePtr);
         }

--- a/Source/Lib/Codec/EbPictureOperators.c
+++ b/Source/Lib/Codec/EbPictureOperators.c
@@ -275,6 +275,8 @@ EB_ERRORTYPE PictureFastDistortion(
     EB_U32                   predLumaOriginIndex,
     EB_U32                   predChromaOriginIndex,
     EB_U32                   size,
+    EB_U32                   puLumaWidth,
+    EB_U32                   puLumaHeight,
     EB_U32                   componentMask,
     EB_U64                   lumaDistortion[DIST_CALC_TOTAL],
     EB_U64                   chromaDistortion[DIST_CALC_TOTAL])
@@ -282,6 +284,8 @@ EB_ERRORTYPE PictureFastDistortion(
     EB_ERRORTYPE return_error = EB_ErrorNone;
 
     const EB_U32 chromaSize = size == 4 ? 4 : size >> 1;
+    const EB_U32 chromaLumaWidth = puLumaWidth == 4 ? 4 : puLumaWidth >> 1;
+    const EB_U32 chromaLumaHeight = puLumaHeight == 4 ? 4 : puLumaHeight >> 1;
 
     // Y
     if (componentMask & PICTURE_BUFFER_DESC_Y_FLAG) {
@@ -291,8 +295,8 @@ EB_ERRORTYPE PictureFastDistortion(
             input->strideY,
             &(pred->bufferY[predLumaOriginIndex]),
             64,
-            size,
-            size);
+            puLumaHeight,
+            puLumaWidth);
     }
 
     // Cb
@@ -303,8 +307,8 @@ EB_ERRORTYPE PictureFastDistortion(
             input->strideCb,
             &(pred->bufferCb[predChromaOriginIndex]),
             32,
-            chromaSize,
-            chromaSize);
+            chromaLumaHeight,
+            chromaLumaWidth);
     }
 
     // Cr
@@ -315,8 +319,8 @@ EB_ERRORTYPE PictureFastDistortion(
             input->strideCr,
             &(pred->bufferCr[predChromaOriginIndex]),
             32,
-            chromaSize,
-            chromaSize);
+            chromaLumaHeight,
+            chromaLumaWidth);
     }
 
     return return_error;

--- a/Source/Lib/Codec/EbPictureOperators.h
+++ b/Source/Lib/Codec/EbPictureOperators.h
@@ -60,6 +60,8 @@ extern EB_ERRORTYPE PictureFastDistortion(
     EB_U32                   predLumaOriginIndex,
     EB_U32                   predChromaOriginIndex,
     EB_U32                   size,
+    EB_U32                   puLumaWidth,
+    EB_U32                   puLumaHeight,
     EB_U32                   componentMask,
     EB_U64                   lumaDistortion[DIST_CALC_TOTAL],
     EB_U64                   chromaDistortion[DIST_CALC_TOTAL]);

--- a/Source/Lib/Codec/EbProductCodingLoop.c
+++ b/Source/Lib/Codec/EbProductCodingLoop.c
@@ -1935,6 +1935,9 @@ void ProductPerformFastLoop(
 	EB_U32							isCandzz = 0;
 	const EB_U32 cuDepth = contextPtr->cuStats->depth;
 	const EB_U32 cuSize = contextPtr->cuStats->size;
+    EB_U32 cuWidth = MIN(cuSize, (EB_U32)(inputPicturePtr->width - contextPtr->cuOriginX));
+    EB_U32 cuHeight = MIN(cuSize, (EB_U32)(inputPicturePtr->height - contextPtr->cuOriginY));
+
 	EB_U32 firstFastCandidateTotalCount;
 	// Initialize first fast cost loop variables
 	EB_U64 bestFirstFastCostSearchCandidateCost = 0xFFFFFFFFFFFFFFFFull;
@@ -2048,8 +2051,8 @@ void ProductPerformFastLoop(
 						inputStrideY,
 						predBufferY,
 						MAX_LCU_SIZE ,
-						cuSize,
-						cuSize));
+                        cuHeight,
+                        cuWidth));
 
                 // Cb
                 if (!!contextPtr->useChromaInformationInFastLoop)
@@ -2062,8 +2065,8 @@ void ProductPerformFastLoop(
 						inputPicturePtr->strideCb,
 						predBufferCb,
 						(MAX_LCU_SIZE >> 1) ,
-						(cuSize >> 1) ,
-						cuSize >> 1);
+						(cuHeight >> 1) ,
+                        cuWidth >> 1);
 
 
                     EB_U8 * const inputBufferCr = inputPicturePtr->bufferCr + inputCrOriginIndex;
@@ -2074,8 +2077,8 @@ void ProductPerformFastLoop(
                         inputPicturePtr->strideCb ,
                         predBufferCr,
                         (MAX_LCU_SIZE >> 1),
-                        (cuSize >> 1),
-                        cuSize >> 1) ;
+                        (cuHeight >> 1),
+                        cuWidth >> 1) ;
                 }
             }
             if (pictureControlSetPtr->ParentPcsPtr->cmplxStatusLcu[lcuAddr] == CMPLX_NOISE) {
@@ -2741,6 +2744,9 @@ EB_EXTERN EB_ERRORTYPE PerformIntra4x4Search(
         EB_U32 partitionOriginX = contextPtr->cuOriginX + INTRA_4x4_OFFSET_X[partitionIndex];
         EB_U32 partitionOriginY = contextPtr->cuOriginY + INTRA_4x4_OFFSET_Y[partitionIndex];
 
+        EB_U32 partitionWidth = MIN(MIN_PU_SIZE, inputPicturePtr->width - partitionOriginX);
+        EB_U32 partitionHeight = MIN(MIN_PU_SIZE, inputPicturePtr->height - partitionOriginY);
+
         inputOriginIndex = (partitionOriginY + inputPicturePtr->originY) * inputPicturePtr->strideY + (partitionOriginX + inputPicturePtr->originX);
         puOriginIndex = ((partitionOriginY & (MAX_LCU_SIZE - 1)) * MAX_LCU_SIZE) + (partitionOriginX & (MAX_LCU_SIZE - 1));
 
@@ -2860,6 +2866,8 @@ EB_EXTERN EB_ERRORTYPE PerformIntra4x4Search(
                         puOriginIndex,
                         puChromaOriginIndex,
                         MIN_PU_SIZE,
+                        partitionWidth,
+                        partitionHeight,
                         PICTURE_BUFFER_DESC_FULL_MASK,
                         &lumaFastDistortion,
                         &chromaFastDistortion);
@@ -2883,6 +2891,8 @@ EB_EXTERN EB_ERRORTYPE PerformIntra4x4Search(
                         puOriginIndex,
                         0,
                         MIN_PU_SIZE,
+                        partitionWidth,
+                        partitionHeight,
                         PICTURE_BUFFER_DESC_LUMA_MASK,
                         &lumaFastDistortion,
                         NULL);

--- a/Source/Lib/Codec/EbProductCodingLoop.c
+++ b/Source/Lib/Codec/EbProductCodingLoop.c
@@ -215,26 +215,91 @@ const EB_FULL_COST_FUNC   fullCostFuncTable[3][3] =
 	/*INTRA */{ IntraFullCostPslice, IntraFullCostPslice, IntraFullCostIslice },
 };
 
+static EB_ERRORTYPE PredictionOlVoidFunc(ModeDecisionContext_t *contextPtr,
+        EB_U32 componentMask,
+        PictureControlSet_t *pictureControlSetPtr,
+        ModeDecisionCandidateBuffer_t *candidateBufferPtr)
+{
+    (void)contextPtr;
+    (void)componentMask;
+    (void)pictureControlSetPtr;
+    (void)candidateBufferPtr;
+    return EB_ErrorNone;
+}
+
 const EB_PREDICTION_FUNC  PredictionFunTableOl[2][3] = {
 
-    { NULL, Inter2Nx2NPuPredictionInterpolationFree,    IntraPredictionOl },  //  Interpolation-free path
-    { NULL, Inter2Nx2NPuPredictionHevc,                 IntraPredictionOl }   //  HEVC Interpolation path
+    { PredictionOlVoidFunc, Inter2Nx2NPuPredictionInterpolationFree,    IntraPredictionOl },  //  Interpolation-free path
+    { PredictionOlVoidFunc, Inter2Nx2NPuPredictionHevc,                 IntraPredictionOl }   //  HEVC Interpolation path
 };
 
+static EB_ERRORTYPE PredictionClVoidFunc(ModeDecisionContext_t *contextPtr,
+        EB_U32 componentMask,
+        PictureControlSet_t *pictureControlSetPtr,
+        ModeDecisionCandidateBuffer_t *candidateBufferPtr)
+{
+    (void)contextPtr;
+    (void)componentMask;
+    (void)pictureControlSetPtr;
+    (void)candidateBufferPtr;
+    return EB_ErrorNone;
+}
+
 const EB_PREDICTION_FUNC  PredictionFunTableCl[2][3] = {
-    { NULL, Inter2Nx2NPuPredictionInterpolationFree ,   IntraPredictionCl }, //  Interpolation-free path
-    { NULL, Inter2Nx2NPuPredictionHevc,                 IntraPredictionCl }  //  HEVC Interpolation path
+    { PredictionClVoidFunc, Inter2Nx2NPuPredictionInterpolationFree ,   IntraPredictionCl }, //  Interpolation-free path
+    { PredictionClVoidFunc, Inter2Nx2NPuPredictionHevc,                 IntraPredictionCl }  //  HEVC Interpolation path
 };
+
+static EB_ERRORTYPE ProductFastCostVoidFunc(ModeDecisionContext_t *contextPtr,
+        CodingUnit_t *cuPtr,
+        ModeDecisionCandidateBuffer_t *candidateBufferPtr,
+        EB_U32 qp,
+        EB_U64 lumaDistortion,
+        EB_U64 chromaDistortion,
+        EB_U64 lambda,
+        PictureControlSet_t *pictureControlSetPtr)
+{
+    (void)contextPtr;
+    (void)cuPtr;
+    (void)candidateBufferPtr;
+    (void)qp;
+    (void)lumaDistortion;
+    (void)chromaDistortion;
+    (void)lambda;
+    (void)pictureControlSetPtr;
+    return EB_ErrorNone;
+}
 
 const EB_FAST_COST_FUNC   ProductFastCostFuncOptTable[3][3] =
 {
-	/*      */{ NULL, NULL, NULL },
+	/*      */{ ProductFastCostVoidFunc, ProductFastCostVoidFunc, ProductFastCostVoidFunc },
 	/*INTER */{ InterFastCostBsliceOpt, InterFastCostPsliceOpt, NULL },
 	/*INTRA */{ Intra2Nx2NFastCostPsliceOpt, Intra2Nx2NFastCostPsliceOpt, Intra2Nx2NFastCostIsliceOpt },
 };
+
+static EB_ERRORTYPE ProductFullLumaCostVoidFunc(CodingUnit_t *cuPtr,
+        EB_U32 cuSize,
+        EB_U32 cuSizeLog2,
+        ModeDecisionCandidateBuffer_t *candidateBufferPtr,
+        EB_U64 *yDistortion,
+        EB_U64 lambda,
+        EB_U64 *yCoeffBits,
+        EB_U32 transformSize)
+{
+    (void)cuPtr;
+    (void)cuSize;
+    (void)cuSizeLog2;
+    (void)candidateBufferPtr;
+    (void)yDistortion;
+    (void)lambda;
+    (void)yCoeffBits;
+    (void)transformSize;
+    return EB_ErrorNone;
+}
+
 const EB_FULL_LUMA_COST_FUNC   ProductFullLumaCostFuncTable[3][3] =
 {
-	/*      */{ NULL, NULL, NULL },
+	/*      */{ ProductFullLumaCostVoidFunc, ProductFullLumaCostVoidFunc, ProductFullLumaCostVoidFunc },
 	/*INTER */{ InterFullLumaCost, InterFullLumaCost, NULL },
 	/*INTRA */{ IntraFullLumaCostPslice, IntraFullLumaCostPslice, IntraFullLumaCostIslice },
 };

--- a/Source/Lib/Codec/EbSequenceControlSet.h
+++ b/Source/Lib/Codec/EbSequenceControlSet.h
@@ -57,7 +57,8 @@ typedef struct SequenceControlSet_s
     EB_U16                      topPadding;
     EB_U16                      rightPadding;
     EB_U16                      botPadding;
-    EB_BOOL                     lcuAligned;
+    // Reference the input frame, rather than memcpy.
+    EB_BOOL                     refInputFrame;
 
     EB_U32                      frameRate;  
     EB_U32                      encoderBitDepth;

--- a/Source/Lib/Codec/EbSequenceControlSet.h
+++ b/Source/Lib/Codec/EbSequenceControlSet.h
@@ -57,6 +57,7 @@ typedef struct SequenceControlSet_s
     EB_U16                      topPadding;
     EB_U16                      rightPadding;
     EB_U16                      botPadding;
+    EB_BOOL                     lcuAligned;
 
     EB_U32                      frameRate;  
     EB_U32                      encoderBitDepth;

--- a/ffmpeg_plugin/0001-lavc-svt_hevc-add-libsvt-hevc-encoder-wrapper.patch
+++ b/ffmpeg_plugin/0001-lavc-svt_hevc-add-libsvt-hevc-encoder-wrapper.patch
@@ -1,4 +1,4 @@
-From 886b8ad9766f0f95f264587d1dd00b2248d19910 Mon Sep 17 00:00:00 2001
+From 976b1d50de0b90e164d112808b11e24ca012852d Mon Sep 17 00:00:00 2001
 From: Jing Sun <jing.a.sun@intel.com>
 Date: Wed, 21 Nov 2018 11:33:04 +0800
 Subject: [PATCH] lavc/svt_hevc: add libsvt hevc encoder wrapper
@@ -80,7 +80,7 @@ index d2f9a39ce5..d8788a7954 100644
  extern AVCodec ff_libvo_amrwbenc_encoder;
 diff --git a/libavcodec/libsvt_hevc.c b/libavcodec/libsvt_hevc.c
 new file mode 100644
-index 0000000000..d2af410cde
+index 0000000000..d7ec22218e
 --- /dev/null
 +++ b/libavcodec/libsvt_hevc.c
 @@ -0,0 +1,659 @@
@@ -584,7 +584,7 @@ index 0000000000..d2af410cde
 +                if (QueryDepthSList(&svt_enc->tmp_input_frame_list) &&
 +                        last_entry && first_entry) {
 +                    // first_entry has been pushed to the last entry of tmp_input_frame_list.
-+                    InterlockedPushListSListEx(&svt_enc->input_frame_list, last_entry,
++                    InterlockedPushListSList(&svt_enc->input_frame_list, last_entry,
 +                            first_entry, QueryDepthSList(&svt_enc->input_frame_list));
 +                }
 +                break;

--- a/ffmpeg_plugin/0001-lavc-svt_hevc-add-libsvt-hevc-encoder-wrapper.patch
+++ b/ffmpeg_plugin/0001-lavc-svt_hevc-add-libsvt-hevc-encoder-wrapper.patch
@@ -1,4 +1,4 @@
-From 976b1d50de0b90e164d112808b11e24ca012852d Mon Sep 17 00:00:00 2001
+From 8cf640f0b955a0f02f74c9e859a48a7d0a99df46 Mon Sep 17 00:00:00 2001
 From: Jing Sun <jing.a.sun@intel.com>
 Date: Wed, 21 Nov 2018 11:33:04 +0800
 Subject: [PATCH] lavc/svt_hevc: add libsvt hevc encoder wrapper
@@ -14,8 +14,8 @@ Signed-off-by: Austin Hu <austin.hu@intel.com>
  configure                |   4 +
  libavcodec/Makefile      |   1 +
  libavcodec/allcodecs.c   |   1 +
- libavcodec/libsvt_hevc.c | 659 +++++++++++++++++++++++++++++++++++++++
- 4 files changed, 665 insertions(+)
+ libavcodec/libsvt_hevc.c | 654 +++++++++++++++++++++++++++++++++++++++
+ 4 files changed, 660 insertions(+)
  create mode 100644 libavcodec/libsvt_hevc.c
 
 diff --git a/configure b/configure
@@ -80,10 +80,10 @@ index d2f9a39ce5..d8788a7954 100644
  extern AVCodec ff_libvo_amrwbenc_encoder;
 diff --git a/libavcodec/libsvt_hevc.c b/libavcodec/libsvt_hevc.c
 new file mode 100644
-index 0000000000..d7ec22218e
+index 0000000000..e0a0e25bfb
 --- /dev/null
 +++ b/libavcodec/libsvt_hevc.c
-@@ -0,0 +1,659 @@
+@@ -0,0 +1,654 @@
 +/*
 +* Scalable Video Technology for HEVC encoder library plugin
 +*
@@ -501,8 +501,7 @@ index 0000000000..d7ec22218e
 +    int av_ret;
 +    input_frame_t *input_frame_entry = NULL;
 +#ifdef _WIN32
-+    SLIST_ENTRY *first_entry = NULL;
-+    SLIST_ENTRY *last_entry = NULL;
++    SLIST_ENTRY *tmp_entry = NULL;
 +#endif
 +
 +    if (EOS_RECEIVED == svt_enc->eos_flag) {
@@ -572,28 +571,24 @@ index 0000000000..d7ec22218e
 +#ifdef _WIN32
 +        // To check whether the list is empty or not, and remove the input buffer
 +        // which has been encoded from the encoding list.
-+        first_entry = InterlockedPopEntrySList(&svt_enc->input_frame_list);
-+        input_frame_entry = (input_frame_t *)first_entry;
-+
-+        while (input_frame_entry) {
++        while (input_frame_entry =
++                (input_frame_t *)InterlockedPopEntrySList(&svt_enc->input_frame_list)) {
 +            if (input_frame_entry->ref_frame->pts == pkt->pts) {
 +                // Unference the AVFrame oject which has been encoded completely.
 +                av_frame_unref(input_frame_entry->ref_frame);
 +                free(input_frame_entry);
 +
-+                if (QueryDepthSList(&svt_enc->tmp_input_frame_list) &&
-+                        last_entry && first_entry) {
-+                    // first_entry has been pushed to the last entry of tmp_input_frame_list.
-+                    InterlockedPushListSList(&svt_enc->input_frame_list, last_entry,
-+                            first_entry, QueryDepthSList(&svt_enc->input_frame_list));
++                // Restore the mismatched input buffers to input buffer list.
++                if (QueryDepthSList(&svt_enc->tmp_input_frame_list)) {
++                    while (tmp_entry = InterlockedPopEntrySList(&svt_enc->tmp_input_frame_list)) {
++                        InterlockedPushEntrySList(&svt_enc->input_frame_list, tmp_entry);
++                    }
 +                }
 +                break;
 +            }
 +
-+            last_entry = &input_frame_entry->list;
-+            InterlockedPushEntrySList(&svt_enc->tmp_input_frame_list, last_entry);
-+
-+            input_frame_entry = (input_frame_t *)InterlockedPopEntrySList(&svt_enc->input_frame_list);
++            // Save the mismatched input buffers.
++            InterlockedPushEntrySList(&svt_enc->tmp_input_frame_list, &input_frame_entry->list);
 +        }
 +
 +        InterlockedFlushSList(&svt_enc->tmp_input_frame_list);

--- a/ffmpeg_plugin/0001-lavc-svt_hevc-add-libsvt-hevc-encoder-wrapper.patch
+++ b/ffmpeg_plugin/0001-lavc-svt_hevc-add-libsvt-hevc-encoder-wrapper.patch
@@ -1,4 +1,4 @@
-From 8cf640f0b955a0f02f74c9e859a48a7d0a99df46 Mon Sep 17 00:00:00 2001
+From 09fa3c18fedb61ec8efe7622a9e15eeea350aaa1 Mon Sep 17 00:00:00 2001
 From: Jing Sun <jing.a.sun@intel.com>
 Date: Wed, 21 Nov 2018 11:33:04 +0800
 Subject: [PATCH] lavc/svt_hevc: add libsvt hevc encoder wrapper
@@ -80,7 +80,7 @@ index d2f9a39ce5..d8788a7954 100644
  extern AVCodec ff_libvo_amrwbenc_encoder;
 diff --git a/libavcodec/libsvt_hevc.c b/libavcodec/libsvt_hevc.c
 new file mode 100644
-index 0000000000..e0a0e25bfb
+index 0000000000..a3e0ccf21a
 --- /dev/null
 +++ b/libavcodec/libsvt_hevc.c
 @@ -0,0 +1,654 @@
@@ -571,8 +571,8 @@ index 0000000000..e0a0e25bfb
 +#ifdef _WIN32
 +        // To check whether the list is empty or not, and remove the input buffer
 +        // which has been encoded from the encoding list.
-+        while (input_frame_entry =
-+                (input_frame_t *)InterlockedPopEntrySList(&svt_enc->input_frame_list)) {
++        while ((input_frame_entry =
++                (input_frame_t *)InterlockedPopEntrySList(&svt_enc->input_frame_list)) != NULL) {
 +            if (input_frame_entry->ref_frame->pts == pkt->pts) {
 +                // Unference the AVFrame oject which has been encoded completely.
 +                av_frame_unref(input_frame_entry->ref_frame);
@@ -580,7 +580,7 @@ index 0000000000..e0a0e25bfb
 +
 +                // Restore the mismatched input buffers to input buffer list.
 +                if (QueryDepthSList(&svt_enc->tmp_input_frame_list)) {
-+                    while (tmp_entry = InterlockedPopEntrySList(&svt_enc->tmp_input_frame_list)) {
++                    while ((tmp_entry = InterlockedPopEntrySList(&svt_enc->tmp_input_frame_list)) != NULL) {
 +                        InterlockedPushEntrySList(&svt_enc->input_frame_list, tmp_entry);
 +                    }
 +                }

--- a/ffmpeg_plugin/0001-lavc-svt_hevc-add-libsvt-hevc-encoder-wrapper.patch
+++ b/ffmpeg_plugin/0001-lavc-svt_hevc-add-libsvt-hevc-encoder-wrapper.patch
@@ -1,4 +1,4 @@
-From b964c0cf3d21d2b1488a55921a81e5a71bd0fd20 Mon Sep 17 00:00:00 2001
+From 886b8ad9766f0f95f264587d1dd00b2248d19910 Mon Sep 17 00:00:00 2001
 From: Jing Sun <jing.a.sun@intel.com>
 Date: Wed, 21 Nov 2018 11:33:04 +0800
 Subject: [PATCH] lavc/svt_hevc: add libsvt hevc encoder wrapper
@@ -14,8 +14,8 @@ Signed-off-by: Austin Hu <austin.hu@intel.com>
  configure                |   4 +
  libavcodec/Makefile      |   1 +
  libavcodec/allcodecs.c   |   1 +
- libavcodec/libsvt_hevc.c | 603 +++++++++++++++++++++++++++++++++++++++
- 4 files changed, 609 insertions(+)
+ libavcodec/libsvt_hevc.c | 659 +++++++++++++++++++++++++++++++++++++++
+ 4 files changed, 665 insertions(+)
  create mode 100644 libavcodec/libsvt_hevc.c
 
 diff --git a/configure b/configure
@@ -80,10 +80,10 @@ index d2f9a39ce5..d8788a7954 100644
  extern AVCodec ff_libvo_amrwbenc_encoder;
 diff --git a/libavcodec/libsvt_hevc.c b/libavcodec/libsvt_hevc.c
 new file mode 100644
-index 0000000000..58172c5616
+index 0000000000..d2af410cde
 --- /dev/null
 +++ b/libavcodec/libsvt_hevc.c
-@@ -0,0 +1,603 @@
+@@ -0,0 +1,659 @@
 +/*
 +* Scalable Video Technology for HEVC encoder library plugin
 +*
@@ -116,7 +116,11 @@ index 0000000000..58172c5616
 +#include "avcodec.h"
 +
 +#include <stdbool.h>
++#ifdef _WIN32
++#include <windows.h>
++#else
 +#include <sys/queue.h>
++#endif
 +
 +typedef enum eos_status {
 +    EOS_NOT_REACHED = 0,
@@ -126,8 +130,12 @@ index 0000000000..58172c5616
 +
 +typedef struct input_frame_s
 +{
-+    AVFrame *ref_frame;
++#ifdef _WIN32
++    SLIST_ENTRY list;
++#else
 +    LIST_ENTRY(input_frame_s) list;
++#endif
++    AVFrame *ref_frame;
 +} input_frame_t;
 +
 +typedef struct SvtContext {
@@ -161,9 +169,14 @@ index 0000000000..58172c5616
 +    int tile_col_count;
 +    int tile_slice_mode;
 +
-+    // Manage the input frames with doubly linked list.
++    // Manage the input frames with linked list.
 +    // But it can be replace by other ways, such as hash table.
++#ifdef _WIN32
++    SLIST_HEADER input_frame_list;
++    SLIST_HEADER tmp_input_frame_list;
++#else
 +    LIST_HEAD(input_frame_list, input_frame_s) input_frame_list;
++#endif
 +    bool ref_frame;
 +} SvtContext;
 +
@@ -378,7 +391,11 @@ index 0000000000..58172c5616
 +
 +        // Record the input referenced frame, to unreference it after getting its
 +        // encoded packet.
++#ifdef _WIN32
++        InterlockedPushEntrySList(&svt_enc->input_frame_list, &input_frame->list);
++#else
 +        LIST_INSERT_HEAD(&svt_enc->input_frame_list, input_frame, list);
++#endif
 +    }
 +
 +    in_data->luma = frame->data[0];
@@ -456,7 +473,12 @@ index 0000000000..58172c5616
 +        goto failed_init_encoder;
 +    }
 +
++#ifdef _WIN32
++    InitializeSListHead(&svt_enc->input_frame_list);
++    InitializeSListHead(&svt_enc->tmp_input_frame_list);
++#else
 +    LIST_INIT(&svt_enc->input_frame_list);
++#endif
 +    svt_enc->ref_frame = true;
 +
 +    return 0;
@@ -478,6 +500,10 @@ index 0000000000..58172c5616
 +    EB_ERRORTYPE svt_ret;
 +    int av_ret;
 +    input_frame_t *input_frame_entry = NULL;
++#ifdef _WIN32
++    SLIST_ENTRY *first_entry = NULL;
++    SLIST_ENTRY *last_entry = NULL;
++#endif
 +
 +    if (EOS_RECEIVED == svt_enc->eos_flag) {
 +        *got_packet = 0;
@@ -543,6 +569,35 @@ index 0000000000..58172c5616
 +    EbH265ReleaseOutBuffer(&header_ptr);
 +
 +    if (svt_enc->ref_frame) {
++#ifdef _WIN32
++        // To check whether the list is empty or not, and remove the input buffer
++        // which has been encoded from the encoding list.
++        first_entry = InterlockedPopEntrySList(&svt_enc->input_frame_list);
++        input_frame_entry = (input_frame_t *)first_entry;
++
++        while (input_frame_entry) {
++            if (input_frame_entry->ref_frame->pts == pkt->pts) {
++                // Unference the AVFrame oject which has been encoded completely.
++                av_frame_unref(input_frame_entry->ref_frame);
++                free(input_frame_entry);
++
++                if (QueryDepthSList(&svt_enc->tmp_input_frame_list) &&
++                        last_entry && first_entry) {
++                    // first_entry has been pushed to the last entry of tmp_input_frame_list.
++                    InterlockedPushListSListEx(&svt_enc->input_frame_list, last_entry,
++                            first_entry, QueryDepthSList(&svt_enc->input_frame_list));
++                }
++                break;
++            }
++
++            last_entry = &input_frame_entry->list;
++            InterlockedPushEntrySList(&svt_enc->tmp_input_frame_list, last_entry);
++
++            input_frame_entry = (input_frame_t *)InterlockedPopEntrySList(&svt_enc->input_frame_list);
++        }
++
++        InterlockedFlushSList(&svt_enc->tmp_input_frame_list);
++#else
 +        LIST_FOREACH(input_frame_entry, &svt_enc->input_frame_list, list) {
 +            if (input_frame_entry->ref_frame->pts == pkt->pts) {
 +                // Unference the AVFrame oject which has been encoded completely.
@@ -553,6 +608,7 @@ index 0000000000..58172c5616
 +                break;
 +            }
 +        }
++#endif
 +    }
 +
 +    *got_packet = 1;

--- a/ffmpeg_plugin/0001-lavc-svt_hevc-add-libsvt-hevc-encoder-wrapper.patch
+++ b/ffmpeg_plugin/0001-lavc-svt_hevc-add-libsvt-hevc-encoder-wrapper.patch
@@ -1,4 +1,4 @@
-From 297c9a0309c8ba06f9f746d7685dceaef7c0b690 Mon Sep 17 00:00:00 2001
+From 30205a046f5b437ac70ffa67ebd3732dfc490285 Mon Sep 17 00:00:00 2001
 From: Jing Sun <jing.a.sun@intel.com>
 Date: Wed, 21 Nov 2018 11:33:04 +0800
 Subject: [PATCH] lavc/svt_hevc: add libsvt hevc encoder wrapper
@@ -9,19 +9,20 @@ Signed-off-by: Jun Zhao <jun.zhao@intel.com>
 Signed-off-by: Jing Sun <jing.a.sun@intel.com>
 Signed-off-by: Austin Hu <austin.hu@intel.com>
 Signed-off-by: Guo Jiansheng <jiansheng.guo@intel.com>
+Signed-off-by: Austin Hu <austin.hu@intel.com>
 ---
  configure                |   4 +
  libavcodec/Makefile      |   1 +
  libavcodec/allcodecs.c   |   1 +
- libavcodec/libsvt_hevc.c | 559 +++++++++++++++++++++++++++++++++++++++
- 4 files changed, 565 insertions(+)
+ libavcodec/libsvt_hevc.c | 606 +++++++++++++++++++++++++++++++++++++++
+ 4 files changed, 612 insertions(+)
  create mode 100644 libavcodec/libsvt_hevc.c
 
 diff --git a/configure b/configure
-index 09bda9b408..454cf65a90 100755
+index 34c2adb4a4..dc5f74f4a9 100755
 --- a/configure
 +++ b/configure
-@@ -267,6 +267,7 @@ External library support:
+@@ -264,6 +264,7 @@ External library support:
    --enable-libspeex        enable Speex de/encoding via libspeex [no]
    --enable-libsrt          enable Haivision SRT protocol via libsrt [no]
    --enable-libssh          enable SFTP protocol via libssh [no]
@@ -29,7 +30,7 @@ index 09bda9b408..454cf65a90 100755
    --enable-libtensorflow   enable TensorFlow as a DNN module backend
                             for DNN based filters like sr [no]
    --enable-libtesseract    enable Tesseract, needed for ocr filter [no]
-@@ -1801,6 +1802,7 @@ EXTERNAL_LIBRARY_LIST="
+@@ -1793,6 +1794,7 @@ EXTERNAL_LIBRARY_LIST="
      libspeex
      libsrt
      libssh
@@ -37,7 +38,7 @@ index 09bda9b408..454cf65a90 100755
      libtensorflow
      libtesseract
      libtheora
-@@ -3229,6 +3231,7 @@ libshine_encoder_select="audio_frame_queue"
+@@ -3191,6 +3193,7 @@ libshine_encoder_select="audio_frame_queue"
  libspeex_decoder_deps="libspeex"
  libspeex_encoder_deps="libspeex"
  libspeex_encoder_select="audio_frame_queue"
@@ -45,7 +46,7 @@ index 09bda9b408..454cf65a90 100755
  libtheora_encoder_deps="libtheora"
  libtwolame_encoder_deps="libtwolame"
  libvo_amrwbenc_encoder_deps="libvo_amrwbenc"
-@@ -6344,6 +6347,7 @@ enabled libsoxr           && require libsoxr soxr.h soxr_create -lsoxr
+@@ -6263,6 +6266,7 @@ enabled libsoxr           && require libsoxr soxr.h soxr_create -lsoxr
  enabled libssh            && require_pkg_config libssh libssh libssh/sftp.h sftp_init
  enabled libspeex          && require_pkg_config libspeex speex speex/speex.h speex_decoder_init
  enabled libsrt            && require_pkg_config libsrt "srt >= 1.3.0" srt/srt.h srt_socket
@@ -54,10 +55,10 @@ index 09bda9b408..454cf65a90 100755
  enabled libtesseract      && require_pkg_config libtesseract tesseract tesseract/capi.h TessBaseAPICreate
  enabled libtheora         && require libtheora theora/theoraenc.h th_info_init -ltheoraenc -ltheoradec -logg
 diff --git a/libavcodec/Makefile b/libavcodec/Makefile
-index c1c9a44f2b..dd9b930b9b 100644
+index 3cd73fbcc6..d39f568585 100644
 --- a/libavcodec/Makefile
 +++ b/libavcodec/Makefile
-@@ -1008,6 +1008,7 @@ OBJS-$(CONFIG_LIBRAV1E_ENCODER)           += librav1e.o
+@@ -991,6 +991,7 @@ OBJS-$(CONFIG_LIBOPUS_ENCODER)            += libopusenc.o libopus.o     \
  OBJS-$(CONFIG_LIBSHINE_ENCODER)           += libshine.o
  OBJS-$(CONFIG_LIBSPEEX_DECODER)           += libspeexdec.o
  OBJS-$(CONFIG_LIBSPEEX_ENCODER)           += libspeexenc.o
@@ -66,10 +67,10 @@ index c1c9a44f2b..dd9b930b9b 100644
  OBJS-$(CONFIG_LIBTWOLAME_ENCODER)         += libtwolame.o
  OBJS-$(CONFIG_LIBVO_AMRWBENC_ENCODER)     += libvo-amrwbenc.o
 diff --git a/libavcodec/allcodecs.c b/libavcodec/allcodecs.c
-index b3184af954..41994e31b3 100644
+index d2f9a39ce5..d8788a7954 100644
 --- a/libavcodec/allcodecs.c
 +++ b/libavcodec/allcodecs.c
-@@ -720,6 +720,7 @@ extern AVCodec ff_librsvg_decoder;
+@@ -707,6 +707,7 @@ extern AVCodec ff_librsvg_decoder;
  extern AVCodec ff_libshine_encoder;
  extern AVCodec ff_libspeex_encoder;
  extern AVCodec ff_libspeex_decoder;
@@ -79,10 +80,10 @@ index b3184af954..41994e31b3 100644
  extern AVCodec ff_libvo_amrwbenc_encoder;
 diff --git a/libavcodec/libsvt_hevc.c b/libavcodec/libsvt_hevc.c
 new file mode 100644
-index 0000000000..fce27a06ea
+index 0000000000..b63b307aad
 --- /dev/null
 +++ b/libavcodec/libsvt_hevc.c
-@@ -0,0 +1,559 @@
+@@ -0,0 +1,606 @@
 +/*
 +* Scalable Video Technology for HEVC encoder library plugin
 +*
@@ -114,11 +115,22 @@ index 0000000000..fce27a06ea
 +#include "internal.h"
 +#include "avcodec.h"
 +
++#include <stdbool.h>
++#include <sys/queue.h>
++
++#define HEVC_LCU_SIZE 64
++
 +typedef enum eos_status {
 +    EOS_NOT_REACHED = 0,
 +    EOS_SENT,
 +    EOS_RECEIVED
 +}EOS_STATUS;
++
++typedef struct input_frame_s
++{
++    AVFrame *ref_frame;
++    LIST_ENTRY(input_frame_s) list;
++} input_frame_t;
 +
 +typedef struct SvtContext {
 +    AVClass *class;
@@ -150,6 +162,11 @@ index 0000000000..fce27a06ea
 +    int tile_row_count;
 +    int tile_col_count;
 +    int tile_slice_mode;
++
++    // Manage the input frames with doubly linked list.
++    // But it can be replace by other ways, such as hash table.
++    LIST_HEAD(input_frame_list, input_frame_s) input_frame_list;
++    bool lcu_aligned;
 +} SvtContext;
 +
 +static int error_mapping(EB_ERRORTYPE svt_ret)
@@ -343,16 +360,28 @@ index 0000000000..fce27a06ea
 +    return EB_ErrorNone;
 +}
 +
-+static void read_in_data(EB_H265_ENC_CONFIGURATION *config,
-+                         const AVFrame *frame,
-+                         EB_BUFFERHEADERTYPE *header_ptr)
++static void read_in_data(SvtContext *svt_enc, const AVFrame *frame,
++        EB_BUFFERHEADERTYPE *header_ptr)
 +{
 +    uint8_t is16bit;
 +    uint64_t frame_size;
 +    EB_H265_ENC_INPUT *in_data = (EB_H265_ENC_INPUT *)header_ptr->pBuffer;
++    EB_H265_ENC_CONFIGURATION *config = &svt_enc->enc_params;
++    input_frame_t *input_frame = NULL;
 +
 +    is16bit = config->encoderBitDepth > 8;
 +    frame_size = (uint64_t)(config->sourceWidth * config->sourceHeight) << is16bit;
++
++    if (svt_enc->lcu_aligned) {
++        input_frame = (input_frame_t *)malloc(sizeof(*input_frame));
++
++        // Keep the inpt frame referenced, rather than copying it inside encoder.
++        input_frame->ref_frame = av_frame_clone(frame);
++
++        // Record the input referenced frame, to unreference it after getting its
++        // encoded packet.
++        LIST_INSERT_HEAD(&svt_enc->input_frame_list, input_frame, list);
++    }
 +
 +    in_data->luma = frame->data[0];
 +    in_data->cb = frame->data[1];
@@ -428,6 +457,11 @@ index 0000000000..fce27a06ea
 +        av_log(avctx, AV_LOG_ERROR, "Failed to alloc data buffer\n");
 +        goto failed_init_encoder;
 +    }
++
++    LIST_INIT(&svt_enc->input_frame_list);
++    if (!(avctx->width % HEVC_LCU_SIZE) && !(avctx->height % HEVC_LCU_SIZE))
++        svt_enc->lcu_aligned = true;
++
 +    return 0;
 +
 +failed_init_encoder:
@@ -446,6 +480,7 @@ index 0000000000..fce27a06ea
 +    EB_BUFFERHEADERTYPE *header_ptr = &svt_enc->in_buf;
 +    EB_ERRORTYPE svt_ret;
 +    int av_ret;
++    input_frame_t *input_frame_entry = NULL;
 +
 +    if (EOS_RECEIVED == svt_enc->eos_flag) {
 +        *got_packet = 0;
@@ -467,7 +502,7 @@ index 0000000000..fce27a06ea
 +            av_log(avctx, AV_LOG_DEBUG, "Sent EOS\n");
 +        }
 +    } else {
-+        read_in_data(&svt_enc->enc_params, frame, header_ptr);
++        read_in_data(svt_enc, frame, header_ptr);
 +        header_ptr->pts = frame->pts;
 +
 +        EbH265EncSendPicture(svt_enc->svt_handle, header_ptr);
@@ -509,6 +544,19 @@ index 0000000000..fce27a06ea
 +        pkt->flags |= AV_PKT_FLAG_DISPOSABLE;
 +
 +    EbH265ReleaseOutBuffer(&header_ptr);
++
++    if (svt_enc->lcu_aligned) {
++        LIST_FOREACH(input_frame_entry, &svt_enc->input_frame_list, list) {
++            if (input_frame_entry->ref_frame->pts == pkt->pts) {
++                // Unference the AVFrame oject which has been encoded completely.
++                av_frame_unref(input_frame_entry->ref_frame);
++
++                LIST_REMOVE(input_frame_entry, list);
++                free(input_frame_entry);
++                break;
++            }
++        }
++    }
 +
 +    *got_packet = 1;
 +

--- a/ffmpeg_plugin/0001-lavc-svt_hevc-add-libsvt-hevc-encoder-wrapper.patch
+++ b/ffmpeg_plugin/0001-lavc-svt_hevc-add-libsvt-hevc-encoder-wrapper.patch
@@ -1,4 +1,4 @@
-From 30205a046f5b437ac70ffa67ebd3732dfc490285 Mon Sep 17 00:00:00 2001
+From b964c0cf3d21d2b1488a55921a81e5a71bd0fd20 Mon Sep 17 00:00:00 2001
 From: Jing Sun <jing.a.sun@intel.com>
 Date: Wed, 21 Nov 2018 11:33:04 +0800
 Subject: [PATCH] lavc/svt_hevc: add libsvt hevc encoder wrapper
@@ -14,8 +14,8 @@ Signed-off-by: Austin Hu <austin.hu@intel.com>
  configure                |   4 +
  libavcodec/Makefile      |   1 +
  libavcodec/allcodecs.c   |   1 +
- libavcodec/libsvt_hevc.c | 606 +++++++++++++++++++++++++++++++++++++++
- 4 files changed, 612 insertions(+)
+ libavcodec/libsvt_hevc.c | 603 +++++++++++++++++++++++++++++++++++++++
+ 4 files changed, 609 insertions(+)
  create mode 100644 libavcodec/libsvt_hevc.c
 
 diff --git a/configure b/configure
@@ -80,10 +80,10 @@ index d2f9a39ce5..d8788a7954 100644
  extern AVCodec ff_libvo_amrwbenc_encoder;
 diff --git a/libavcodec/libsvt_hevc.c b/libavcodec/libsvt_hevc.c
 new file mode 100644
-index 0000000000..b63b307aad
+index 0000000000..58172c5616
 --- /dev/null
 +++ b/libavcodec/libsvt_hevc.c
-@@ -0,0 +1,606 @@
+@@ -0,0 +1,603 @@
 +/*
 +* Scalable Video Technology for HEVC encoder library plugin
 +*
@@ -117,8 +117,6 @@ index 0000000000..b63b307aad
 +
 +#include <stdbool.h>
 +#include <sys/queue.h>
-+
-+#define HEVC_LCU_SIZE 64
 +
 +typedef enum eos_status {
 +    EOS_NOT_REACHED = 0,
@@ -166,7 +164,7 @@ index 0000000000..b63b307aad
 +    // Manage the input frames with doubly linked list.
 +    // But it can be replace by other ways, such as hash table.
 +    LIST_HEAD(input_frame_list, input_frame_s) input_frame_list;
-+    bool lcu_aligned;
++    bool ref_frame;
 +} SvtContext;
 +
 +static int error_mapping(EB_ERRORTYPE svt_ret)
@@ -372,7 +370,7 @@ index 0000000000..b63b307aad
 +    is16bit = config->encoderBitDepth > 8;
 +    frame_size = (uint64_t)(config->sourceWidth * config->sourceHeight) << is16bit;
 +
-+    if (svt_enc->lcu_aligned) {
++    if (svt_enc->ref_frame) {
 +        input_frame = (input_frame_t *)malloc(sizeof(*input_frame));
 +
 +        // Keep the inpt frame referenced, rather than copying it inside encoder.
@@ -459,8 +457,7 @@ index 0000000000..b63b307aad
 +    }
 +
 +    LIST_INIT(&svt_enc->input_frame_list);
-+    if (!(avctx->width % HEVC_LCU_SIZE) && !(avctx->height % HEVC_LCU_SIZE))
-+        svt_enc->lcu_aligned = true;
++    svt_enc->ref_frame = true;
 +
 +    return 0;
 +
@@ -545,7 +542,7 @@ index 0000000000..b63b307aad
 +
 +    EbH265ReleaseOutBuffer(&header_ptr);
 +
-+    if (svt_enc->lcu_aligned) {
++    if (svt_enc->ref_frame) {
 +        LIST_FOREACH(input_frame_entry, &svt_enc->input_frame_list, list) {
 +            if (input_frame_entry->ref_frame->pts == pkt->pts) {
 +                // Unference the AVFrame oject which has been encoded completely.

--- a/gstreamer-plugin/gstsvthevcenc.h
+++ b/gstreamer-plugin/gstsvthevcenc.h
@@ -12,6 +12,12 @@
 
 #include <EbApi.h>
 
+#ifdef _WIN32
+#include <windows.h>
+#else
+#include <sys/queue.h>
+#endif
+
 G_BEGIN_DECLS
 #define GST_TYPE_SVTHEVCENC \
   (gst_svthevcenc_get_type())
@@ -58,6 +64,16 @@ typedef enum
   GST_SVTHEVC_ENC_PRED_STRUCT_RANDOM_ACCESS,
 } GstSvtHevcEncPredStruct;
 
+typedef struct _GstInputFrame
+{
+#ifdef _WIN32
+    SLIST_ENTRY list;
+#else
+    LIST_ENTRY(_GstInputFrame) list;
+#endif
+    GstVideoCodecFrame *ref_frame;
+} GstInputFrame;
+
 typedef struct _GstSvtHevcEnc
 {
   GstVideoEncoder video_encoder;
@@ -81,6 +97,19 @@ typedef struct _GstSvtHevcEnc
   int dts_offset;
   const gchar *svt_version;
   gboolean inited;
+
+  /*
+   * Manage the input frames with linked list.
+   * But it can be replace by other ways, such
+   * as hash table.
+   */
+#ifdef _WIN32
+  SLIST_HEADER input_frame_list;
+  SLIST_HEADER tmp_input_frame_list;
+#else
+  LIST_HEAD(input_frame_list, _GstInputFrame) input_frame_list;
+#endif
+  gboolean ref_frame;
 } GstSvtHevcEnc;
 
 typedef struct _GstSvtHevcEncClass


### PR DESCRIPTION
By replacing memcpy in EbH265EncSendPicture, with direct assigning the
pointers of Input FIFO object with the ones of the EB_H265_ENC_INPUT
object YUV buffers, which should be safe (loked) by application.

The buffers belonging to an Input FIFO object don't need to be padded,
because they're just used as source sample data in PictureAnalysis,
MotionEstimation and EncDec (sharpness enabled) kernels.

Note: width and height of input frames are required to be aligned with 8
samples by de-blocking filter. So the solution applies for almost all typical
resolutions.

ffmpeg & GStreamer SVT-HEVC plugin: references the input AVFrame objects, and
manages the input referenced frames with linked list.

Signed-off-by: Austin Hu <austin.hu@intel.com>