### PR TITLE
Update the Y sample buffer indexing for position A in Motion Estimation.

### DIFF
--- a/Source/Lib/Codec/EbMotionEstimation.c
+++ b/Source/Lib/Codec/EbMotionEstimation.c
@@ -3429,6 +3429,8 @@ static void TestSearchAreaBounds(
         ySearchCenter - ((originY + ySearchCenter) - ((EB_S16)refPicPtr->height - 1)) :
         ySearchCenter;
 
+    searchRegionIndex = (EB_S16)(refPicPtr->originX + originX) + xSearchCenter +
+        ((EB_S16)(refPicPtr->originY + originY) + ySearchCenter) * refPicPtr->strideY;
 
     EB_U64 MvASad = NxMSadKernel_funcPtrArray[!!(ASM_TYPES & AVX2_MASK)][lcuWidth >> 3](
         contextPtr->lcuSrcPtr,


### PR DESCRIPTION
NxM SAD is calculated between the current LCU buffer and its corresponding
reference one in reconstructed picture for O/A/B/C/D positions.

Note: the same change should be also applied in hme_mv_center_check()
      of SVT-AV1.

Signed-off-by: Austin Hu <austin.hu@intel.com>