### PR TITLE
ffmpeg plugin: target CPU socket option added

### DIFF
--- a/ffmpeg_plugin/0001-lavc-svt_hevc-add-libsvt-hevc-encoder-wrapper.patch
+++ b/ffmpeg_plugin/0001-lavc-svt_hevc-add-libsvt-hevc-encoder-wrapper.patch
@@ -15,8 +15,8 @@ Signed-off-by: Guo Jiansheng <jiansheng.guo@intel.com>
  configure                |   4 +
  libavcodec/Makefile      |   1 +
  libavcodec/allcodecs.c   |   1 +
- libavcodec/libsvt_hevc.c | 578 +++++++++++++++++++++++++++++++++++++++++++++++
- 4 files changed, 584 insertions(+)
+ libavcodec/libsvt_hevc.c | 583 +++++++++++++++++++++++++++++++++++++++++++++++
+ 4 files changed, 589 insertions(+)
  create mode 100644 libavcodec/libsvt_hevc.c
 
 diff --git a/configure b/configure
@@ -84,7 +84,7 @@ new file mode 100644
 index 0000000..95d6c35
 --- /dev/null
 +++ b/libavcodec/libsvt_hevc.c
-@@ -0,0 +1,578 @@
+@@ -0,0 +1,583 @@
 +/*
 +* Scalable Video Technology for HEVC encoder library plugin
 +*
@@ -147,6 +147,7 @@ index 0000000..95d6c35
 +    int forced_idr;
 +    int la_depth;
 +    int thread_count;
++    int target_socket;
 +    int high_dynamic_range;
 +    int unrestricted_motion_vector;
 +    int tile_row_count;
@@ -288,6 +289,7 @@ index 0000000..95d6c35
 +    param->asmType = svt_enc->asm_type;
 +    param->intraRefreshType =  svt_enc->forced_idr;
 +    param->highDynamicRangeInput = svt_enc->high_dynamic_range;
++    param->targetSocket = svt_enc->target_socket;
 +    if (param->rateControlMode) {
 +        param->maxQpAllowed = avctx->qmax;
 +        param->minQpAllowed = avctx->qmin;
@@ -597,6 +599,9 @@ index 0000000..95d6c35
 +
 +    { "sc_detection", "Scene change detection", OFFSET(scd),
 +      AV_OPT_TYPE_BOOL, { .i64 = 1 }, 0, 1, VE },
++
++    { "socket", "Target CPU socket to use.  -1 use all available", OFFSET(target_socket),
++      AV_OPT_TYPE_INT, {.i64 = -1 }, -1, 1, VE },
 +
 +    { "thread_count", "Number of threads [0: Auto, 96: Min]", OFFSET(thread_count),
 +      AV_OPT_TYPE_INT, {.i64 = 0}, 0, INT_MAX, VE },

--- a/ffmpeg_plugin/0002-doc-Add-libsvt_hevc-encoder-docs.patch
+++ b/ffmpeg_plugin/0002-doc-Add-libsvt_hevc-encoder-docs.patch
@@ -119,6 +119,9 @@ index eefd124..81debda 100644
 +Set @emph{general_tier_flag}.  This may affect the level chosen for the stream
 +if it is not explicitly specified. Can assume one of the following possible values:
 +
++@item socket
++Target CPU socket to use. 0 or 1 are supported. -1 use all available (default)
++
 +@table @samp
 +@item main
 +main tier


### PR DESCRIPTION
# Description
In real SVT HEVC use as a part of FFmpeg on multi-socket systems (e.g .Xeon 8260L) there is a strong need to select the target socket to run encoder on to balance the server load evenly. Moreover the ffmpeg plugin should be consistent with GStreamer plugin that has such option.

# Issue

<!--
Mention if the PR fixes or address an issue in this section
https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
Example
Fixes #999
If this PR involves fixing a bug that does not already have an issue created for it, please create an issue with sufficient info to reproduce the problem. Make sure to cross reference that issue within this PR.
--->

# Author(s)


# Performance impact
<!--
Type an x in the box that is relevant to your PR. Make sure to mention how it is relevant in the description section.
Example
- [x] memory
--->
- [ ] quality
- [ ] memory
- [x] speed
- [ ] 8 bit
- [ ] 10 bit
- [ ] N/A

# Merge method
- [x] Allow the maintainer to squash and merge when PR is ready to create a 1-commit to the master branch. The maintainer will be able to fix typos / combine commit messages to create a more readable 1-commit message or use whatever is stated in the 'Description' section
- [ ] I will clean up my commits and the maintainer shall use 'rebase and merge' to the master branch
