### PR TITLE
fix the hang caused by pthread_cancel

### DIFF
--- a/Source/Lib/Codec/EbThreads.c
+++ b/Source/Lib/Codec/EbThreads.c
@@ -80,8 +80,8 @@ EB_HANDLE EbCreateThread(
 
         if (ret != 0) {
             if (ret == EPERM) {
-
                 pthread_cancel(*((pthread_t*)threadHandle));
+                pthread_join(*((pthread_t*)threadHandle), NULL);
                 free(threadHandle);
 
                 threadHandle = (pthread_t*)malloc(sizeof(pthread_t));


### PR DESCRIPTION
Signed-off-by: Jing Li <jing.b.li@intel.com>

# Description
pthread_cancel is an async call, need to join() before next move, otherwise it may crash.

# Issue
If init/deinit for about 150 times with default input parameter, will crash at set_thread_affinity()
<!--
Mention if the PR fixes or address an issue in this section
https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
Example
Fixes #999
If this PR involves fixing a bug that does not already have an issue created for it, please create an issue with sufficient info to reproduce the problem. Make sure to cross reference that issue within this PR.
--->

# Author(s)


# Performance impact
<!--
Type an x in the box that is relevant to your PR. Make sure to mention how it is relevant in the description section.
Example
- [x] memory
--->
- [ ] quality
- [ ] memory
- [ ] speed
- [ ] 8 bit
- [ ] 10 bit
- [ ] N/A

# Merge method
- [ ] Allow the maintainer to squash and merge when PR is ready to create a 1-commit to the master branch. The maintainer will be able to fix typos / combine commit messages to create a more readable 1-commit message or use whatever is stated in the 'Description' section
- [ ] I will clean up my commits and the maintainer shall use 'rebase and merge' to the master branch
