### PR TITLE
Adjust PAREF_OUT

### DIFF
--- a/Source/Lib/Codec/EbDefinitions.h
+++ b/Source/Lib/Codec/EbDefinitions.h
@@ -11,8 +11,6 @@
 extern "C" {
 #endif
 
-#define PAREF_OUT 1 // Disconnect pa ref  from input for both single/multi core
-
 //#define BENCHMARK 0
 #define LATENCY_PROFILE 0
 //#define DEBUG_LIFE_CYCLE 0

--- a/Source/Lib/Codec/EbEncHandle.c
+++ b/Source/Lib/Codec/EbEncHandle.c
@@ -883,11 +883,8 @@ EB_API EB_ERRORTYPE EbInitEncoder(EB_COMPONENTTYPE *h265EncComponent)
         referencePictureBufferDescInitData.maxHeight              = encHandlePtr->sequenceControlSetInstanceArray[instanceIndex]->sequenceControlSetPtr->maxInputLumaHeight;
         referencePictureBufferDescInitData.bitDepth               = encHandlePtr->sequenceControlSetInstanceArray[instanceIndex]->sequenceControlSetPtr->inputBitdepth;
         referencePictureBufferDescInitData.colorFormat            = EB_YUV420;
-#if PAREF_OUT
         referencePictureBufferDescInitData.bufferEnableMask       = PICTURE_BUFFER_DESC_LUMA_MASK;
-#else
-        referencePictureBufferDescInitData.bufferEnableMask       = 0;
-#endif
+
         referencePictureBufferDescInitData.leftPadding            = encHandlePtr->sequenceControlSetInstanceArray[instanceIndex]->sequenceControlSetPtr->lcuSize + ME_FILTER_TAP;
         referencePictureBufferDescInitData.rightPadding           = encHandlePtr->sequenceControlSetInstanceArray[instanceIndex]->sequenceControlSetPtr->lcuSize + ME_FILTER_TAP;
         referencePictureBufferDescInitData.topPadding             = encHandlePtr->sequenceControlSetInstanceArray[instanceIndex]->sequenceControlSetPtr->lcuSize + ME_FILTER_TAP;

--- a/Source/Lib/Codec/EbPictureAnalysisProcess.c
+++ b/Source/Lib/Codec/EbPictureAnalysisProcess.c
@@ -4254,7 +4254,11 @@ void* PictureAnalysisKernel(void *inputPtr)
 		pictureHeighInLcu = (sequenceControlSetPtr->lumaHeight + sequenceControlSetPtr->lcuSize - 1) / sequenceControlSetPtr->lcuSize;
 		lcuTotalCount = pictureWidthInLcu * pictureHeighInLcu;
 
-#if PAREF_OUT
+		// Pad pictures to multiple min cu size
+		PadPictureToMultipleOfMinCuSizeDimensions(
+			sequenceControlSetPtr,
+			inputPicturePtr);
+
         // Backup the Y component data from input picture into PA reference picture, to work arond the race condition that
         // the input picture buffer pointed by PA reference picture (in ResourceCoordination) would be updated even though
         // it's still being referenced.
@@ -4263,16 +4267,11 @@ void* PictureAnalysisKernel(void *inputPtr)
         for (EB_U32 row = 0; row < inputPicturePtr->height; row++) {
             EB_MEMCPY(pa + row * inputPaddedPicturePtr->strideY, in + row * inputPicturePtr->strideY, sizeof(EB_U8) * inputPicturePtr->width);
         }
-#endif
 
         // Set picture parameters to account for subpicture, picture scantype, and set regions by resolutions
 		SetPictureParametersForStatisticsGathering(
 			sequenceControlSetPtr);
 
-		// Pad pictures to multiple min cu size
-		PadPictureToMultipleOfMinCuSizeDimensions(
-			sequenceControlSetPtr,
-			inputPicturePtr);
 
 		// Pre processing operations performed on the input picture
         PicturePreProcessingOperations(

--- a/Source/Lib/Codec/EbResourceCoordinationProcess.c
+++ b/Source/Lib/Codec/EbResourceCoordinationProcess.c
@@ -615,10 +615,6 @@ void* ResourceCoordinationKernel(void *inputPtr)
                 pictureControlSetWrapperPtr,
                 1);
 
-#if !PAREF_OUT
-        ((EbPaReferenceObject_t*)pictureControlSetPtr->paReferencePictureWrapperPtr->objectPtr)->inputPaddedPicturePtr->bufferY = inputPicturePtr->bufferY;
-#endif
-
         // Get Empty Output Results Object
         // Note: record the PCS object into output of the Resource Coordination process for EOS frame(s).
         //       Because EbH265GetPacket() can get the encoded bit stream only if Packetization process has


### PR DESCRIPTION
Adjusted the PAREF_OUT PR 455
+ Moved the padding of the input picture prior to the copying of the
picture to the picture analysis reference picture
+ Removed the PAREF_OUT #define

Testing has shown this will fix the SVT defield test cases which
were failing because the field dimensions were not a multiple of 8.

Signed-off-by: Mark Feldman <mark.feldman@intel.com>