### PR TITLE
Fix -level 0 error checking

### DIFF
--- a/Source/Lib/Codec/EbEncHandle.c
+++ b/Source/Lib/Codec/EbEncHandle.c
@@ -2134,7 +2134,7 @@ static EB_ERRORTYPE VerifySettings(\
 	}
 
 	// For levels below level 4 (exclusive), only the main tier is allowed
-    if(config->level < 40 && config->tier != 0){
+    if(config->level > 0 && config->level < 40 && config->tier != 0) {
         SVT_LOG("SVT [Error]: Instance %u: For levels below level 4 (exclusive), only the main tier is allowed\n",channelNumber+1);
         return_error = EB_ErrorBadParameter;
     }
@@ -2383,7 +2383,7 @@ static EB_ERRORTYPE VerifySettings(\
         return_error = EB_ErrorBadParameter;
     }
 
-    if (levelIdx < 13) {
+    if (levelIdx < TOTAL_LEVEL_COUNT) {
     // Check if the current input video is conformant with the Level constraint
     if(config->level != 0 && (((EB_U64)sequenceControlSetPtr->maxInputLumaWidth * (EB_U64)sequenceControlSetPtr->maxInputLumaHeight) > maxLumaPictureSize[levelIdx])){
         SVT_LOG("SVT [Error]: Instance %u: The input luma picture size exceeds the maximum luma picture size allowed for level %s\n",channelNumber+1, levelIdc);


### PR DESCRIPTION
Level 0 is auto level decided by encoder, should not be blocked by level/tier error checking.

Signed-off-by: Jun Tian <jun.tian@intel.com>

# Description
Level 0 is auto level decided by encoder, should not be blocked by level/tier error checking.

# Issue
Fixes #553 
<!--
Mention if the PR fixes or address an issue in this section
https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
Example
Fixes #999
If this PR involves fixing a bug that does not already have an issue created for it, please create an issue with sufficient info to reproduce the problem. Make sure to cross reference that issue within this PR.
--->

# Author(s)
@tianjunwork 

# Performance impact
<!--
Type an x in the box that is relevant to your PR. Make sure to mention how it is relevant in the description section.
Example
- [x] memory
--->
- [ ] quality
- [ ] memory
- [ ] speed
- [ ] 8 bit
- [ ] 10 bit
- [x] N/A

# Merge method
- [x] Allow the maintainer to squash and merge when PR is ready to create a 1-commit to the master branch. The maintainer will be able to fix typos / combine commit messages to create a more readable 1-commit message or use whatever is stated in the 'Description' section
- [ ] I will clean up my commits and the maintainer shall use 'rebase and merge' to the master branch
