### PR TITLE
Uninitialized memory fix

### DIFF
--- a/Source/App/EbAppConfig.c
+++ b/Source/App/EbAppConfig.c
@@ -1227,6 +1227,7 @@ EB_ERRORTYPE ReadCommandLine(
 
     for (index = 0; index < MAX_CHANNEL_NUMBER; ++index){
         config_strings[index] = (char*)malloc(sizeof(char)*COMMAND_LINE_MAX_SIZE);
+        memset(config_strings[index], 0, sizeof(char)*COMMAND_LINE_MAX_SIZE);
     }
 
     // Copy tokens (except for CHANNEL_NUMBER_TOKEN ) into a temp token buffer hosting all tokens that are passed through the command line


### PR DESCRIPTION
Fixing an issue reported by running the memory sanitizer on Linux.
Initializing memory allocated for processing the command lines.

Signed-off-by: Mark Feldman <mark.feldman@intel.com>