### PR TITLE
App/EbAppContext.c: Remove unused AllocateOutputBuffers

### DIFF
--- a/Source/App/EbAppContext.c
+++ b/Source/App/EbAppContext.c
@@ -416,28 +416,6 @@ EB_ERRORTYPE AllocateOutputReconBuffers(
     return return_error;
 }
 
-EB_ERRORTYPE AllocateOutputBuffers(
-    EbConfig_t				*config,
-    EbAppContext_t			*callbackData)
-{
-
-    EB_ERRORTYPE   return_error = EB_ErrorNone;
-    uint32_t		   outputStreamBufferSize = (uint32_t)(EB_OUTPUTSTREAMBUFFERSIZE_MACRO(config->inputPaddedHeight * config->inputPaddedWidth));;
-    {
-        EB_APP_MALLOC(EB_BUFFERHEADERTYPE*, callbackData->streamBufferPool, sizeof(EB_BUFFERHEADERTYPE), EB_N_PTR, EB_ErrorInsufficientResources);
-
-        // Initialize Header
-        callbackData->streamBufferPool->nSize = sizeof(EB_BUFFERHEADERTYPE);
-
-        EB_APP_MALLOC(uint8_t*, callbackData->streamBufferPool->pBuffer, outputStreamBufferSize, EB_N_PTR, EB_ErrorInsufficientResources);
-
-        callbackData->streamBufferPool->nAllocLen = outputStreamBufferSize;
-        callbackData->streamBufferPool->pAppPrivate = NULL;
-        callbackData->streamBufferPool->sliceType = EB_INVALID_PICTURE;
-    }
-    return return_error;
-}
-
 EB_ERRORTYPE PreloadFramesIntoRam(
     EbConfig_t				*config)
 {
@@ -667,16 +645,7 @@ EB_ERRORTYPE InitEncoder(
         return return_error;
     }
 
-    // STEP 7: Allocate output buffers carrying the bitstream out
-    return_error = AllocateOutputBuffers(
-        config,
-        callbackData);
-
-    if (return_error != EB_ErrorNone) {
-        return return_error;
-    }
-
-    // STEP 8: Allocate output Recon Buffer
+    // STEP 7: Allocate output Recon Buffer
     return_error = AllocateOutputReconBuffers(
         config,
         callbackData);

--- a/Source/App/EbAppContext.h
+++ b/Source/App/EbAppContext.h
@@ -27,7 +27,6 @@ typedef struct EbAppContext_s {
 
     // Buffer Pools
     EB_BUFFERHEADERTYPE                *inputBufferPool;
-    EB_BUFFERHEADERTYPE                *streamBufferPool;
     EB_BUFFERHEADERTYPE                *reconBuffer;
 
 	// Instance Index


### PR DESCRIPTION
Since nothing is using the `streamBufferPool`, it would be better to remove it for now

Matching SVT-AV1 PR: https://github.com/OpenVisualCloud/SVT-AV1/pull/1209