### PR TITLE
Fix static analysis warning

### DIFF
--- a/Source/App/EbAppProcessCmd.c
+++ b/Source/App/EbAppProcessCmd.c
@@ -992,6 +992,12 @@ void fillOneSegment(
         return;
     }
 
+    if (x1 > config->sourceWidth || x2 > config->sourceWidth ||
+        y1 > config->sourceHeight || y2 > config->sourceHeight) {
+        printf("\nSVT [Warning]: provided region is invalid, cannot perform caculation");
+        return;
+    }
+
     uint32_t widthMinInLCU = MIN(x1, x2) / EB_SEGMENT_BLOCK_SIZE;
     uint32_t widthMaxInLCU = MIN((MAX(x1, x2) + EB_SEGMENT_BLOCK_SIZE - 1) / EB_SEGMENT_BLOCK_SIZE,pictureWidthInLcu);
 

--- a/Source/Lib/Codec/EbEncHandle.c
+++ b/Source/Lib/Codec/EbEncHandle.c
@@ -402,8 +402,8 @@ EB_ERRORTYPE EbHevcInitThreadManagmentParams(){
                     maxSize = maxSize * 2;
                     lpGroup = (processorGroup*)realloc(lpGroup,maxSize * sizeof(processorGroup));
                     if (lpGroup == (processorGroup*) EB_NULL) {
-                        return EB_ErrorInsufficientResources;
                         fclose(fin);
+                        return EB_ErrorInsufficientResources;
                     }
                 }
                 lpGroup[socket_id].group[lpGroup[socket_id].num++] = processor_id;


### PR DESCRIPTION
Signed-off-by: Jun Tian <tianjun1.0@gmail.com>

# Description
Address the rest static analysis warnings:
Unvalidated integer value '...?y1:y2' that is received from 'fscanf' at line 987 is used as an operand to a binary operator at line 999.
Unvalidated integer value '((x1) > (x2) ? (x1) : (x2)) + 64' that is received from 'fscanf' at line 987 is used as an operand to a binary operator at line 996. Also there is one similar error on line 996.
Unvalidated integer value '...?x1:x2' that is received from 'fscanf' at line 987 is used as an operand to a binary operator at line 996. Also there is one similar error on line 996.
Unvalidated integer value '((y1) > (y2) ? (y1) : (y2)) + 64' that is received from 'fscanf' at line 987 is used as an operand to a binary operator at line 999. Also there is one similar error on line 999.

# Issue

<!--
Mention if the PR fixes or address an issue in this section
https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
Example
Fixes #999
If this PR involves fixing a bug that does not already have an issue created for it, please create an issue with sufficient info to reproduce the problem. Make sure to cross reference that issue within this PR.
--->

# Author(s)
@tianjunwork 

# Performance impact
<!--
Type an x in the box that is relevant to your PR. Make sure to mention how it is relevant in the description section.
Example
- [x] memory
--->
- [ ] quality
- [ ] memory
- [ ] speed
- [ ] 8 bit
- [ ] 10 bit
- [x] N/A

# Merge method
- [x] Allow the maintainer to squash and merge when PR is ready to create a 1-commit to the master branch. The maintainer will be able to fix typos / combine commit messages to create a more readable 1-commit message or use whatever is stated in the 'Description' section
- [ ] I will clean up my commits and the maintainer shall use 'rebase and merge' to the master branch
