### PR TITLE
Create patch for FFmpeg n6.0

### DIFF
--- a/ffmpeg_plugin/n6.0-0001-lavc-svt_hevc-add-libsvt-hevc-encoder-wrapper.patch
+++ b/ffmpeg_plugin/n6.0-0001-lavc-svt_hevc-add-libsvt-hevc-encoder-wrapper.patch
@@ -1,0 +1,677 @@
+From 1863ee7d76945102207bd5ded5628c6a95a6c7c3 Mon Sep 17 00:00:00 2001
+From: Diego Pasqualin <diego.pasqualin@showmax.com>
+Date: Sun, 25 Jun 2023 18:06:16 -0300
+Subject: [PATCH] lavc/svt_hevc: add libsvt hevc encoder wrapper
+
+Signed-off-by: Zhengxu Huang <zhengxu.huang@intel.com>
+Signed-off-by: Hassene Tmar <hassene.tmar@intel.com>
+Signed-off-by: Jun Zhao <jun.zhao@intel.com>
+Signed-off-by: Jing Sun <jing.a.sun@intel.com>
+Signed-off-by: Austin Hu <austin.hu@intel.com>
+Signed-off-by: Guo Jiansheng <jiansheng.guo@intel.com>
+Signed-off-by: Christopher Degawa <ccom@randomderp.com>
+Signed-off-by: Guo Jiansheng <jiansheng.guo@intel.com>
+Signed-off-by: Diego Pasqualin <diego.pasqualin@showmax.com>
+---
+ configure                |   4 +
+ libavcodec/Makefile      |   1 +
+ libavcodec/allcodecs.c   |   1 +
+ libavcodec/libsvt_hevc.c | 586 +++++++++++++++++++++++++++++++++++++++
+ 4 files changed, 592 insertions(+)
+ create mode 100644 libavcodec/libsvt_hevc.c
+
+diff --git a/configure b/configure
+index b6616f00b6..61f6ea2e97 100755
+--- a/configure
++++ b/configure
+@@ -291,6 +291,7 @@ External library support:
+   --enable-libwebp         enable WebP encoding via libwebp [no]
+   --enable-libx264         enable H.264 encoding via x264 [no]
+   --enable-libx265         enable HEVC encoding via x265 [no]
++  --enable-libsvthevc      enable HEVC encoding via svt [no]
+   --enable-libxavs         enable AVS encoding via xavs [no]
+   --enable-libxavs2        enable AVS2 encoding via xavs2 [no]
+   --enable-libxcb          enable X11 grabbing using XCB [autodetect]
+@@ -1804,6 +1805,7 @@ EXTERNAL_LIBRARY_LIST="
+     jni
+     ladspa
+     lcms2
++    libsvthevc
+     libaom
+     libass
+     libbluray
+@@ -3396,6 +3398,7 @@ libx264rgb_encoder_deps="libx264"
+ libx264rgb_encoder_select="libx264_encoder"
+ libx265_encoder_deps="libx265"
+ libx265_encoder_select="atsc_a53"
++libsvt_hevc_encoder_deps="libsvthevc"
+ libxavs_encoder_deps="libxavs"
+ libxavs2_encoder_deps="libxavs2"
+ libxvid_encoder_deps="libxvid"
+@@ -6752,6 +6755,7 @@ enabled mmal              && { check_lib mmal interface/mmal/mmal.h mmal_port_co
+                                  check_lib mmal interface/mmal/mmal.h mmal_port_connect -lmmal_core -lmmal_util -lmmal_vc_client -lbcm_host; } ||
+                                die "ERROR: mmal not found" &&
+                                check_func_headers interface/mmal/mmal.h "MMAL_PARAMETER_VIDEO_MAX_NUM_CALLBACKS"; }
++enabled libsvthevc        && require_pkg_config libsvthevc SvtHevcEnc EbApi.h EbInitHandle
+ enabled openal            && { check_pkg_config openal "openal >= 1.1" "AL/al.h" alGetError ||
+                                { for al_extralibs in "${OPENAL_LIBS}" "-lopenal" "-lOpenAL32"; do
+                                check_lib openal 'AL/al.h' alGetError "${al_extralibs}" && break; done } ||
+diff --git a/libavcodec/Makefile b/libavcodec/Makefile
+index 389253f5d0..92b33a83f0 100644
+--- a/libavcodec/Makefile
++++ b/libavcodec/Makefile
+@@ -1128,6 +1128,7 @@ OBJS-$(CONFIG_LIBWEBP_ANIM_ENCODER)       += libwebpenc_common.o libwebpenc_anim
+ OBJS-$(CONFIG_LIBX262_ENCODER)            += libx264.o
+ OBJS-$(CONFIG_LIBX264_ENCODER)            += libx264.o
+ OBJS-$(CONFIG_LIBX265_ENCODER)            += libx265.o
++OBJS-$(CONFIG_LIBSVT_HEVC_ENCODER)        += libsvt_hevc.o
+ OBJS-$(CONFIG_LIBXAVS_ENCODER)            += libxavs.o
+ OBJS-$(CONFIG_LIBXAVS2_ENCODER)           += libxavs2.o
+ OBJS-$(CONFIG_LIBXVID_ENCODER)            += libxvid.o
+diff --git a/libavcodec/allcodecs.c b/libavcodec/allcodecs.c
+index e593ad19af..69ba2faf96 100644
+--- a/libavcodec/allcodecs.c
++++ b/libavcodec/allcodecs.c
+@@ -814,6 +814,7 @@ extern LIBX264_CONST FFCodec ff_libx264_encoder;
+ #endif
+ extern const FFCodec ff_libx264rgb_encoder;
+ extern FFCodec ff_libx265_encoder;
++extern FFCodec ff_libsvt_hevc_encoder;
+ extern const FFCodec ff_libxavs_encoder;
+ extern const FFCodec ff_libxavs2_encoder;
+ extern const FFCodec ff_libxvid_encoder;
+diff --git a/libavcodec/libsvt_hevc.c b/libavcodec/libsvt_hevc.c
+new file mode 100644
+index 0000000000..338092b403
+--- /dev/null
++++ b/libavcodec/libsvt_hevc.c
+@@ -0,0 +1,586 @@
++/*
++* Scalable Video Technology for HEVC encoder library plugin
++*
++* Copyright (c) 2019 Intel Corporation
++*
++* This file is part of FFmpeg.
++*
++* FFmpeg is free software; you can redistribute it and/or
++* modify it under the terms of the GNU Lesser General Public
++* License as published by the Free Software Foundation; either
++* version 2.1 of the License, or (at your option) any later version.
++*
++* FFmpeg is distributed in the hope that it will be useful,
++* but WITHOUT ANY WARRANTY; without even the implied warranty of
++* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
++* Lesser General Public License for more details.
++*
++* You should have received a copy of the GNU Lesser General Public
++* License along with this program; if not, write to the Free Software
++* Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
++*/
++
++#include "EbApi.h"
++
++#include "libavutil/common.h"
++#include "libavutil/frame.h"
++#include "libavutil/opt.h"
++
++#include "avcodec.h"
++#include "encode.h"
++#include "internal.h"
++#include "codec_internal.h"
++
++
++typedef enum eos_status {
++    EOS_NOT_REACHED = 0,
++    EOS_SENT,
++    EOS_RECEIVED
++}EOS_STATUS;
++
++typedef struct SvtContext {
++    AVClass *class;
++
++    EB_H265_ENC_CONFIGURATION enc_params;
++    EB_COMPONENTTYPE *svt_handle;
++    EB_BUFFERHEADERTYPE in_buf;
++    uint8_t *in_data;
++    EOS_STATUS eos_flag;
++
++    // User options.
++    int profile;
++    int hierarchical_level;
++    int enc_mode;
++    int tier;
++    int level;
++    int rc_mode;
++    int scd;
++    int tune;
++    int base_layer_switch_mode;
++    int qp;
++    int aud;
++    int asm_type;
++    int forced_idr;
++    int la_depth;
++    int thread_count;
++    int target_socket;
++    int high_dynamic_range;
++    int unrestricted_motion_vector;
++    int tile_row_count;
++    int tile_col_count;
++    int tile_slice_mode;
++    int pred_struct;
++    int vid_info;
++} SvtContext;
++
++static int error_mapping(EB_ERRORTYPE svt_ret)
++{
++    switch (svt_ret) {
++    case EB_ErrorInsufficientResources:
++        return AVERROR(ENOMEM);
++
++    case EB_ErrorUndefined:
++    case EB_ErrorInvalidComponent:
++    case EB_ErrorBadParameter:
++        return AVERROR(EINVAL);
++
++    case EB_ErrorDestroyThreadFailed:
++    case EB_ErrorSemaphoreUnresponsive:
++    case EB_ErrorDestroySemaphoreFailed:
++    case EB_ErrorCreateMutexFailed:
++    case EB_ErrorMutexUnresponsive:
++    case EB_ErrorDestroyMutexFailed:
++        return AVERROR_EXTERNAL;
++
++    case EB_NoErrorEmptyQueue:
++        return AVERROR(EAGAIN);
++
++    case EB_ErrorNone:
++        return 0;
++
++    default:
++        return AVERROR_UNKNOWN;
++    }
++}
++
++static void free_buffer(SvtContext *svt_enc)
++{
++    if (svt_enc && svt_enc->in_data) {
++        av_freep(&svt_enc->in_data);
++        svt_enc->in_data = NULL;
++    }
++}
++
++static EB_ERRORTYPE alloc_buffer(SvtContext *svt_enc)
++{
++    EB_BUFFERHEADERTYPE *in_buf = &svt_enc->in_buf;
++    EB_H265_ENC_INPUT *in_data = NULL;
++
++    memset(in_buf, 0, sizeof(*in_buf));
++    in_buf->nSize = sizeof(*in_buf);
++    in_buf->sliceType = EB_INVALID_PICTURE;
++
++    in_data = (EB_H265_ENC_INPUT *)av_mallocz(sizeof(*in_data));
++    if (in_data) {
++        svt_enc->in_data = in_buf->pBuffer = (uint8_t *)in_data;
++        return EB_ErrorNone;
++    } else {
++        return EB_ErrorInsufficientResources;
++    }
++}
++
++static int config_enc_params(EB_H265_ENC_CONFIGURATION *param,
++                             AVCodecContext *avctx)
++{
++    SvtContext *svt_enc = avctx->priv_data;
++
++    param->sourceWidth = avctx->width;
++    param->sourceHeight = avctx->height;
++
++    if ((avctx->pix_fmt == AV_PIX_FMT_YUV420P10) ||
++        (avctx->pix_fmt == AV_PIX_FMT_YUV422P10) ||
++        (avctx->pix_fmt == AV_PIX_FMT_YUV444P10)) {
++        av_log(avctx, AV_LOG_DEBUG, "Set 10 bits depth input\n");
++        param->encoderBitDepth = 10;
++    } else {
++        av_log(avctx, AV_LOG_DEBUG, "Set 8 bits depth input\n");
++        param->encoderBitDepth = 8;
++    }
++
++    if ((avctx->pix_fmt == AV_PIX_FMT_YUV420P) ||
++        (avctx->pix_fmt == AV_PIX_FMT_YUV420P10))
++        param->encoderColorFormat = EB_YUV420;
++    else if ((avctx->pix_fmt == AV_PIX_FMT_YUV422P) ||
++             (avctx->pix_fmt == AV_PIX_FMT_YUV422P10))
++        param->encoderColorFormat = EB_YUV422;
++    else
++        param->encoderColorFormat = EB_YUV444;
++
++    param->profile = svt_enc->profile;
++
++    if (FF_PROFILE_HEVC_MAIN_STILL_PICTURE == param->profile) {
++        av_log(avctx, AV_LOG_ERROR, "Main Still Picture Profile not supported\n");
++        return EB_ErrorBadParameter;
++    }
++
++    if ((param->encoderColorFormat >= EB_YUV422) &&
++        (param->profile != FF_PROFILE_HEVC_REXT)) {
++        av_log(avctx, AV_LOG_WARNING, "Rext Profile forced for 422 or 444\n");
++        param->profile = FF_PROFILE_HEVC_REXT;
++    }
++
++    if ((FF_PROFILE_HEVC_MAIN == param->profile) &&
++        (param->encoderBitDepth > 8)) {
++        av_log(avctx, AV_LOG_WARNING, "Main10 Profile forced for 10 bits\n");
++        param->profile = FF_PROFILE_HEVC_MAIN_10;
++    }
++
++    param->targetBitRate = avctx->bit_rate;
++    param->vbvMaxrate = avctx->rc_max_rate;
++    param->vbvBufsize = avctx->rc_buffer_size;
++
++    if (avctx->gop_size > 0)
++        param->intraPeriodLength = avctx->gop_size - 1;
++
++    if ((avctx->framerate.num > 0) && (avctx->framerate.den > 0)) {
++        param->frameRateNumerator = avctx->framerate.num;
++        param->frameRateDenominator =
++            avctx->framerate.den * avctx->ticks_per_frame;
++    } else {
++        param->frameRateNumerator = avctx->time_base.den;
++        param->frameRateDenominator =
++            avctx->time_base.num * avctx->ticks_per_frame;
++    }
++
++    param->hierarchicalLevels = svt_enc->hierarchical_level;
++    param->encMode = svt_enc->enc_mode;
++    param->tier = svt_enc->tier;
++    param->level = svt_enc->level;
++    param->rateControlMode = svt_enc->rc_mode;
++    param->sceneChangeDetection = svt_enc->scd;
++    param->tune = svt_enc->tune;
++    param->baseLayerSwitchMode = svt_enc->base_layer_switch_mode;
++    param->qp = svt_enc->qp;
++    param->accessUnitDelimiter = svt_enc->aud;
++    param->asmType = svt_enc->asm_type;
++    param->intraRefreshType =  svt_enc->forced_idr;
++    param->highDynamicRangeInput = svt_enc->high_dynamic_range;
++    param->targetSocket = svt_enc->target_socket;
++    if (param->rateControlMode) {
++        param->maxQpAllowed = avctx->qmax;
++        param->minQpAllowed = avctx->qmin;
++    }
++
++    if (svt_enc->la_depth != -1)
++        param->lookAheadDistance = svt_enc->la_depth;
++
++    if ((svt_enc->thread_count > 0) &&
++        (svt_enc->thread_count < (EB_THREAD_COUNT_MIN_CORE * EB_THREAD_COUNT_FACTOR))) {
++        param->threadCount = EB_THREAD_COUNT_MIN_CORE * EB_THREAD_COUNT_FACTOR;
++        av_log(avctx, AV_LOG_WARNING, "Thread count is set too small, forced to %"PRId32"\n",
++               param->threadCount);
++    } else if (svt_enc->thread_count % EB_THREAD_COUNT_MIN_CORE) {
++        param->threadCount = (svt_enc->thread_count + EB_THREAD_COUNT_MIN_CORE - 1)
++                             / EB_THREAD_COUNT_MIN_CORE * EB_THREAD_COUNT_MIN_CORE;
++        av_log(avctx, AV_LOG_DEBUG, "Thread count is rounded to %"PRId32"\n",
++               param->threadCount);
++    } else {
++        param->threadCount = svt_enc->thread_count;
++    }
++
++    if (avctx->flags & AV_CODEC_FLAG_GLOBAL_HEADER)
++        param->codeVpsSpsPps = 0;
++    else
++        param->codeVpsSpsPps = 1;
++
++    param->codeEosNal = 1;
++
++    if (svt_enc->unrestricted_motion_vector == 0 || svt_enc->unrestricted_motion_vector == 1) {
++        param->unrestrictedMotionVector = svt_enc->unrestricted_motion_vector;
++    } else {
++        av_log(avctx, AV_LOG_ERROR, "Unrestricted Motion Vector should be set 0 or 1\n");
++        return EB_ErrorBadParameter;
++    }
++
++    if(svt_enc->tile_row_count >= 1 && svt_enc->tile_row_count <= 16) {
++        param->tileRowCount = svt_enc->tile_row_count;
++    } else {
++        av_log(avctx, AV_LOG_ERROR, "Tile Row Count should between 1-16\n");
++        return EB_ErrorBadParameter;
++    }
++
++    if(svt_enc->tile_col_count >= 1 && svt_enc->tile_col_count <= 16) {
++        param->tileColumnCount = svt_enc->tile_col_count;
++    } else {
++        av_log(avctx, AV_LOG_ERROR, "Tile Column Count should between 1-16\n");
++        return EB_ErrorBadParameter;
++    }
++
++    if(svt_enc->tile_slice_mode == 0 || svt_enc->tile_slice_mode == 1) {
++        param->tileSliceMode = svt_enc->tile_slice_mode;
++    } else {
++        av_log(avctx, AV_LOG_ERROR, "Tile Slice Mode should be set 0 or 1\n");
++        return EB_ErrorBadParameter;
++    }
++
++    if(svt_enc->pred_struct >= 0 && svt_enc->pred_struct <= 2) {
++        param->predStructure = svt_enc->pred_struct;
++    } else {
++        av_log(avctx, AV_LOG_ERROR, "Pred Structure should between 0-2\n");
++        return EB_ErrorBadParameter;
++    }
++
++    if(svt_enc->vid_info == 0 || svt_enc->vid_info == 1) {
++        param->videoUsabilityInfo = svt_enc->vid_info;
++    } else {
++        av_log(avctx, AV_LOG_ERROR, "Video Usability Info should be set 0 or 1\n");
++        return EB_ErrorBadParameter;
++    }
++    return EB_ErrorNone;
++}
++
++static void read_in_data(EB_H265_ENC_CONFIGURATION *config,
++                         const AVFrame *frame,
++                         EB_BUFFERHEADERTYPE *header_ptr)
++{
++    uint8_t is16bit;
++    uint64_t frame_size;
++    EB_H265_ENC_INPUT *in_data = (EB_H265_ENC_INPUT *)header_ptr->pBuffer;
++
++    is16bit = config->encoderBitDepth > 8;
++    frame_size = (uint64_t)(config->sourceWidth * config->sourceHeight) << is16bit;
++
++    in_data->luma = frame->data[0];
++    in_data->cb = frame->data[1];
++    in_data->cr = frame->data[2];
++
++    in_data->yStride = frame->linesize[0] >> is16bit;
++    in_data->cbStride = frame->linesize[1] >> is16bit;
++    in_data->crStride = frame->linesize[2] >> is16bit;
++
++    if (config->encoderColorFormat == EB_YUV420)
++        frame_size *= 3/2u;
++    else if (config->encoderColorFormat == EB_YUV422)
++        frame_size *= 2u;
++    else
++        frame_size *= 3u;
++
++    header_ptr->nFilledLen += frame_size;
++}
++
++static av_cold int eb_enc_init(AVCodecContext *avctx)
++{
++    SvtContext *svt_enc = avctx->priv_data;
++    EB_ERRORTYPE svt_ret;
++
++    svt_enc->eos_flag = EOS_NOT_REACHED;
++
++    svt_ret = EbInitHandle(&svt_enc->svt_handle, svt_enc, &svt_enc->enc_params);
++    if (svt_ret != EB_ErrorNone) {
++        av_log(avctx, AV_LOG_ERROR, "Failed to init handle\n");
++        return error_mapping(svt_ret);
++    }
++
++    svt_ret = config_enc_params(&svt_enc->enc_params, avctx);
++    if (svt_ret != EB_ErrorNone) {
++        av_log(avctx, AV_LOG_ERROR, "Failed to config parameters\n");
++        goto failed_init_handle;
++    }
++
++    svt_ret = EbH265EncSetParameter(svt_enc->svt_handle, &svt_enc->enc_params);
++    if (svt_ret != EB_ErrorNone) {
++        av_log(avctx, AV_LOG_ERROR, "Failed to set parameters\n");
++        goto failed_init_handle;
++    }
++
++    svt_ret = EbInitEncoder(svt_enc->svt_handle);
++    if (svt_ret != EB_ErrorNone) {
++        av_log(avctx, AV_LOG_ERROR, "Failed to init encoder\n");
++        goto failed_init_handle;
++    }
++
++    if (avctx->flags & AV_CODEC_FLAG_GLOBAL_HEADER) {
++        EB_BUFFERHEADERTYPE *header_ptr = NULL;
++
++        svt_ret = EbH265EncStreamHeader(svt_enc->svt_handle, &header_ptr);
++        if (svt_ret != EB_ErrorNone) {
++            av_log(avctx, AV_LOG_ERROR, "Failed to build stream header\n");
++            goto failed_init_encoder;
++        }
++
++        avctx->extradata_size = header_ptr->nFilledLen;
++        avctx->extradata = av_malloc(avctx->extradata_size + AV_INPUT_BUFFER_PADDING_SIZE);
++        if (!avctx->extradata) {
++            av_log(avctx, AV_LOG_ERROR, "Failed to allocate extradata\n");
++            svt_ret = EB_ErrorInsufficientResources;
++            goto failed_init_encoder;
++        }
++        memcpy(avctx->extradata, header_ptr->pBuffer, avctx->extradata_size);
++        memset(avctx->extradata+avctx->extradata_size, 0, AV_INPUT_BUFFER_PADDING_SIZE);
++    }
++
++    svt_ret = alloc_buffer(svt_enc);
++    if (svt_ret != EB_ErrorNone) {
++        av_log(avctx, AV_LOG_ERROR, "Failed to alloc data buffer\n");
++        goto failed_init_encoder;
++    }
++    return 0;
++
++failed_init_encoder:
++    EbDeinitEncoder(svt_enc->svt_handle);
++failed_init_handle:
++    EbDeinitHandle(svt_enc->svt_handle);
++    svt_enc->svt_handle = NULL;
++    svt_enc = NULL;
++    return error_mapping(svt_ret);
++}
++
++static int eb_encode_frame(AVCodecContext *avctx, AVPacket *pkt,
++                           const AVFrame *frame, int *got_packet)
++{
++    SvtContext *svt_enc = avctx->priv_data;
++    EB_BUFFERHEADERTYPE *header_ptr = &svt_enc->in_buf;
++    EB_ERRORTYPE svt_ret;
++    int av_ret;
++
++    if (EOS_RECEIVED == svt_enc->eos_flag) {
++        *got_packet = 0;
++        return 0;
++    }
++
++    if (!frame) {
++        if (!svt_enc->eos_flag) {
++            svt_enc->eos_flag = EOS_SENT;
++
++            header_ptr->nAllocLen = 0;
++            header_ptr->nFilledLen = 0;
++            header_ptr->nTickCount = 0;
++            header_ptr->nFlags = EB_BUFFERFLAG_EOS;
++            header_ptr->pBuffer = NULL;
++
++            EbH265EncSendPicture(svt_enc->svt_handle, header_ptr);
++
++            av_log(avctx, AV_LOG_DEBUG, "Sent EOS\n");
++        }
++    } else {
++        read_in_data(&svt_enc->enc_params, frame, header_ptr);
++        header_ptr->pts = frame->pts;
++
++        EbH265EncSendPicture(svt_enc->svt_handle, header_ptr);
++
++        av_log(avctx, AV_LOG_DEBUG, "Sent PTS %"PRId64"\n", header_ptr->pts);
++    }
++
++    header_ptr = NULL;
++    svt_ret = EbH265GetPacket(svt_enc->svt_handle, &header_ptr, svt_enc->eos_flag);
++
++    if (svt_ret == EB_NoErrorEmptyQueue) {
++        *got_packet = 0;
++        av_log(avctx, AV_LOG_DEBUG, "Received none\n");
++        return 0;
++    } else if (svt_ret == EB_ErrorMax) {
++        *got_packet = 0;
++        av_log(avctx, AV_LOG_ERROR, "Received NULL packet with error code 0x%X\n", header_ptr->nFlags);
++        return AVERROR_INVALIDDATA;
++    }
++
++    av_log(avctx, AV_LOG_DEBUG, "Received PTS %"PRId64" packet\n", header_ptr->pts);
++
++    av_ret = ff_get_encode_buffer(avctx, pkt, header_ptr->nFilledLen, 0);
++    if (av_ret) {
++        av_log(avctx, AV_LOG_ERROR, "Failed to allocate a packet\n");
++        EbH265ReleaseOutBuffer(&header_ptr);
++        return av_ret;
++    }
++
++    memcpy(pkt->data, header_ptr->pBuffer, header_ptr->nFilledLen);
++    pkt->size = header_ptr->nFilledLen;
++    pkt->pts  = header_ptr->pts;
++    pkt->dts  = header_ptr->dts;
++
++    if ((header_ptr->sliceType == EB_IDR_PICTURE) ||
++        (header_ptr->sliceType == EB_I_PICTURE))
++        pkt->flags |= AV_PKT_FLAG_KEY;
++    if (header_ptr->sliceType == EB_NON_REF_PICTURE)
++        pkt->flags |= AV_PKT_FLAG_DISPOSABLE;
++
++    EbH265ReleaseOutBuffer(&header_ptr);
++
++    *got_packet = 1;
++
++    if (EB_BUFFERFLAG_EOS == header_ptr->nFlags)
++       svt_enc->eos_flag = EOS_RECEIVED;
++
++    return 0;
++}
++
++static av_cold int eb_enc_close(AVCodecContext *avctx)
++{
++    SvtContext *svt_enc = avctx->priv_data;
++
++    if (svt_enc) {
++        free_buffer(svt_enc);
++
++        if (svt_enc->svt_handle) {
++            EbDeinitEncoder(svt_enc->svt_handle);
++            EbDeinitHandle(svt_enc->svt_handle);
++            svt_enc->svt_handle = NULL;
++        }
++    }
++
++    return 0;
++}
++
++#define OFFSET(x) offsetof(SvtContext, x)
++#define VE AV_OPT_FLAG_VIDEO_PARAM | AV_OPT_FLAG_ENCODING_PARAM
++static const AVOption options[] = {
++    { "asm_type", "Assembly instruction set type [0: C Only, 1: Auto]", OFFSET(asm_type),
++      AV_OPT_TYPE_BOOL, { .i64 = 1 }, 0, 1, VE },
++
++    { "aud", "Include Access Unit Delimiter", OFFSET(aud),
++      AV_OPT_TYPE_BOOL, { .i64 = 0 }, 0, 1, VE },
++
++    { "bl_mode", "Random Access Prediction Structure type setting", OFFSET(base_layer_switch_mode),
++      AV_OPT_TYPE_BOOL, { .i64 = 0 }, 0, 1, VE },
++
++    { "forced-idr", "If forcing keyframes, force them as IDR frames.", OFFSET(forced_idr),
++      AV_OPT_TYPE_INT,   { .i64 = -1 }, -1, INT_MAX, VE },
++
++    { "hielevel", "Hierarchical prediction levels setting", OFFSET(hierarchical_level),
++      AV_OPT_TYPE_INT, { .i64 = 3 }, 0, 3, VE , "hielevel"},
++        { "flat",   NULL, 0, AV_OPT_TYPE_CONST, { .i64 = 0 },  INT_MIN, INT_MAX, VE, "hielevel" },
++        { "1 level", NULL, 0, AV_OPT_TYPE_CONST, { .i64 = 1 },  INT_MIN, INT_MAX, VE, "hielevel" },
++        { "2 level", NULL, 0, AV_OPT_TYPE_CONST, { .i64 = 2 },  INT_MIN, INT_MAX, VE, "hielevel" },
++        { "3 level", NULL, 0, AV_OPT_TYPE_CONST, { .i64 = 3 },  INT_MIN, INT_MAX, VE, "hielevel" },
++
++    { "la_depth", "Look ahead distance [0, 256]", OFFSET(la_depth),
++      AV_OPT_TYPE_INT, { .i64 = -1 }, -1, 256, VE },
++
++    { "level", "Set level (level_idc)", OFFSET(level),
++      AV_OPT_TYPE_INT, { .i64 = 0 }, 0, 0xff, VE, "level" },
++
++    { "preset", "Encoding preset [0, 12]",
++      OFFSET(enc_mode), AV_OPT_TYPE_INT, { .i64 = 7 }, 0, 12, VE },
++
++    { "profile", "Profile setting, Main Still Picture Profile not supported", OFFSET(profile),
++      AV_OPT_TYPE_INT, { .i64 = FF_PROFILE_HEVC_MAIN }, FF_PROFILE_HEVC_MAIN, FF_PROFILE_HEVC_REXT, VE, "profile"},
++
++    { "qp", "QP value for intra frames", OFFSET(qp),
++      AV_OPT_TYPE_INT, { .i64 = 32 }, 0, 51, VE },
++
++    { "rc", "Bit rate control mode", OFFSET(rc_mode),
++      AV_OPT_TYPE_INT, { .i64 = 0 }, 0, 1, VE , "rc"},
++        { "cqp", NULL, 0, AV_OPT_TYPE_CONST, { .i64 = 0 },  INT_MIN, INT_MAX, VE, "rc" },
++        { "vbr", NULL, 0, AV_OPT_TYPE_CONST, { .i64 = 1 },  INT_MIN, INT_MAX, VE, "rc" },
++
++    { "sc_detection", "Scene change detection", OFFSET(scd),
++      AV_OPT_TYPE_BOOL, { .i64 = 1 }, 0, 1, VE },
++
++    { "socket", "Target CPU socket to use.  -1 use all available", OFFSET(target_socket),
++      AV_OPT_TYPE_INT, {.i64 = -1 }, -1, 1, VE },
++
++    { "thread_count", "Number of threads [0: Auto, 96: Min]", OFFSET(thread_count),
++      AV_OPT_TYPE_INT, {.i64 = 0}, 0, INT_MAX, VE },
++
++    { "tier", "Set tier (general_tier_flag)", OFFSET(tier),
++      AV_OPT_TYPE_INT, { .i64 = 0 }, 0, 1, VE, "tier" },
++        { "main", NULL, 0, AV_OPT_TYPE_CONST, { .i64 = 0 }, 0, 0, VE, "tier" },
++        { "high", NULL, 0, AV_OPT_TYPE_CONST, { .i64 = 1 }, 0, 0, VE, "tier" },
++
++    { "tune", "Quality tuning mode", OFFSET(tune), AV_OPT_TYPE_INT, { .i64 = 1 }, 0, 2, VE, "tune" },
++        { "sq", "Visually optimized mode", 0,
++          AV_OPT_TYPE_CONST, { .i64 = 0 },  INT_MIN, INT_MAX, VE, "tune" },
++        { "oq",  "PSNR / SSIM optimized mode",  0,
++          AV_OPT_TYPE_CONST, { .i64 = 1 },  INT_MIN, INT_MAX, VE, "tune" },
++        { "vmaf", "VMAF optimized mode", 0,
++          AV_OPT_TYPE_CONST, { .i64 = 2 },  INT_MIN, INT_MAX, VE, "tune" },
++    { "hdr", "High dynamic range input (HDR10)", OFFSET(high_dynamic_range), AV_OPT_TYPE_INT, { .i64 = 0}, 0, 1, VE, "hdr" },
++    { "umv", "Enables or disables unrestricted motion vectors", OFFSET(unrestricted_motion_vector),
++      AV_OPT_TYPE_BOOL, { .i64 = 1 }, 0, 1, VE },
++    { "tile_row_cnt", "tile count in the row", OFFSET(tile_row_count), AV_OPT_TYPE_INT, { .i64 = 1 }, 1, 16, VE },
++    { "tile_col_cnt", "tile count in the column", OFFSET(tile_col_count), AV_OPT_TYPE_INT, { .i64 = 1 }, 1, 16, VE },
++    { "tile_slice_mode", "per slice per tile, only valid for multi-tile", OFFSET(tile_slice_mode),
++      AV_OPT_TYPE_BOOL, { .i64 = 0 }, 0, 1, VE },
++    { "pred_struct", "The prediction structure", OFFSET(pred_struct), AV_OPT_TYPE_INT, { .i64 = 2 }, 0, 2, VE },
++    { "vid_info", "Enables or disables sending a vui structure in the HEVC Elementary bitstream.", OFFSET(vid_info),
++      AV_OPT_TYPE_BOOL, { .i64 = 0 }, 0, 1, VE },
++    {NULL},
++};
++
++static const AVClass class = {
++    .class_name = "libsvt_hevc",
++    .item_name  = av_default_item_name,
++    .option     = options,
++    .version    = LIBAVUTIL_VERSION_INT,
++};
++
++static const FFCodecDefault eb_enc_defaults[] = {
++    { "b",         "7M"    },
++    { "qmin",      "10"    },
++    { "qmax",      "48"    },
++    { "g",         "-2"    },
++    { NULL },
++};
++
++const FFCodec ff_libsvt_hevc_encoder = {
++    .p.name           = "libsvt_hevc",
++    CODEC_LONG_NAME("SVT-HEVC(Scalable Video Technology for HEVC) encoder"),
++    .priv_data_size   = sizeof(SvtContext),
++    .p.type           = AVMEDIA_TYPE_VIDEO,
++    .p.id             = AV_CODEC_ID_HEVC,
++    .init             = eb_enc_init,
++    FF_CODEC_ENCODE_CB(eb_encode_frame),
++    .close            = eb_enc_close,
++    .p.capabilities   = AV_CODEC_CAP_DELAY | AV_CODEC_CAP_DR1,
++    .p.pix_fmts       = (const enum AVPixelFormat[]){ AV_PIX_FMT_YUV420P,
++                                                      AV_PIX_FMT_YUV420P10,
++                                                      AV_PIX_FMT_YUV422P,
++                                                      AV_PIX_FMT_YUV422P10,
++                                                      AV_PIX_FMT_YUV444P,
++                                                      AV_PIX_FMT_YUV444P10,
++                                                      AV_PIX_FMT_NONE },
++    .p.priv_class     = &class,
++    .defaults         = eb_enc_defaults,
++    .caps_internal    = FF_CODEC_CAP_INIT_CLEANUP,
++    .p.wrapper_name   = "libsvt_hevc",
++};
+-- 
+2.34.1
+


### PR DESCRIPTION
# Description

Add patch file to compile SVT-HEVC with FFmpeg n6.0. Main changes besides resolving simple merge conflict are:

- Replace  `ff_alloc_packet2` by `ff_get_encode_buffer` as defined [here](https://github.com/FFmpeg/FFmpeg/commit/6e7e3a3820f0888ff92d6be44f40ff733bcce874).
-  Replace `AVCodec` by `FFCodec` as defined [here](https://github.com/FFmpeg/FFmpeg/commit/20f972701806be20a77f808db332d9489343bb78).

Let me know if I should modify the commit or "Signed-off-by" list in the patch.

# Issue

Fixes #641 

# Author(s)

Diego Pasqualin (Showmax Engineering s.r.o.)

# Performance impact

- [ ] quality
- [ ] memory
- [ ] speed
- [ ] 8 bit
- [ ] 10 bit
- [x] N/A

# Merge method

- [x] Allow the maintainer to squash and merge when PR is ready to create a 1-commit to the master branch. The maintainer will be able to fix typos / combine commit messages to create a more readable 1-commit message or use whatever is stated in the 'Description' section
- [ ] I will clean up my commits and the maintainer shall use 'rebase and merge' to the master branch
