### PR TITLE
Fix an issue that ffmpeg patch files could not be applied

### DIFF
--- a/ffmpeg_plugin/master-0001-lavc-svt_hevc-add-libsvt-hevc-encoder-wrapper.patch
+++ b/ffmpeg_plugin/master-0001-lavc-svt_hevc-add-libsvt-hevc-encoder-wrapper.patch
@@ -40,7 +40,7 @@ index 6bfd98b..93c87cb 100755
      libass
      libbluray
 @@ -3315,6 +3317,7 @@ libx264_encoder_select="atsc_a53"
- libx264rgb_encoder_deps="libx264 x264_csp_bgr"
+ libx264rgb_encoder_deps="libx264"
  libx264rgb_encoder_select="libx264_encoder"
  libx265_encoder_deps="libx265"
 +libsvt_hevc_encoder_deps="libsvthevc"


### PR DESCRIPTION
# Description
ffmpeg file "configure" has been changed.
https://github.com/FFmpeg/FFmpeg/commit/f32f56468c6caa03f4ebbf6cf58b2bb7bc775216
So there is an error when I run `git apply ../SVT-HEVC/ffmpeg_plugin/master-0001-lavc-svt_hevc-add-libsvt-hevc-encoder-wrapper.patch`:

```
error: patch failed: configure:3315
error: configure: patch does not apply
```
This change fixes this error.

# Author(s)
Kusaanko

# Merge method
- [x] Allow the maintainer to squash and merge when PR is ready to create a 1-commit to the master branch. The maintainer will be able to fix typos / combine commit messages to create a more readable 1-commit message or use whatever is stated in the 'Description' section
- [x] I will clean up my commits and the maintainer shall use 'rebase and merge' to the master branch
