### PR TITLE
fix EB_ENC_PD_ERROR4 EB_ENC_PD_ERROR8 in race conditions

### DIFF
--- a/Source/Lib/Codec/EbEncDecProcess.c
+++ b/Source/Lib/Codec/EbEncDecProcess.c
@@ -3231,15 +3231,11 @@ void* EncDecKernel(void *inputPtr)
             if (((pictureControlSetPtr->sliceType == EB_P_PICTURE) || (pictureControlSetPtr->sliceType == EB_B_PICTURE)) &&
                     pictureControlSetPtr->ParentPcsPtr->refPaPcsArray[REF_LIST_0]) {
                 ((EbPaReferenceObject_t *)pictureControlSetPtr->ParentPcsPtr->refPaPcsArray[REF_LIST_0]->paReferencePictureWrapperPtr->objectPtr)->dependentPicturesCount--;
-                EbReleaseObject(pictureControlSetPtr->ParentPcsPtr->refPaPcsArray[REF_LIST_0]->paReferencePictureWrapperPtr);
-                EbReleaseObject(pictureControlSetPtr->ParentPcsPtr->refPaPcsArray[REF_LIST_0]->pPcsWrapperPtr);
             }
 
             if ((pictureControlSetPtr->sliceType == EB_B_PICTURE) &&
                     pictureControlSetPtr->ParentPcsPtr->refPaPcsArray[REF_LIST_1]) {
                 ((EbPaReferenceObject_t *)pictureControlSetPtr->ParentPcsPtr->refPaPcsArray[REF_LIST_1]->paReferencePictureWrapperPtr->objectPtr)->dependentPicturesCount--;
-                EbReleaseObject(pictureControlSetPtr->ParentPcsPtr->refPaPcsArray[REF_LIST_1]->paReferencePictureWrapperPtr);
-                EbReleaseObject(pictureControlSetPtr->ParentPcsPtr->refPaPcsArray[REF_LIST_1]->pPcsWrapperPtr);
             }
 
             // Note: release the PPCS and its PA reference picture in both EncDec and RateControl

--- a/Source/Lib/Codec/EbReferenceObject.h
+++ b/Source/Lib/Codec/EbReferenceObject.h
@@ -54,7 +54,7 @@ typedef struct EbPaReferenceObject_s {
 	EB_U8                          yMean[MAX_NUMBER_OF_TREEBLOCKS_PER_PICTURE];
 	EB_PICTURE                       sliceType;
 
-	EB_U32 dependentPicturesCount; //number of pic using this reference frame  
+	EB_S32 dependentPicturesCount; //number of pic using this reference frame
     PictureParentControlSet_t       *pPcsPtr;
 } EbPaReferenceObject_t;
 

--- a/Source/Lib/Codec/EbResourceCoordinationProcess.c
+++ b/Source/Lib/Codec/EbResourceCoordinationProcess.c
@@ -472,7 +472,7 @@ void* ResourceCoordinationKernel(void *inputPtr)
         // Parent PCS is released by the Rate Control after passing through MDC->MD->ENCDEC->Packetization
         EbObjectIncLiveCount(
             pictureControlSetWrapperPtr,
-            1);
+            2);
 
         pictureControlSetPtr        = (PictureParentControlSet_t*) pictureControlSetWrapperPtr->objectPtr;
 
@@ -605,15 +605,10 @@ void* ResourceCoordinationKernel(void *inputPtr)
         pictureControlSetPtr->paReferencePictureWrapperPtr = referencePictureWrapperPtr;
 
         // Note: the PPCS and its PA reference picture will be released in both EncDec and RateControl kernels.
-        // Give the new Reference a nominal liveCount of 2, meanwhile increase liveCount of PPCS with 1 as it's
-        // already 1 after dequeuing from the PPCS FIFO.
+        // Give the new Reference a nominal liveCount of 2
         EbObjectIncLiveCount(
                 pictureControlSetPtr->paReferencePictureWrapperPtr,
                 2);
-
-        EbObjectIncLiveCount(
-                pictureControlSetWrapperPtr,
-                1);
 
         // Get Empty Output Results Object
         // Note: record the PCS object into output of the Resource Coordination process for EOS frame(s).


### PR DESCRIPTION
double release leads to duplicated objects in empty queue

