### PR TITLE
Fix a divide by zero issue

### DIFF
--- a/Source/Lib/Codec/EbInitialRateControlProcess.c
+++ b/Source/Lib/Codec/EbInitialRateControlProcess.c
@@ -700,8 +700,13 @@ void UpdateHomogeneityOverTime(
 
 		} // PCS loop
 
-		meanSqrvariance64x64Based = meanSqrvariance64x64Based / (noFramesToCheck - 1);
-		meanvariance64x64Based = meanvariance64x64Based / (noFramesToCheck - 1);
+        if (noFramesToCheck == 1) {
+            meanSqrvariance64x64Based = 0;
+            meanvariance64x64Based = 0;
+        } else {
+            meanSqrvariance64x64Based = meanSqrvariance64x64Based / (noFramesToCheck - 1);
+            meanvariance64x64Based = meanvariance64x64Based / (noFramesToCheck - 1);
+        }
 
 		// Compute variance
 		pictureControlSetPtr->lcuVarianceOfVarianceOverTime[lcuIdx] = meanSqrvariance64x64Based - meanvariance64x64Based * meanvariance64x64Based;


### PR DESCRIPTION
Signed-off-by: Jun Tian <jun.tian@intel.com>

# Description
With command line in #602, behavior is different between gcc-10 and 8.
gcc-10 gives `floating point exception` for `divide by zero`. gcc-8 simply returns 0.
This PR fixes the exception when code is compiled with gcc-10.

# Issue
#602
<!--
Mention if the PR fixes or address an issue in this section
https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
Example
Fixes #999
If this PR involves fixing a bug that does not already have an issue created for it, please create an issue with sufficient info to reproduce the problem. Make sure to cross reference that issue within this PR.
--->

# Author(s)
@tianjunwork 

# Performance impact
<!--
Type an x in the box that is relevant to your PR. Make sure to mention how it is relevant in the description section.
Example
- [x] memory
--->
- [ ] quality
- [ ] memory
- [ ] speed
- [ ] 8 bit
- [ ] 10 bit
- [x] N/A

# Merge method
- [x] Allow the maintainer to squash and merge when PR is ready to create a 1-commit to the master branch. The maintainer will be able to fix typos / combine commit messages to create a more readable 1-commit message or use whatever is stated in the 'Description' section
- [ ] I will clean up my commits and the maintainer shall use 'rebase and merge' to the master branch
