### PR TITLE
Expand the precision of bitrate in log print

### DIFF
--- a/Source/App/EbAppMain.c
+++ b/Source/App/EbAppMain.c
@@ -252,11 +252,11 @@ int32_t main(int32_t argc, char* argv[])
                         else {
                             printf("Total Frames\t\tFrame Rate\t\tByte Count\t\tBitrate\n");
                         }
-                        printf("%12d\t\t%4.2f fps\t\t%10.0f\t\t%5.2f kbps\n",
-                            (int32_t)configs[instanceCount]->performanceContext.frameCount,
-                            (double)frameRate,
-                            (double)configs[instanceCount]->performanceContext.byteCount,
-                            ((double)(configs[instanceCount]->performanceContext.byteCount << 3) * frameRate / (configs[instanceCount]->framesEncoded * 1000)));
+                        printf("%12llu\t\t%4.2f fps\t\t%10llu\t\t%5.2f kbps\n",
+                            configs[instanceCount]->performanceContext.frameCount,
+                            frameRate,
+                            configs[instanceCount]->performanceContext.byteCount,
+                            (double)(configs[instanceCount]->performanceContext.byteCount << 3) * frameRate / (configs[instanceCount]->framesEncoded * 1000ULL));
                         fflush(stdout);
                     }
                 }


### PR DESCRIPTION
Signed-off-by: Jun Tian <jun.tian@intel.com>

# Description
Expand the precision to mitigate overflow in bitrate log print.
![image](https://user-images.githubusercontent.com/4551215/87084801-ab115c00-c1e3-11ea-9af6-1417020d635c.png)
![image](https://user-images.githubusercontent.com/4551215/87084587-5837a480-c1e3-11ea-9b79-430faa8a5f68.png)

# Issue

<!--
Mention if the PR fixes or address an issue in this section
https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
Example
Fixes #999
If this PR involves fixing a bug that does not already have an issue created for it, please create an issue with sufficient info to reproduce the problem. Make sure to cross reference that issue within this PR.
--->

# Author(s)
@tianjunwork 

# Performance impact
<!--
Type an x in the box that is relevant to your PR. Make sure to mention how it is relevant in the description section.
Example
- [x] memory
--->
- [ ] quality
- [ ] memory
- [ ] speed
- [ ] 8 bit
- [ ] 10 bit
- [x] N/A

# Merge method
- [x] Allow the maintainer to squash and merge when PR is ready to create a 1-commit to the master branch. The maintainer will be able to fix typos / combine commit messages to create a more readable 1-commit message or use whatever is stated in the 'Description' section
- [ ] I will clean up my commits and the maintainer shall use 'rebase and merge' to the master branch
